### PR TITLE
Makefile: fix missing version information in build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PKG_PREFIX := github.com/VictoriaMetrics/VictoriaLogs
+VM_PKG_PREFIX := github.com/VictoriaMetrics/VictoriaMetrics
 
 MAKE_CONCURRENCY ?= $(shell getconf _NPROCESSORS_ONLN)
 MAKE_PARALLEL := $(MAKE) -j $(MAKE_CONCURRENCY)
@@ -11,7 +12,7 @@ ifeq ($(PKG_TAG),)
 PKG_TAG := $(BUILDINFO_TAG)
 endif
 
-GO_BUILDINFO = -X '$(PKG_PREFIX)/lib/buildinfo.Version=$(APP_NAME)-$(DATEINFO_TAG)-$(BUILDINFO_TAG)'
+GO_BUILDINFO = -X '$(VM_PKG_PREFIX)/lib/buildinfo.Version=$(APP_NAME)-$(DATEINFO_TAG)-$(BUILDINFO_TAG)'
 TAR_OWNERSHIP ?= --owner=1000 --group=1000
 
 .PHONY: $(MAKECMDGOALS)


### PR DESCRIPTION
during build the linker flag that populates buildinfo.Version was pointing at github.com/VictoriaMetrics/VictoriaLogs/lib/buildinfo, but all binaries import github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo.

```diff
+ VM_PKG_PREFIX := github.com/VictoriaMetrics/VictoriaMetrics

- GO_BUILDINFO = -X '$(PKG_PREFIX)/lib/buildinfo.Version=$(APP_NAME)-$(DATEINFO_TAG)-$(BUILDINFO_TAG)'
+ GO_BUILDINFO = -X '$(VM_PKG_PREFIX)/lib/buildinfo.Version=$(APP_NAME)-$(DATEINFO_TAG)-$(BUILDINFO_TAG)'
```