### PR TITLE
app/vmui/vlogs: improve autocomplete usability, add quick autocompletion, remove unnecessary data fetching for autocompletion

### DIFF
--- a/app/vmui/packages/vmui/src/components/Configurators/AdditionalSettings/AdditionalSettings.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/AdditionalSettings/AdditionalSettings.tsx
@@ -8,33 +8,19 @@ import { TuneIcon } from "../../Main/Icons";
 import Button from "../../Main/Button/Button";
 import classNames from "classnames";
 import useBoolean from "../../../hooks/useBoolean";
-import useEventListener from "../../../hooks/useEventListener";
 import Tooltip from "../../Main/Tooltip/Tooltip";
 import { AUTOCOMPLETE_QUICK_KEY } from "../../Main/ShortcutKeys/constants/keyList";
+import { useQuickAutocomplete } from "../../../hooks/useQuickAutocomplete";
 
 const AdditionalSettingsControls: FC = () => {
   const { isMobile } = useDeviceDetect();
   const { autocomplete } = useQueryState();
   const queryDispatch = useQueryDispatch();
+  useQuickAutocomplete();
 
   const onChangeAutocomplete = () => {
     queryDispatch({ type: "TOGGLE_AUTOCOMPLETE" });
   };
-
-  const onChangeQuickAutocomplete = () => {
-    queryDispatch({ type: "SET_AUTOCOMPLETE_QUICK", payload: true });
-  };
-
-  const handleKeyDown = (e: KeyboardEvent) => {
-    /** @see AUTOCOMPLETE_QUICK_KEY */
-    const { code, ctrlKey, altKey } = e;
-    if (code === "Space" && (ctrlKey || altKey)) {
-      e.preventDefault();
-      onChangeQuickAutocomplete();
-    }
-  };
-
-  useEventListener("keydown", handleKeyDown);
 
   return (
     <div

--- a/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/LogsQL/LogsQueryEditorAutocomplete.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/LogsQL/LogsQueryEditorAutocomplete.tsx
@@ -13,7 +13,8 @@ const LogsQueryEditorAutocomplete: FC<QueryEditorAutocompleteProps> = ({
   caretPosition,
   hasHelperText,
   onSelect,
-  onFoundOptions
+  onFoundOptions,
+  isOpen
 }) => {
   const [offsetPos, setOffsetPos] = useState({ top: 0, left: 0 });
 
@@ -41,7 +42,7 @@ const LogsQueryEditorAutocomplete: FC<QueryEditorAutocompleteProps> = ({
       query: value,
       ...getContextData(part, cursorStartPosition)
     };
-  }, [logicalParts, caretPosition]);
+  }, [logicalParts, caretPosition, value]);
 
   const { fieldNames, fieldValues, loading } = useFetchLogsQLOptions(contextData);
 
@@ -141,6 +142,10 @@ const LogsQueryEditorAutocomplete: FC<QueryEditorAutocompleteProps> = ({
     span.remove();
     marker.remove();
   }, [anchorEl, caretPosition, hasHelperText, fullValue]);
+
+  if (!isOpen) {
+    return;
+  }
 
   return (
     <>

--- a/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/LogsQL/parser.ts
+++ b/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/LogsQL/parser.ts
@@ -107,7 +107,7 @@ export const getContextData = (part: LogicalPart, cursorPos: number): ContextDat
     contextType: ContextType.Unknown,
   };
 
-  // Determine context type based on logical part type
+  // Determine a context type based on a logical part type
   determineContextType(part, valueBeforeCursor, valueAfterCursor, metaData);
 
   // Clean up quotes in valueContext
@@ -131,7 +131,7 @@ const handleFilterValue = (valueBeforeCursor: string, metaData: ContextData): vo
   const [filterName, ...filterValue] = valueBeforeCursor.split(":");
   metaData.contextType = ContextType.FilterValue;
   metaData.filterName = filterName;
-  const enhanceOperators = ["=", "-", "!", "~", "<", ">", "<=", ">="] as const;
+  const enhanceOperators = ["=", "-", "!"] as const;
   const enhanceOperator = enhanceOperators.find(op => op === filterValue[0]);
   if (enhanceOperator) {
     metaData.valueContext = filterValue.slice(1).join(":");
@@ -142,7 +142,7 @@ const handleFilterValue = (valueBeforeCursor: string, metaData: ContextData): vo
   }
 };
 
