### PR TITLE
metrics: track active streams for vlinsert

### DIFF
--- a/app/vlstorage/main.go
+++ b/app/vlstorage/main.go
@@ -78,7 +78,10 @@ var localStorage *logstorage.Storage
 var localStorageMetrics *metrics.Set
 
 var netstorageInsert *netinsert.Storage
+var netstorageInsertMetrics *metrics.Set
+
 var netstorageSelect *netselect.Storage
+var netstorageSelectMetrics *metrics.Set
 
 // Init initializes vlstorage.
 //
@@ -141,9 +144,19 @@ func initNetworkStorage() {
 
 	logger.Infof("starting insert service for nodes %s", *storageNodeAddrs)
 	netstorageInsert = netinsert.NewStorage(*storageNodeAddrs, authCfgs, isTLSs, *insertConcurrency, *insertDisableCompression)
+	netstorageInsertMetrics = metrics.NewSet()
+	netstorageInsertMetrics.RegisterMetricsWriter(func(w io.Writer) {
+		netstorageInsert.WriteMetrics(w)
+	})
+	metrics.RegisterSet(netstorageInsertMetrics)
 
 	logger.Infof("initializing select service for nodes %s", *storageNodeAddrs)
 	netstorageSelect = netselect.NewStorage(*storageNodeAddrs, authCfgs, isTLSs, *selectDisableCompression)
+	netstorageSelectMetrics = metrics.NewSet()
+	netstorageSelectMetrics.RegisterMetricsWriter(func(w io.Writer) {
+		netstorageSelect.WriteMetrics(w)
+	})
+	metrics.RegisterSet(netstorageSelectMetrics)
 
 	logger.Infof("initialized all the network services")
 }

--- a/app/vlstorage/netinsert/netinsert.go
+++ b/app/vlstorage/netinsert/netinsert.go
@@ -48,6 +48,7 @@ type Storage struct {
 	wg     sync.WaitGroup
 }
 
+// WriteMetrics writes internal storage metrics to the provided writer in Prometheus text exposition format.
 func (s *Storage) WriteMetrics(w io.Writer) {
 	metrics.WriteCounterUint64(w, `vl_insert_remote_send_errors_total`, s.RemoteSendFailed.Load())
 }

--- a/app/vlstorage/netinsert/netinsert.go
+++ b/app/vlstorage/netinsert/netinsert.go
@@ -50,12 +50,7 @@ type Storage struct {
 
 // WriteMetrics writes internal storage metrics to the provided writer in Prometheus text exposition format.
 func (s *Storage) WriteMetrics(w io.Writer) {
-	activeStreams := s.GetActiveStreams()
-	if activeStreams == 0 {
-		return
-	}
-
-	metrics.WriteGaugeUint64(w, `vl_insert_active_streams`, activeStreams)
+	metrics.WriteGaugeUint64(w, `vl_insert_active_streams`, s.GetActiveStreams())
 	metrics.WriteCounterUint64(w, `vl_insert_remote_send_errors_total`, s.RemoteSendFailed.Load())
 }
 

--- a/app/vlstorage/netselect/netselect.go
+++ b/app/vlstorage/netselect/netselect.go
@@ -318,6 +318,7 @@ func (s *Storage) MustStop() {
 	s.sns = nil
 }
 
+// WriteMetrics writes internal storage metrics to the provided writer in Prometheus text exposition format.
 func (s *Storage) WriteMetrics(w io.Writer) {
 	metrics.WriteGaugeUint64(w, `vl_select_remote_send_errors_total`, s.remoteSendErrors.Load())
 }


### PR DESCRIPTION
- `vl_insert_active_streams` reports the total number of active log streams currently being tracked by vlinsert since startup.

Waiting for merge of https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9317.

Related issue: https://github.com/VictoriaMetrics/VictoriaLogs/issues/45