### PR TITLE
app/vmui: fix groups auto-expand on list update

### DIFF
--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsOptions/BarHitsOptions.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsOptions/BarHitsOptions.tsx
@@ -61,15 +61,6 @@ const BarHitsOptions: FC<Props> = ({ onChange }) => {
 
   return (
     <div className="vm-bar-hits-options">
-      <Tooltip title={hideChart ? "Show chart and resume hits updates" : "Hide chart and pause hits updates"}>
-        <Button
-          variant="text"
-          color="primary"
-          startIcon={hideChart ? <VisibilityOffIcon/> : <VisibilityIcon/>}
-          onClick={toggleHideChart}
-          ariaLabel="settings"
-        />
-      </Tooltip>
       <div ref={optionsButtonRef}>
         <Tooltip title="Graph settings">
           <Button
@@ -81,6 +72,15 @@ const BarHitsOptions: FC<Props> = ({ onChange }) => {
           />
         </Tooltip>
       </div>
+      <Tooltip title={hideChart ? "Show chart and resume hits updates" : "Hide chart and pause hits updates"}>
+        <Button
+          variant="text"
+          color="primary"
+          startIcon={hideChart ? <VisibilityOffIcon/> : <VisibilityIcon/>}
+          onClick={toggleHideChart}
+          ariaLabel="settings"
+        />
+      </Tooltip>
       <Popper
         open={openOptions}
         placement="bottom-right"

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBarChart/ExploreLogsBarChart.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBarChart/ExploreLogsBarChart.tsx
@@ -69,6 +69,8 @@ const ExploreLogsBarChart: FC<Props> = ({ logHits, period, error, isLoading, onA
   }, [logHits]);
 
   const noDataMessage: string = useMemo(() => {
+    if (isLoading) return "";
+
     const noData = data.every(d => d.length === 0);
     const noTimestamps = data[0].length === 0;
     const noValues = data[1].length === 0;
@@ -81,7 +83,7 @@ const ExploreLogsBarChart: FC<Props> = ({ logHits, period, error, isLoading, onA
     } else if (noValues) {
       return "No value information available for the current queries and time range.";
     } return "";
-  }, [data, hideChart]);
+  }, [data, hideChart, isLoading]);
 
   const setPeriod = ({ from, to }: {from: Date, to: Date}) => {
     timeDispatch({ type: "SET_PERIOD", payload: { from, to } });

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/ExploreLogsBody.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/ExploreLogsBody.tsx
@@ -1,5 +1,12 @@
 import { FC, useRef } from "preact/compat";
-import { CodeIcon, ListIcon, TableIcon, PlayIcon } from "../../../components/Main/Icons";
+import {
+  CodeIcon,
+  ListIcon,
+  TableIcon,
+  PlayIcon,
+  VisibilityOffIcon,
+  VisibilityIcon
+} from "../../../components/Main/Icons";
 import Tabs from "../../../components/Main/Tabs/Tabs";
 import "./style.scss";
 import classNames from "classnames";
@@ -12,6 +19,10 @@ import GroupView from "./views/GroupView/GroupView";
 import TableView from "./views/TableView/TableView";
 import JsonView from "./views/JsonView/JsonView";
 import LiveTailingView from "./views/LiveTailingView/LiveTailingView";
+import Tooltip from "../../../components/Main/Tooltip/Tooltip";
+import Button from "../../../components/Main/Button/Button";
+import { useSearchParams } from "react-router-dom";
+import Alert from "../../../components/Main/Alert/Alert";
 
 export interface ExploreLogBodyProps {
   data: Logs[];
@@ -37,6 +48,18 @@ const ExploreLogsBody: FC<ExploreLogBodyProps> = ({ data, isLoading }) => {
   const { setSearchParamsFromKeys } = useSearchParamsFromObject();
   const [activeTab, setActiveTab] = useStateSearchParams(DisplayType.group, "view");
   const settingsRef = useRef<HTMLDivElement>(null);
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [hideLogs, setHideLogs] = useStateSearchParams(false, "hide_logs");
+
+  const toggleHideLogs = () => {
+    setHideLogs(prev => {
+      const newVal = !prev;
+      newVal ? searchParams.set("hide_logs", "true") : searchParams.delete("hide_logs");
+      setSearchParams(searchParams);
+      return newVal;
+    });
+  };
 
   const handleChangeTab = (view: string) => {
     setActiveTab(view as DisplayType);
@@ -82,19 +105,33 @@ const ExploreLogsBody: FC<ExploreLogBodyProps> = ({ data, isLoading }) => {
           className="vm-explore-logs-body-header__settings"
           ref={settingsRef}
         />
+        <Tooltip title={hideLogs ? "Show Logs" : "Hide Logs"}>
+          <Button
+            variant="text"
+            color="primary"
+            startIcon={hideLogs ? <VisibilityOffIcon/> : <VisibilityIcon/>}
+            onClick={toggleHideLogs}
+            ariaLabel="settings"
+          />
+        </Tooltip>
       </div>
 
       <div
         className={classNames({
           "vm-explore-logs-body__table": true,
+          "vm-explore-logs-body__table_hide": hideLogs,
           "vm-explore-logs-body__table_mobile": isMobile,
         })}
       >
-        {ActiveTabComponent &&
-            <ActiveTabComponent
-              data={data}
-              settingsRef={settingsRef}
-            />
+        {hideLogs && (
+          <Alert variant="info">Logs are hidden. Updates paused.</Alert>
+        )}
+
+        {!hideLogs && ActiveTabComponent &&
+          <ActiveTabComponent
+            data={data}
+            settingsRef={settingsRef}
+          />
         }
       </div>
     </div>

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/style.scss
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/style.scss
@@ -4,11 +4,12 @@
   position: relative;
 
   &-header {
-    background-color: $color-background-block;
-    z-index: 3;
-    margin: -$padding-medium 0-$padding-medium 0;
     position: sticky;
     top: 0;
+    margin: -$padding-medium 0-$padding-medium 0;
+    grid-template-columns: 1fr auto auto;
+    background-color: $color-background-block;
+    z-index: 3;
 
     @media (max-width:1000px) {
       top: 51px;

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/views/TableView/style.scss
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/views/TableView/style.scss
@@ -5,6 +5,5 @@
   &__settings-buttons {
     display: flex;
     align-items: center;
-    gap: $padding-small;
   }
 }

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogs.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/GroupLogs/GroupLogs.tsx
@@ -68,7 +68,10 @@ const GroupLogs: FC<Props> = ({ logs, settingsRef }) => {
   const paginatedGroups = usePaginateGroups(groupData, page, rowsPerPage);
 
   const handleToggleExpandAll = useCallback(() => {
-    setExpandGroups(new Array(groupData.length).fill(!expandAll));
+    setExpandGroups(prev => {
+      const keepClosed = (prev.every(v => !v) && prev.length) || isMobile;
+      return new Array(groupData.length).fill(!keepClosed);
+    });
   }, [expandAll, groupData.length]);
 
   const handleChangeExpand = useCallback((i: number) => (value: boolean) => {

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/hooks/useFetchLogHits.ts
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/hooks/useFetchLogHits.ts
@@ -6,13 +6,18 @@ import { getHitsTimeParams } from "../../../utils/logs";
 import { LOGS_GROUP_BY, LOGS_LIMIT_HITS } from "../../../constants/logs";
 import { isEmptyObject } from "../../../utils/object";
 import { useTenant } from "../../../hooks/useTenant";
+import { useSearchParams } from "react-router-dom";
 
 export const useFetchLogHits = (server: string, query: string) => {
   const tenant = useTenant();
+  const [searchParams] = useSearchParams();
+
   const [logHits, setLogHits] = useState<LogHits[]>([]);
   const [isLoading, setIsLoading] = useState<{[key: number]: boolean;}>([]);
   const [error, setError] = useState<ErrorTypes | string>();
   const abortControllerRef = useRef(new AbortController());
+
+  const hideChart = useMemo(() => searchParams.get("hide_chart"), [searchParams]);
 
   const url = useMemo(() => getLogHitsUrl(server), [server]);
 
@@ -80,6 +85,13 @@ export const useFetchLogHits = (server: string, query: string) => {
       abortControllerRef.current.abort();
     };
   }, []);
+
+  useEffect(() => {
+    if (hideChart) {
+      setLogHits([]);
+      setError(undefined);
+    }
+  }, [hideChart]);
 
   return {
     logHits,

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/hooks/useFetchLogs.ts
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/hooks/useFetchLogs.ts
@@ -4,14 +4,18 @@ import { ErrorTypes, TimeParams } from "../../../types";
 import { Logs } from "../../../api/types";
 import dayjs from "dayjs";
 import { useTenant } from "../../../hooks/useTenant";
+import { useSearchParams } from "react-router-dom";
 
 export const useFetchLogs = (server: string, query: string, limit: number) => {
   const tenant = useTenant();
+  const [searchParams] = useSearchParams();
 
   const [logs, setLogs] = useState<Logs[]>([]);
   const [isLoading, setIsLoading] = useState<{ [key: number]: boolean }>({});
   const [error, setError] = useState<ErrorTypes | string>();
   const abortControllerRef = useRef(new AbortController());
+
+  const hideLogs = useMemo(() => searchParams.get("hide_logs"), [searchParams]);
 
   const url = useMemo(() => getLogsUrl(server), [server]);
 
@@ -74,6 +78,13 @@ export const useFetchLogs = (server: string, query: string, limit: number) => {
       abortControllerRef.current.abort();
     };
   }, []);
+
+  useEffect(() => {
+    if (hideLogs) {
+      setLogs([]);
+      setError(undefined);
+    }
+  }, [hideLogs]);
 
   return {
     logs,

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -19,6 +19,10 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 ## tip
 
 * FEATURE: [vlogscli](https://docs.victoriametrics.com/victorialogs/querying/vlogscli/): add ability to configure auth options and TLS options for connections to the `-datasource.url`. See [auth options docs](https://docs.victoriametrics.com/victorialogs/querying/vlogscli/#auth-options) and [TLS options docs](https://docs.victoriametrics.com/victorialogs/querying/vlogscli/#tls-options). See [this feature request](https://github.com/VictoriaMetrics/VictoriaLogs/issues/54). Thanks to @thom-vend for [the initial pull request](https://github.com/VictoriaMetrics/VictoriaLogs/pull/457).
+* FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add the ability to hide the logs panel to view only the graph. When the logs panel is hidden, the `/query` request is not executed.
+
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): prevent groups from automatically expanding on list updates if all groups were previously collapsed. See [#92](https://github.com/VictoriaMetrics/VictoriaLogs/issues/92).
+
 
 ## [v1.25.1](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.25.1)
 


### PR DESCRIPTION
### Describe Your Changes

- Add the ability to hide the logs panel for viewing only the graph. When hidden, the `/query` request is not executed.
- Prevent groups from automatically expanding on list updates if all groups were previously collapsed.

Related issue:  VictoriaMetrics/VictoriaLogs#92
This PR is a copy of https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9366.

![image](https://github.com/user-attachments/assets/ce4e749b-6f30-4ed0-8a7c-de1b91ab9778)
