### PR TITLE
Vlogs json size calculation

### DIFF
--- a/lib/logstorage/block_test.go
+++ b/lib/logstorage/block_test.go
@@ -1,9 +1,11 @@
 package logstorage
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestBlockMustInitFromRows(t *testing.T) {
@@ -204,4 +206,117 @@ func TestBlockMustInitFromRows_Overflow(t *testing.T) {
 	f(10, 10, 10)
 	f(15, 30, 15)
 	f(maxColumnsPerBlock+1000, 1, maxColumnsPerBlock)
+}
+
+func TestBlockUncompressedSizeBytes(t *testing.T) {
+	f := func(rows [][]Field) {
+		t.Helper()
+
+		// Build expected JSON and calculate actual serialized size
+		var totalSize int
+		for _, fields := range rows {
+			m := make(map[string]string)
+			m["_time"] = time.RFC3339Nano
+
+			for _, f := range fields {
+				if f.Value == "" {
+					continue // skip empty values
+				}
+				key := f.Name
+				if key == "_msg" || key == "" {
+					key = "_msg" // normalize empty names
+				}
+				m[key] = f.Value
+			}
+
+			b, err := json.Marshal(m)
+			if err != nil {
+				t.Fatalf("failed to marshal JSON: %v", err)
+			}
+			totalSize += len(b) + 1 // +1 for newline if expected
+		}
+
+		b := &block{}
+		timestamps := make([]int64, len(rows)) // values don't matter for size estimation
+		b.MustInitFromRows(timestamps, rows)
+
+		actualSize := b.uncompressedSizeBytes()
+		if actualSize != totalSize {
+			t.Fatalf("unexpected uncompressed size;\n got  %d\n want %d, testcase: %v", actualSize, totalSize, rows)
+		}
+	}
+
+	// Empty block
+	f(nil)
+
+	// Single row with one field
+	f([][]Field{
+		{{"msg", "hello"}},
+	})
+
+	// Multiple rows with constant columns
+	f([][]Field{
+		{{"level", "info"}},
+		{{"level", "info"}},
+	})
+
+	// Multiple rows with variable columns
+	f([][]Field{
+		{{"msg", "first"}},
+		{{"msg", "second"}},
+	})
+
+	// Mixed constant and variable columns
+	f([][]Field{
+		{{"service", "api"}, {"msg", "start"}},
+		{{"service", "api"}, {"msg", "end"}},
+	})
+
+	// Empty values ignored
+	f([][]Field{
+		{{"msg", "hello"}, {"empty", ""}},
+		{{"msg", ""}, {"empty", "world"}},
+	})
+}
+
+// TestEstimatedJSONRowLenMatchesBlockUncompressedSizeBytes verifies that
+// EstimatedJSONRowLen and block.uncompressedSizeBytes stay in sync.
+// If this test fails, update the calculations in both functions so that they
+// produce identical results for the same set of log entries.
+func TestEstimatedJSONRowLenMatchesBlockUncompressedSizeBytes(t *testing.T) {
+	f := func(rows [][]Field) {
+		t.Helper()
+
+		b := &block{}
+		timestamps := make([]int64, len(rows))
+		b.MustInitFromRows(timestamps, rows)
+
+		sizeBlock := b.uncompressedSizeBytes()
+		sizeRows := 0
+		for _, fields := range rows {
+			sizeRows += EstimatedJSONRowLen(fields)
+		}
+
+		if sizeBlock != sizeRows {
+			t.Fatalf("sizes mismatch: block=%d rows=%d for rows: %+v", sizeBlock, sizeRows, rows)
+		}
+	}
+
+	// Test cases
+	f(nil)
+
+	// Single row with one field
+	f([][]Field{{{"msg", "hello"}}})
+
+	// Multiple rows with constant column
+	f([][]Field{{{"level", "info"}}, {{"level", "info"}}})
+
+	// Multiple rows with variable columns
+	f([][]Field{{{"msg", "first"}}, {{"msg", "second"}}})
+
+	// Mixed constant and variable columns
+	f([][]Field{{{"service", "api"}, {"msg", "start"}}, {{"service", "api"}, {"msg", "end"}}})
+
+	// Empty values ignored
+	f([][]Field{{{"msg", "hello"}, {"empty", ""}}, {{"msg", ""}, {"empty", "world"}}})
 }

--- a/lib/logstorage/block_test.go
+++ b/lib/logstorage/block_test.go
@@ -222,10 +222,7 @@ func TestBlockUncompressedSizeBytes(t *testing.T) {
 				if f.Value == "" {
 					continue // skip empty values
 				}
-				key := f.Name
-				if key == "_msg" || key == "" {
-					key = "_msg" // normalize empty names
-				}
+				key := getRawFieldName(f.Name)
 				m[key] = f.Value
 			}
 

--- a/lib/logstorage/inmemory_part.go
+++ b/lib/logstorage/inmemory_part.go
@@ -96,7 +96,7 @@ func (mp *inmemoryPart) mustInitFromRows(lr *logRows) {
 		fields := rows[i]
 		trs.timestamps = append(trs.timestamps, timestamps[i])
 		trs.rows = append(trs.rows, fields)
-		uncompressedBlockSizeBytes += uncompressedRowSizeBytes(fields)
+		uncompressedBlockSizeBytes += uint64(EstimatedJSONRowLen(fields))
 	}
 	bsw.MustWriteRows(sidPrev, trs.timestamps, trs.rows)
 	putTmpRows(trs)

--- a/lib/logstorage/inmemory_part_test.go
+++ b/lib/logstorage/inmemory_part_test.go
@@ -224,43 +224,43 @@ func TestInmemoryPartInitFromBlockStreamReaders(t *testing.T) {
 	f([]*LogRows{GetLogRows(nil, nil, nil, nil, ""), GetLogRows(nil, nil, nil, nil, "")}, 0, 0)
 
 	// Check merge with a single reader
-	f([]*LogRows{newTestLogRows(1, 1, 0)}, 1, 1.4)
-	f([]*LogRows{newTestLogRows(1, 10, 0)}, 1, 4.6)
-	f([]*LogRows{newTestLogRows(1, 100, 0)}, 1, 12.0)
-	f([]*LogRows{newTestLogRows(1, 1000, 0)}, 1, 17.1)
-	f([]*LogRows{newTestLogRows(1, 10000, 0)}, 3, 17.2)
-	f([]*LogRows{newTestLogRows(10, 1, 0)}, 10, 2.1)
-	f([]*LogRows{newTestLogRows(100, 1, 0)}, 100, 2.3)
-	f([]*LogRows{newTestLogRows(1000, 1, 0)}, 1000, 2.4)
-	f([]*LogRows{newTestLogRows(10, 10, 0)}, 10, 5.5)
-	f([]*LogRows{newTestLogRows(10, 100, 0)}, 10, 12.4)
+	f([]*LogRows{newTestLogRows(1, 1, 0)}, 1, 1)
+	f([]*LogRows{newTestLogRows(1, 10, 0)}, 1, 5)
+	f([]*LogRows{newTestLogRows(1, 100, 0)}, 1, 13)
+	f([]*LogRows{newTestLogRows(1, 1000, 0)}, 1, 18)
+	f([]*LogRows{newTestLogRows(1, 10000, 0)}, 3, 18)
+	f([]*LogRows{newTestLogRows(10, 1, 0)}, 10, 2)
+	f([]*LogRows{newTestLogRows(100, 1, 0)}, 100, 2)
+	f([]*LogRows{newTestLogRows(1000, 1, 0)}, 1000, 2)
+	f([]*LogRows{newTestLogRows(10, 10, 0)}, 10, 6)
+	f([]*LogRows{newTestLogRows(10, 100, 0)}, 10, 13)
 
 	//Check merge with multiple readers
 	f([]*LogRows{
 		newTestLogRows(1, 1, 0),
 		newTestLogRows(1, 1, 1),
-	}, 2, 1.7)
+	}, 2, 1)
 	f([]*LogRows{
 		newTestLogRows(2, 2, 0),
 		newTestLogRows(2, 2, 0),
-	}, 2, 4.2)
+	}, 2, 4)
 	f([]*LogRows{
 		newTestLogRows(1, 20, 0),
 		newTestLogRows(1, 10, 1),
 		newTestLogRows(1, 5, 2),
-	}, 3, 5.5)
+	}, 3, 5)
 	f([]*LogRows{
 		newTestLogRows(10, 20, 0),
 		newTestLogRows(20, 10, 1),
 		newTestLogRows(30, 5, 2),
-	}, 60, 5.2)
+	}, 60, 5)
 	f([]*LogRows{
 		newTestLogRows(10, 20, 0),
 		newTestLogRows(20, 10, 1),
 		newTestLogRows(30, 5, 2),
 		newTestLogRows(20, 7, 3),
 		newTestLogRows(10, 9, 4),
-	}, 90, 5.0)
+	}, 90, 5)
 }
 
 func newTestLogRows(streams, rowsPerStream int, seed int64) *LogRows {

--- a/lib/logstorage/inmemory_part_test.go
+++ b/lib/logstorage/inmemory_part_test.go
@@ -113,10 +113,10 @@ func TestInmemoryPartMustInitFromRows_Overflow(t *testing.T) {
 	}
 
 	// check block overflow with unique tag rows
-	f(newTestLogRowsUniqTags(5, 21, 100), 5, 0.5)
-	f(newTestLogRowsUniqTags(5, 10, 100), 5, 0.6)
-	f(newTestLogRowsUniqTags(1, 2001, 1), 1, 1.7)
-	f(newTestLogRowsUniqTags(15, 20, 250), 15, 0.6)
+	f(newTestLogRowsUniqTags(5, 21, 100), 5, 0.6)
+	f(newTestLogRowsUniqTags(5, 10, 100), 5, 0.7)
+	f(newTestLogRowsUniqTags(1, 2001, 1), 1, 2.0)
+	f(newTestLogRowsUniqTags(15, 20, 250), 15, 0.8)
 }
 
 func checkCompressionRate(t *testing.T, ph *partHeader, compressionRateExpected float64) {
@@ -187,7 +187,7 @@ func TestInmemoryPartInitFromBlockStreamReaders(t *testing.T) {
 		ph := &mpDst.ph
 		checkCompressionRate(t, ph, compressionRateExpected)
 		if ph.UncompressedSizeBytes != uncompressedSizeBytesExpected {
-			t.Fatalf("unexpected uncompressedSizeBytes in partHeader; got %d; want %d", ph.UncompressedSizeBytes, uncompressedSizeBytesExpected)
+			t.Fatalf("unexpected UncompressedSizeBytes in partHeader; got %d; want %d", ph.UncompressedSizeBytes, uncompressedSizeBytesExpected)
 		}
 		if ph.RowsCount != uint64(rowsCountExpected) {
 			t.Fatalf("unexpected number of entries in partHeader; got %d; want %d", ph.RowsCount, rowsCountExpected)
@@ -224,14 +224,14 @@ func TestInmemoryPartInitFromBlockStreamReaders(t *testing.T) {
 	f([]*LogRows{GetLogRows(nil, nil, nil, nil, ""), GetLogRows(nil, nil, nil, nil, "")}, 0, 0)
 
 	// Check merge with a single reader
-	f([]*LogRows{newTestLogRows(1, 1, 0)}, 1, 1.3)
+	f([]*LogRows{newTestLogRows(1, 1, 0)}, 1, 1.4)
 	f([]*LogRows{newTestLogRows(1, 10, 0)}, 1, 4.6)
 	f([]*LogRows{newTestLogRows(1, 100, 0)}, 1, 12.0)
 	f([]*LogRows{newTestLogRows(1, 1000, 0)}, 1, 17.1)
 	f([]*LogRows{newTestLogRows(1, 10000, 0)}, 3, 17.2)
 	f([]*LogRows{newTestLogRows(10, 1, 0)}, 10, 2.1)
 	f([]*LogRows{newTestLogRows(100, 1, 0)}, 100, 2.3)
-	f([]*LogRows{newTestLogRows(1000, 1, 0)}, 1000, 2.2)
+	f([]*LogRows{newTestLogRows(1000, 1, 0)}, 1000, 2.4)
 	f([]*LogRows{newTestLogRows(10, 10, 0)}, 10, 5.5)
 	f([]*LogRows{newTestLogRows(10, 100, 0)}, 10, 12.4)
 
@@ -243,7 +243,7 @@ func TestInmemoryPartInitFromBlockStreamReaders(t *testing.T) {
 	f([]*LogRows{
 		newTestLogRows(2, 2, 0),
 		newTestLogRows(2, 2, 0),
-	}, 2, 3.8)
+	}, 2, 4.2)
 	f([]*LogRows{
 		newTestLogRows(1, 20, 0),
 		newTestLogRows(1, 10, 1),

--- a/lib/logstorage/inmemory_part_test.go
+++ b/lib/logstorage/inmemory_part_test.go
@@ -90,7 +90,7 @@ func TestInmemoryPartMustInitFromRows(t *testing.T) {
 	f(newTestLogRows(100, 1, 0), 100, 2.3)
 	f(newTestLogRows(10, 5, 0), 10, 3.6)
 	f(newTestLogRows(10, 1000, 0), 10, 17.1)
-	f(newTestLogRows(100, 100, 0), 100, 12.4)
+	f(newTestLogRows(100, 100, 0), 100, 13)
 }
 
 func TestInmemoryPartMustInitFromRows_Overflow(t *testing.T) {
@@ -226,14 +226,14 @@ func TestInmemoryPartInitFromBlockStreamReaders(t *testing.T) {
 	// Check merge with a single reader
 	f([]*LogRows{newTestLogRows(1, 1, 0)}, 1, 1.5)
 	f([]*LogRows{newTestLogRows(1, 10, 0)}, 1, 4.6)
-	f([]*LogRows{newTestLogRows(1, 100, 0)}, 1, 12.0)
+	f([]*LogRows{newTestLogRows(1, 100, 0)}, 1, 13.0)
 	f([]*LogRows{newTestLogRows(1, 1000, 0)}, 1, 17.1)
 	f([]*LogRows{newTestLogRows(1, 10000, 0)}, 3, 17.2)
 	f([]*LogRows{newTestLogRows(10, 1, 0)}, 10, 2.1)
 	f([]*LogRows{newTestLogRows(100, 1, 0)}, 100, 2.3)
 	f([]*LogRows{newTestLogRows(1000, 1, 0)}, 1000, 2.4)
 	f([]*LogRows{newTestLogRows(10, 10, 0)}, 10, 5.5)
-	f([]*LogRows{newTestLogRows(10, 100, 0)}, 10, 12.4)
+	f([]*LogRows{newTestLogRows(10, 100, 0)}, 10, 13)
 
 	//Check merge with multiple readers
 	f([]*LogRows{

--- a/lib/logstorage/inmemory_part_test.go
+++ b/lib/logstorage/inmemory_part_test.go
@@ -78,14 +78,14 @@ func TestInmemoryPartMustInitFromRows(t *testing.T) {
 	f(GetLogRows(nil, nil, nil, nil, ""), 0, 0)
 
 	// Check how inmemoryPart works with a single stream
-	f(newTestLogRows(1, 1, 0), 1, 1.3)
+	f(newTestLogRows(1, 1, 0), 1, 1.5)
 	f(newTestLogRows(1, 2, 0), 1, 1.7)
 	f(newTestLogRows(1, 10, 0), 1, 4.6)
 	f(newTestLogRows(1, 1000, 0), 1, 17.1)
-	f(newTestLogRows(1, 20000, 0), 5, 16.8)
+	f(newTestLogRows(1, 20000, 0), 6, 16.8)
 
 	// Check how inmemoryPart works with multiple streams
-	f(newTestLogRows(2, 1, 0), 2, 1.6)
+	f(newTestLogRows(2, 1, 0), 2, 1.8)
 	f(newTestLogRows(10, 1, 0), 10, 2.1)
 	f(newTestLogRows(100, 1, 0), 100, 2.3)
 	f(newTestLogRows(10, 5, 0), 10, 3.6)
@@ -224,43 +224,43 @@ func TestInmemoryPartInitFromBlockStreamReaders(t *testing.T) {
 	f([]*LogRows{GetLogRows(nil, nil, nil, nil, ""), GetLogRows(nil, nil, nil, nil, "")}, 0, 0)
 
 	// Check merge with a single reader
-	f([]*LogRows{newTestLogRows(1, 1, 0)}, 1, 1)
-	f([]*LogRows{newTestLogRows(1, 10, 0)}, 1, 5)
-	f([]*LogRows{newTestLogRows(1, 100, 0)}, 1, 13)
-	f([]*LogRows{newTestLogRows(1, 1000, 0)}, 1, 18)
-	f([]*LogRows{newTestLogRows(1, 10000, 0)}, 3, 18)
-	f([]*LogRows{newTestLogRows(10, 1, 0)}, 10, 2)
-	f([]*LogRows{newTestLogRows(100, 1, 0)}, 100, 2)
-	f([]*LogRows{newTestLogRows(1000, 1, 0)}, 1000, 2)
-	f([]*LogRows{newTestLogRows(10, 10, 0)}, 10, 6)
-	f([]*LogRows{newTestLogRows(10, 100, 0)}, 10, 13)
+	f([]*LogRows{newTestLogRows(1, 1, 0)}, 1, 1.5)
+	f([]*LogRows{newTestLogRows(1, 10, 0)}, 1, 4.6)
+	f([]*LogRows{newTestLogRows(1, 100, 0)}, 1, 12.0)
+	f([]*LogRows{newTestLogRows(1, 1000, 0)}, 1, 17.1)
+	f([]*LogRows{newTestLogRows(1, 10000, 0)}, 3, 17.2)
+	f([]*LogRows{newTestLogRows(10, 1, 0)}, 10, 2.1)
+	f([]*LogRows{newTestLogRows(100, 1, 0)}, 100, 2.3)
+	f([]*LogRows{newTestLogRows(1000, 1, 0)}, 1000, 2.4)
+	f([]*LogRows{newTestLogRows(10, 10, 0)}, 10, 5.5)
+	f([]*LogRows{newTestLogRows(10, 100, 0)}, 10, 12.4)
 
 	//Check merge with multiple readers
 	f([]*LogRows{
 		newTestLogRows(1, 1, 0),
 		newTestLogRows(1, 1, 1),
-	}, 2, 1)
+	}, 2, 1.7)
 	f([]*LogRows{
 		newTestLogRows(2, 2, 0),
 		newTestLogRows(2, 2, 0),
-	}, 2, 4)
+	}, 2, 4.2)
 	f([]*LogRows{
 		newTestLogRows(1, 20, 0),
 		newTestLogRows(1, 10, 1),
 		newTestLogRows(1, 5, 2),
-	}, 3, 5)
+	}, 3, 5.5)
 	f([]*LogRows{
 		newTestLogRows(10, 20, 0),
 		newTestLogRows(20, 10, 1),
 		newTestLogRows(30, 5, 2),
-	}, 60, 5)
+	}, 60, 5.2)
 	f([]*LogRows{
 		newTestLogRows(10, 20, 0),
 		newTestLogRows(20, 10, 1),
 		newTestLogRows(30, 5, 2),
 		newTestLogRows(20, 7, 3),
 		newTestLogRows(10, 9, 4),
-	}, 90, 5)
+	}, 90, 5.0)
 }
 
 func newTestLogRows(streams, rowsPerStream int, seed int64) *LogRows {

--- a/lib/logstorage/log_rows.go
+++ b/lib/logstorage/log_rows.go
@@ -353,7 +353,7 @@ func (lr *LogRows) MustAdd(tenantID TenantID, timestamp int64, fields, streamFie
 			return
 		}
 	}