-/** Function to determine context type based on part type and value */
+/** Function to determine a context type based on part type and value */
 const determineContextType = (
   part: LogicalPart,
   valueBeforeCursor: string,

--- a/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/QueryEditor.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/QueryEditor.tsx
@@ -14,6 +14,7 @@ export interface QueryEditorAutocompleteProps {
   caretPosition: [number, number]; // [start, end]
   hasHelperText: boolean;
   includeFunctions: boolean;
+  isOpen: boolean;
   onSelect: (val: string, caretPosition: number) => void;
   onFoundOptions: (val: AutocompleteOptions[]) => void;
 }
@@ -137,7 +138,7 @@ const QueryEditor: FC<QueryEditorProps> = ({
         inputmode={"search"}
         caretPosition={caretPositionInput}
       />
-      {showAutocomplete && autocomplete && AutocompleteEl && (
+      {autocomplete && AutocompleteEl && (
         <AutocompleteEl
           value={value}
           anchorEl={autocompleteAnchorEl}
@@ -146,6 +147,7 @@ const QueryEditor: FC<QueryEditorProps> = ({
           includeFunctions={includeFunctions}
           onSelect={handleSelect}
           onFoundOptions={handleChangeFoundOptions}
+          isOpen={showAutocomplete}
         />
       )}
     </div>

--- a/app/vmui/packages/vmui/src/hooks/useQuickAutocomplete.ts
+++ b/app/vmui/packages/vmui/src/hooks/useQuickAutocomplete.ts
@@ -1,0 +1,24 @@
+import { useCallback } from "preact/compat";
+import useEventListener from "./useEventListener";
+import { useQueryDispatch } from "../state/query/QueryStateContext";
+
+export const useQuickAutocomplete = () => {
+  const queryDispatch = useQueryDispatch();
+
+  const setQuickAutocomplete = useCallback((value: boolean) => {
+    queryDispatch({ type: "SET_AUTOCOMPLETE_QUICK", payload: value });
+  }, [queryDispatch]);
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    /** @see AUTOCOMPLETE_QUICK_KEY */
+    const { code, ctrlKey, altKey } = e;
+    if (code === "Space" && (ctrlKey || altKey)) {
+      e.preventDefault();
+      setQuickAutocomplete(true);
+    }
+  };
+
+  useEventListener("keydown", handleKeyDown);
+
+  return setQuickAutocomplete;
+};

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsHeader/ExploreLogsHeader.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsHeader/ExploreLogsHeader.tsx
@@ -11,6 +11,9 @@ import { useQueryDispatch, useQueryState } from "../../../state/query/QueryState
 import Switch from "../../../components/Main/Switch/Switch";
 import QueryHistory from "../../../components/QueryHistory/QueryHistory";
 import useBoolean from "../../../hooks/useBoolean";
+import { useQuickAutocomplete } from "../../../hooks/useQuickAutocomplete";
+import { AUTOCOMPLETE_QUICK_KEY } from "../../../components/Main/ShortcutKeys/constants/keyList";
+import Tooltip from "../../../components/Main/Tooltip/Tooltip";
 
 export interface ExploreLogHeaderProps {
   query: string;
@@ -32,8 +35,9 @@ const ExploreLogsHeader: FC<ExploreLogHeaderProps> = ({
   onRun,
 }) => {
   const { isMobile } = useDeviceDetect();
-  const { autocomplete, queryHistory } = useQueryState();
+  const { autocomplete, queryHistory, autocompleteQuick } = useQueryState();
   const queryDispatch = useQueryDispatch();
+  const setQuickAutocomplete = useQuickAutocomplete();
 
   const [errorLimit, setErrorLimit] = useState("");
   const [limitInput, setLimitInput] = useState(limit);
@@ -85,6 +89,13 @@ const ExploreLogsHeader: FC<ExploreLogHeaderProps> = ({
     }
   }, [query, awaitQuery]);
 
+  const onChangeHandle = (value: string) => {
+    onChange(value);
+    if (autocompleteQuick) {
+      setQuickAutocomplete(false);
+    }
+  };
+
   return (
     <div
       className={classNames({
@@ -96,12 +107,12 @@ const ExploreLogsHeader: FC<ExploreLogHeaderProps> = ({
       <div className="vm-explore-logs-header-top">
         <QueryEditor
           value={query}
-          autocomplete={autocomplete}
+          autocomplete={autocomplete || autocompleteQuick}
           autocompleteEl={LogsQueryEditorAutocomplete}
           onArrowUp={createHandlerArrow(-1)}
           onArrowDown={createHandlerArrow(1)}
           onEnter={onRun}
-          onChange={onChange}
+          onChange={onChangeHandle}
           label={"Log query"}
           error={error}
         />
@@ -116,12 +127,14 @@ const ExploreLogsHeader: FC<ExploreLogHeaderProps> = ({
       </div>
       <div className="vm-explore-logs-header-bottom">
         <div className="vm-explore-logs-header-bottom-contols">
-          <Switch
-            label={"Autocomplete"}
-            value={autocomplete}
-            onChange={onChangeAutocomplete}
-            fullWidth={isMobile}
-          />
+          <Tooltip title={<>Quick tip: {AUTOCOMPLETE_QUICK_KEY}</>}>
+            <Switch
+              label={"Autocomplete"}
+              value={autocomplete}
+              onChange={onChangeAutocomplete}
+              fullWidth={isMobile}
+            />
+          </Tooltip>
         </div>
         <div className="vm-explore-logs-header-bottom-helpful">
           <a

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -19,6 +19,7 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 ## tip
 
 * FEATURE: [vlogscli](https://docs.victoriametrics.com/victorialogs/querying/vlogscli/): add ability to configure auth options and TLS options for connections to the `-datasource.url`. See [auth options docs](https://docs.victoriametrics.com/victorialogs/querying/vlogscli/#auth-options) and [TLS options docs](https://docs.victoriametrics.com/victorialogs/querying/vlogscli/#tls-options). See [this feature request](https://github.com/VictoriaMetrics/VictoriaLogs/issues/54). Thanks to @thom-vend for [the initial pull request](https://github.com/VictoriaMetrics/VictoriaLogs/pull/457).
+* FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): improve autocomplete functionality with enhanced quick autocomplete via hotkey support and removed special characters from autocomplete suggestions. See [this comment](https://github.com/VictoriaMetrics/VictoriaLogs/issues/70#issuecomment-3043591443) for details.
 
 ## [v1.25.1](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.25.1)
 


### PR DESCRIPTION
### Describe Your Changes
This pr is copy of [this one](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9333).

Related issue: #70 
- added quick autocompletion for the VictoriaLogs via hotkeys;
- removed unnecessary data fetching for autocompletion;
- removed special chars which triggers autocompletion. Now autocompletion works only for `!`, `-`, `=`. 

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
