### PR TITLE
lib/logstorage: removed unnecessary temporary dirs removal

### DIFF
--- a/lib/logstorage/datadb.go
+++ b/lib/logstorage/datadb.go
@@ -155,9 +155,6 @@ func mustCreateDatadb(path string) {
 
 // mustOpenDatadb opens datadb at the given path with the given flushInterval for in-memory data.
 func mustOpenDatadb(pt *partition, path string, flushInterval time.Duration) *datadb {
-	// Remove temporary directories, which may be left after unclean shutdown.
-	fs.MustRemoveTemporaryDirs(path)
-
 	partNames := mustReadPartNames(path)
 	mustRemoveUnusedDirs(path, partNames)
 


### PR DESCRIPTION
### Describe Your Changes

temporary dirs, that are expected to be removed by fs.MustRemoveTemporaryDirs are created by fs.MustRemoveDirAtomic, which is not invoked at all in lib/logstorage at all. removing it's invocation

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
