### PR TITLE
docs: troubleshooting guide

### DIFF
--- a/docs/victorialogs/LogsQL.md
+++ b/docs/victorialogs/LogsQL.md
@@ -3676,7 +3676,7 @@ _time:5m | stats count_uniq_hash(ip) unique_ips_count
 The following query returns an estimated number of unique `(host, path)` pairs for the corresponding [fields](https://docs.victoriametrics.com/victorialogs/keyconcepts/#data-model)
 over the last 5 minutes:
 
-```js
+```logsql
 _time:5m | stats count_uniq_hash(host, path) unique_host_path_pairs
 ```
 


### PR DESCRIPTION
A troubleshooting guide is needed to understand why the queries are slow and to gain a good understanding of how VictoriaLogs works.

Related: https://github.com/VictoriaMetrics/VictoriaLogs/issues/458