### PR TITLE
metrics: add metric to track failed requests to remote storages

### DIFF
--- a/app/vlstorage/main.go
+++ b/app/vlstorage/main.go
@@ -78,6 +78,7 @@ var localStorage *logstorage.Storage
 var localStorageMetrics *metrics.Set
 
 var netstorageInsert *netinsert.Storage
+
 var netstorageSelect *netselect.Storage
 
 // Init initializes vlstorage.

--- a/app/vlstorage/netinsert/netinsert.go
+++ b/app/vlstorage/netinsert/netinsert.go
@@ -21,6 +21,7 @@ import (
 	"github.com/valyala/fastrand"
 
 	"github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage"
+	"github.com/VictoriaMetrics/metrics"
 )
 
 // the maximum size of a single data block sent to storage node.
@@ -66,8 +67,12 @@ type storageNode struct {
 	pendingData          *bytesutil.ByteBuffer
 	pendingDataLastFlush time.Time
 
+	// sendErrors counts failed send attempts for this storage node.
+	sendErrors *metrics.Counter
+
 	// the unix timestamp until the storageNode is disabled for data writing.
 	disabledUntil atomic.Uint64
+	isBroken      atomic.Uint32
 }
 
 func newStorageNode(s *Storage, addr string, ac *promauth.Config, isTLS bool) *storageNode {
@@ -89,6 +94,8 @@ func newStorageNode(s *Storage, addr string, ac *promauth.Config, isTLS bool) *s
 		},
 		ac: ac,
 
+		sendErrors: metrics.GetOrCreateCounter(fmt.Sprintf(`vl_insert_remote_send_errors_total{url=%q}`, addr)),
+
 		pendingData: &bytesutil.ByteBuffer{},
 	}
 
@@ -97,6 +104,13 @@ func newStorageNode(s *Storage, addr string, ac *promauth.Config, isTLS bool) *s
 		defer s.wg.Done()
 		sn.backgroundFlusher()
 	}()
+
+	_ = metrics.GetOrCreateGauge(fmt.Sprintf(`vl_insert_remote_broken{url=%q}`, addr), func() float64 {
+		if sn.isBroken.Load() == 1 {
+			return 1
+		}
+		return 0
+	})
 
 	return sn
 }
@@ -204,6 +218,7 @@ func (sn *storageNode) sendInsertRequest(pendingData *bytesutil.ByteBuffer) erro
 	}
 
 	if sn.disabledUntil.Load() > fasttime.UnixTimestamp() {
+		sn.sendErrors.Inc()
 		return errTemporarilyDisabled
 	}
 
@@ -236,14 +251,13 @@ func (sn *storageNode) sendInsertRequest(pendingData *bytesutil.ByteBuffer) erro
 
 	resp, err := sn.c.Do(req)
 	if err != nil {
-		// Disable sn for data writing for 10 seconds.
-		sn.disabledUntil.Store(fasttime.UnixTimestamp() + 10)
-
+		sn.setDisableTemporarily()
 		return fmt.Errorf("cannot send data block with the length %d to %q: %s", pendingData.Len(), reqURL, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode/100 == 2 {
+		sn.isBroken.Store(0)
 		return nil
 	}
 
@@ -252,14 +266,19 @@ func (sn *storageNode) sendInsertRequest(pendingData *bytesutil.ByteBuffer) erro
 		respBody = []byte(fmt.Sprintf("%s", err))
 	}
 
-	// Disable sn for data writing for 10 seconds.
-	sn.disabledUntil.Store(fasttime.UnixTimestamp() + 10)
+	sn.setDisableTemporarily()
 
 	return fmt.Errorf("unexpected status code returned when sending data block to %q: %d; want 2xx; response body: %q", reqURL, resp.StatusCode, respBody)
 }
 
 func (sn *storageNode) getRequestURL(path string) string {
 	return fmt.Sprintf("%s://%s%s?version=%s", sn.scheme, sn.addr, path, url.QueryEscape(ProtocolVersion))
+}
+
+func (sn *storageNode) setDisableTemporarily() {
+	sn.disabledUntil.Store(fasttime.UnixTimestamp() + 10)
+	sn.isBroken.Store(1)
+	sn.sendErrors.Inc()
 }
 
 var zstdBufPool bytesutil.ByteBufferPool

--- a/app/vlstorage/netinsert/netinsert.go
+++ b/app/vlstorage/netinsert/netinsert.go
@@ -105,11 +105,11 @@ func newStorageNode(s *Storage, addr string, ac *promauth.Config, isTLS bool) *s
 		sn.backgroundFlusher()
 	}()
 
