### PR TITLE
metrics: per-query read metrics

### DIFF
--- a/lib/logstorage/parser.go
+++ b/lib/logstorage/parser.go
@@ -256,6 +256,9 @@ type Query struct {
 
 	// timestamp is the timestamp context used for parsing the query.
 	timestamp int64
+
+	// searchStats contains search statistics for the query.
+	searchStats *searchStats
 }
 
 type queryOptions struct {
@@ -1355,9 +1358,10 @@ func parseQuery(lex *lexer) (*Query, error) {
 		return nil, fmt.Errorf("%w; context: [%s]", err, lex.context())
 	}
 	q := &Query{
-		opts:      opts,
-		f:         f,
-		timestamp: lex.currentTimestamp,
+		opts:        opts,
+		f:           f,
+		timestamp:   lex.currentTimestamp,
+		searchStats: &searchStats{},
 	}
 
 	if lex.isKeyword("|") {

--- a/lib/logstorage/storage_search.go
+++ b/lib/logstorage/storage_search.go
@@ -101,7 +101,13 @@ func (f writeBlockResultFunc) newDataBlockWriter() WriteDataBlockFunc {
 // RunQuery runs the given q and calls writeBlock for results.
 func (s *Storage) RunQuery(ctx context.Context, tenantIDs []TenantID, q *Query, writeBlock WriteDataBlockFunc) error {
 	writeBlockResult := writeBlock.newBlockResultWriter()
-	return s.runQuery(ctx, tenantIDs, q, writeBlockResult)
+
+	err := s.runQuery(ctx, tenantIDs, q, writeBlockResult)
+
+	// Update metrics regardless of the error
+	updateSearchMetrics(q.searchStats)
+
+	return err
 }
 
 // runQueryFunc must run the given q and pass query results to writeBlock
@@ -130,20 +136,15 @@ func (s *Storage) runQuery(ctx context.Context, tenantIDs []TenantID, q *Query, 
 		filter:       q.f,
 		fieldsFilter: fieldsFilter,
 	}
-	ss := &searchStats{}
 
 	workersCount := q.GetConcurrency()
 
 	search := func(stopCh <-chan struct{}, writeBlockToPipes writeBlockResultFunc) error {
-		s.search(workersCount, so, ss, stopCh, writeBlockToPipes)
+		s.search(workersCount, so, q.searchStats, stopCh, writeBlockToPipes)
 		return nil
 	}
 
-	err = runPipes(ctx, q.pipes, search, writeBlock, workersCount)
-
-	updateSearchMetrics(ss)
-
-	return err
+	return runPipes(ctx, q.pipes, search, writeBlock, workersCount)
 }
 
 // searchFunc must perform search and pass its results to writeBlock.


### PR DESCRIPTION
Adds 3 histograms that track how many rows, bytes, blocks and streams a single query touches:

- `vl_storage_rows_read_per_query` tracks the number of log rows read from storage during each query execution.
- `vl_storage_blocks_read_per_query` counts the number of storage blocks processed during each query execution.
- `vl_storage_stream_used_per_query` tracks the number of unique log streams used to fetch data (not the number of unique log streams after fetching). Measures the efficiency of stream-based filtering and data locality.

Related issue: https://github.com/VictoriaMetrics/VictoriaLogs/issues/45