-	rowLen := uncompressedRowSizeBytes(fields)
+	rowLen := EstimatedJSONRowLen(fields)
 	if rowLen > maxUncompressedBlockSize {
 		line := MarshalFieldsToJSON(nil, fields)
 		logger.Warnf("ignoring too long log entry with the estimated length of %d bytes, since it exceeds the limit %d bytes; "+
@@ -506,6 +506,13 @@ func getCanonicalFieldName(fieldName string) string {
 	return fieldName
 }
 
+func getRawFieldName(fieldName string) string {
+	if fieldName == "" {
+		return "_msg"
+	}
+	return fieldName
+}
+
 // GetRowString returns string representation of the row with the given idx.
 func (lr *LogRows) GetRowString(idx int) string {
 	tf := TimeFormatter(lr.timestamps[idx])
@@ -604,17 +611,30 @@ func PutLogRows(lr *LogRows) {
 var logRowsPool sync.Pool
 
 // EstimatedJSONRowLen returns an approximate length of the log entry with the given fields if represented as JSON.
+//
+// The calculation logic must stay in sync with block.uncompressedSizeBytes() in block.go.
+// If you change logic here, update block.uncompressedSizeBytes() accordingly and vice versa.
 func EstimatedJSONRowLen(fields []Field) int {
 	n := len("{}\n")
 	n += len(`"_time":""`) + len(time.RFC3339Nano)
 	for _, f := range fields {
-		nameLen := len(f.Name)
-		if nameLen == 0 {
-			nameLen = len("_msg")
+		// VictoriaLogs data model (https://docs.victoriametrics.com/victorialogs/keyconcepts/#data-model)
+		// treats empty values as non-existing values
+		if f.Value == "" {
+			continue
 		}
-		n += len(`,"":""`) + nameLen + len(f.Value)
+
+		name := getRawFieldName(f.Name)
+		n += estimatedJSONFieldLen(name, f.Value)
 	}
 	return n
+}
+
+// estimatedJSONFieldLen returns an approximate length of the field with the given name and value if represented as JSON.
+//
+// The field name must be in raw form (e.g., "" to "_msg") before passing.
+func estimatedJSONFieldLen(name, value string) int {
+	return len(`,"":""`) + len(name) + len(value)
 }
 
 // GetInsertRow returns InsertRow from a pool.

--- a/lib/logstorage/rows_test.go
+++ b/lib/logstorage/rows_test.go
@@ -100,11 +100,11 @@ func TestGetRowsSizeBytes(t *testing.T) {
 	}
 	f(nil, 0)
 	f([][]Field{}, 0)
-	f([][]Field{{}}, 35)
-	f([][]Field{{{Name: "foo"}}}, 40)
+	f([][]Field{{}}, 48)
+	f([][]Field{{{Name: "foo"}}}, 48)
 
 	_, rows := newTestRows(1000, 10)
-	f(rows, 233900)
+	f(rows, 286900)
 }
 
 func TestRowsAppendRows(t *testing.T) {


### PR DESCRIPTION
There is an inconsistency in how bytes were calculated:
- Ingestion bytes uses JSON format calculation (`EstimatedJSONRowLen()`)
- Uncompressed bytes uses text format calculation (timestamp + field1=value1 format)

This PR updates `block.uncompressedSizeBytes()` to use JSON format calculation.