-	_ = metrics.GetOrCreateGauge(fmt.Sprintf(`vl_insert_remote_broken{url=%q}`, addr), func() float64 {
+	_ = metrics.GetOrCreateGauge(fmt.Sprintf(`vl_insert_remote_is_reachable{url=%q}`, addr), func() float64 {
 		if sn.isBroken.Load() == 1 {
-			return 1
+			return 0
 		}
-		return 0
+		return 1
 	})
 
 	return sn

--- a/app/vlstorage/netselect/netselect.go
+++ b/app/vlstorage/netselect/netselect.go
@@ -352,7 +352,7 @@ func (s *Storage) runQuery(stopCh <-chan struct{}, tenantIDs []logstorage.Tenant
 			})
 			if err != nil {
 				if !errors.Is(err, context.Canceled) {
-					s.sns[nodeIdx].sendErrors.Inc()
+					sn.sendErrors.Inc()
 				}
 				// Cancel the remaining parallel queries
 				cancel()

--- a/app/vlstorage/netselect/netselect.go
+++ b/app/vlstorage/netselect/netselect.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/contextutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
@@ -21,7 +22,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/promauth"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/slicesutil"
 
-	"github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage"
+	"github.com/VictoriaMetrics/metrics"
 )
 
 const (
@@ -83,6 +84,9 @@ type storageNode struct {
 
 	// ac is auth config used for setting request headers such as Authorization and Host.
 	ac *promauth.Config
+
+	// sendErrors counts failed send attempts for this storage node.
+	sendErrors *metrics.Counter
 }
 
 func newStorageNode(s *Storage, addr string, ac *promauth.Config, isTLS bool) *storageNode {
@@ -103,6 +107,8 @@ func newStorageNode(s *Storage, addr string, ac *promauth.Config, isTLS bool) *s
 			Transport: ac.NewRoundTripper(tr),
 		},
 		ac: ac,
+
+		sendErrors: metrics.GetOrCreateCounter(fmt.Sprintf(`vl_select_remote_send_errors_total{url=%q}`, addr)),
 	}
 	return sn
 }
@@ -345,6 +351,9 @@ func (s *Storage) runQuery(stopCh <-chan struct{}, tenantIDs []logstorage.Tenant
 				writeBlock(uint(nodeIdx), db)
 			})
 			if err != nil {
+				if !errors.Is(err, context.Canceled) {
+					s.sns[nodeIdx].sendErrors.Inc()
+				}
 				// Cancel the remaining parallel queries
 				cancel()
 			}

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -18,7 +18,7 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 ## tip
 
-* FEATURE: expose `vl_insert_remote_send_errors_total`, `vl_select_remote_send_errors_total` and `vl_insert_remote_broken` metrics for monitoring failed remote insert/select attempts and detecting temporarily disabled or broken remote storage nodes.
+* FEATURE: expose `vl_insert_remote_send_errors_total`, `vl_select_remote_send_errors_total` and `vl_insert_remote_is_reachable` metrics for monitoring failed remote insert/select attempts and detecting temporarily disabled or broken remote storage nodes.
 
 * BUGFIX: properly return VictoriaLogs version at `./victoria-logs -version` and at the `vm_app_version` metric exposed via [`/metrics` page](https://docs.victoriametrics.com/victorialogs/#monitoring). See [#409](https://github.com/VictoriaMetrics/VictoriaLogs/issues/409). The bug has been introduced in [v1.25.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.25.0).
 

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -18,6 +18,8 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 ## tip
 
+* FEATURE: expose `vl_insert_remote_send_errors_total`, `vl_select_remote_send_errors_total` and `vl_insert_remote_broken` metrics for monitoring failed remote insert/select attempts and detecting temporarily disabled or broken remote storage nodes.
+
 * BUGFIX: properly return VictoriaLogs version at `./victoria-logs -version` and at the `vm_app_version` metric exposed via [`/metrics` page](https://docs.victoriametrics.com/victorialogs/#monitoring). See [#409](https://github.com/VictoriaMetrics/VictoriaLogs/issues/409). The bug has been introduced in [v1.25.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.25.0).
 
 ## [v1.25.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.25.0)


### PR DESCRIPTION
- `vl_insert_remote_send_errors_total` tracks the total number of failed attempts to send log data to remote storage nodes.
- `vl_select_remote_errors_total` tracks the total number of failed queries to remote storage, excluding context cancellations.

Related issue: https://github.com/VictoriaMetrics/VictoriaLogs/issues/45