### PR TITLE
Spelling fixes, Markdown standard

### DIFF
--- a/app/vlinsert/insertutil/line_reader.go
+++ b/app/vlinsert/insertutil/line_reader.go
@@ -151,7 +151,7 @@ func (lr *LineReader) skipUntilNextLine() (bool, int) {
 			// Include skipped bytes before \n, including the newline itself.
 			skipSizeBytes += n + 1 - len(lr.buf)
 			// Include \n in the buf, so too long line is replaced with an empty line.
-			// This is needed for maintaining synchorinzation consistency between lines
+			// This is needed for maintaining synchronization consistency between lines
 			// in protocols such as Elasticsearch bulk import.
 			lr.buf = append(lr.buf[:0], lr.buf[n:]...)
 			return true, skipSizeBytes

--- a/app/vlinsert/loki/loki.go
+++ b/app/vlinsert/loki/loki.go
@@ -75,7 +75,7 @@ func getCommonParams(r *http.Request) (*commonParams, error) {
 	if rv := httputil.GetRequestValue(r, "disable_message_parsing", "VL-Loki-Disable-Message-Parsing"); rv != "" {
 		bv, err := strconv.ParseBool(rv)
 		if err != nil {
-			return nil, fmt.Errorf("cannot parse dusable_message_parsing=%q: %s", rv, err)
+			return nil, fmt.Errorf("cannot parse disable_message_parsing=%q: %s", rv, err)
 		}
 		parseMessage = !bv
 	}

--- a/app/vlogscli/main.go
+++ b/app/vlogscli/main.go
@@ -39,7 +39,7 @@ var (
 	projectID = flag.Int("projectID", 0, "Project ID to query; see https://docs.victoriametrics.com/victorialogs/#multitenancy")
 
 	username    = flag.String("username", "", "Optional basic auth username to use for the -datasource.url")
-	password    = flagutil.NewPassword("password", "Optional basic auth password to use for the -datsource.url")
+	password    = flagutil.NewPassword("password", "Optional basic auth password to use for the -datasource.url")
 	bearerToken = flagutil.NewPassword("bearerToken", "Optional bearer auth token to use for the -datasource.url")
 
 	tlsCAFile     = flag.String("tlsCAFile", "", "Optional path to TLS CA file to use for verifying connections to the -datasource.url. By default, system CA is used")

--- a/app/vlselect/logsql/logsql.go
+++ b/app/vlselect/logsql/logsql.go
@@ -1137,7 +1137,7 @@ func parseCommonArgs(r *http.Request) (*logstorage.Query, []logstorage.TenantID,
 	// Extract tenantID
 	tenantID, err := logstorage.GetTenantIDFromRequest(r)
 	if err != nil {
-		return nil, nil, fmt.Errorf("cannot obtain tenanID: %w", err)
+		return nil, nil, fmt.Errorf("cannot obtain tenantID: %w", err)
 	}
 	tenantIDs := []logstorage.TenantID{tenantID}
 

--- a/app/vlselect/logsql/logsql_test.go
+++ b/app/vlselect/logsql/logsql_test.go
@@ -46,7 +46,7 @@ func TestParseExtraFilters_Failure(t *testing.T) {
 	f(`[1,2]`)
 	f(`{"foo":[1]}`)
 
-	// Invliad LogsQL filter
+	// Invalid LogsQL filter
 	f(`foo:(bar`)
 
 	// excess pipe
@@ -95,7 +95,7 @@ func TestParseExtraStreamFilters_Failure(t *testing.T) {
 	f(`[1,2]`)
 	f(`{"foo":[1]}`)
 
-	// Invliad LogsQL filter
+	// Invalid LogsQL filter
 	f(`foo:(bar`)
 
 	// excess pipe

--- a/app/vmui/Dockerfile-web
+++ b/app/vmui/Dockerfile-web
@@ -3,8 +3,8 @@ COPY build /build
 
 WORKDIR /build
 COPY web/ /build/
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o web-amd64 github.com/VictoriMetrics/vmui/ && \
-    GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o web-windows github.com/VictoriMetrics/vmui/
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o web-amd64 github.com/VictoriaMetrics/vmui/ && \
+    GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o web-windows github.com/VictoriaMetrics/vmui/
 
 FROM alpine:3.22.1
 USER root

--- a/docs/victorialogs/FAQ.md
+++ b/docs/victorialogs/FAQ.md
@@ -45,7 +45,6 @@ VictoriaLogs is optimized specifically for logs. So it provides the following fe
 - Fast full-text search over all the [log fields](https://docs.victoriametrics.com/victorialogs/keyconcepts/#data-model) out of the box.
 - Good integration with traditional command-line tools for log analysis. See [these docs](https://docs.victoriametrics.com/victorialogs/querying/#command-line).
 
-
 ## What is the difference between VictoriaLogs and Grafana Loki?
 
 Both Grafana Loki and VictoriaLogs are designed for log management and processing.
@@ -77,7 +76,6 @@ VictoriaLogs and Grafana Loki have the following differences:
 
 See [this article](https://itnext.io/why-victorialogs-is-a-better-alternative-to-grafana-loki-7e941567c4d5) for more details.
 
-
 ## What is the difference between VictoriaLogs and ClickHouse?
 
 ClickHouse is an extremely fast and efficient analytical database. It can be used for logs storage, analysis and processing.
@@ -107,7 +105,6 @@ VictoriaLogs is designed solely for logs. VictoriaLogs uses [similar design idea
   This may increase the complexity of the system and, subsequently, increase its' maintenance costs.
 
 - VictoriaLogs provides [built-in Web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui) for logs' exploration.
-
 
 ## How does VictoriaLogs work?
 
@@ -322,13 +319,14 @@ _time:1h _stream_id:in(_time:1h | top 3 (_stream_id) | keep _stream_id) | count_
 The query works in the following way:
 
 - It selects top 3 log streams with the biggest number of logs during the last hour with the following subquery:
+
   ```logsql
   _time:1h | top 3 (_stream_id) | keep _stream_id
   ```
+
   This subquery uses [`top`](https://docs.victoriametrics.com/victorialogs/logsql/#top-pipe) and [`keep`](https://docs.victoriametrics.com/victorialogs/logsql/#fields-pipe) pipes.
 
 - Then it selects all the logs across the selected log streams over the last hour with the help of [`_stream_id:...` filter](https://docs.victoriametrics.com/victorialogs/logsql/#_stream_id-filter).
-
 
 ## How to estimate the needed compute resources for the given workload?
 

--- a/docs/victorialogs/LogsQL.md
+++ b/docs/victorialogs/LogsQL.md
@@ -30,6 +30,7 @@ LogsQL provides the following features:
 If you aren't familiar with VictoriaLogs, then start with [key concepts docs](https://docs.victoriametrics.com/victorialogs/keyconcepts/).
 
 Then follow these docs:
+
 - [How to run VictoriaLogs](https://docs.victoriametrics.com/victorialogs/quickstart/).
 - [how to ingest data into VictoriaLogs](https://docs.victoriametrics.com/victorialogs/data-ingestion/).
 - [How to query VictoriaLogs](https://docs.victoriametrics.com/victorialogs/querying/).
@@ -284,7 +285,6 @@ The list of LogsQL filters:
 - [`Less than` filter](#lt_field-filter) - matches logs where the given field value is smaller than the other field value
 - [`Less than or equal` filter](#le_field-filter) - matches logs where the given field value doesn't exceed the other field value
 - [Logical filter](#logical-filter) - allows combining other filters
-
 
 ### Time filter
 
@@ -576,7 +576,6 @@ See also:
 - [Prefix filter](#prefix-filter)
 - [Logical filter](#logical-filter)
 
-
 ### Phrase filter
 
 Is you need to search for log messages with the specific phrase inside them, then just wrap the phrase into quotes according to [these docs](#string-literals).
@@ -638,7 +637,6 @@ See also:
 - [Word filter](#word-filter)
 - [Prefix filter](#prefix-filter)
 - [Logical filter](#logical-filter)
-
 
 ### Prefix filter
 
@@ -715,7 +713,6 @@ See also:
 - [Exact-filter](#exact-filter)
 - [Logical filter](#logical-filter)
 
-
 ### Substring filter
 
 If it is needed to find logs with some substring, then `~"substring"` filter can be used. The substring can be but in quotes according to [these docs](#string-literals).
@@ -743,7 +740,6 @@ See also:
 - [Word filter](#word-filter)
 - [Phrase filter](#phrase-filter)
 - [Regexp filter](#regexp-filter)
-
 
 ### Range comparison filter
 
@@ -782,7 +778,6 @@ See also:
 - [Word filter](#word-filter)
 - [Logical filter](#logical-filter)
 
-
 ### Any value filter
 
 Sometimes it is needed to find log entries containing any non-empty value for the given [log field](https://docs.victoriametrics.com/victorialogs/keyconcepts/#data-model).
@@ -797,7 +792,6 @@ See also:
 - [Empty value filter](#empty-value-filter)
 - [Prefix filter](#prefix-filter)
 - [Logical filter](#logical-filter)
-
 
 ### Exact filter
 
@@ -849,7 +843,6 @@ See also:
 - [Prefix filter](#prefix-filter)
 - [Logical filter](#logical-filter)
 
-
 ### Exact prefix filter
 
 Sometimes it is needed to find log messages starting with some prefix. This can be done with the `="prefix"*` filter.
@@ -900,7 +893,6 @@ See also:
 - [Phrase filter](#phrase-filter)
 - [Logical filter](#logical-filter)
 
-
 ### Multi-exact filter
 
 Sometimes it is needed to locate log messages with a field containing one of the given values. This can be done with multiple [exact filters](#exact-filter)
@@ -932,7 +924,6 @@ See also:
 - [Prefix filter](#prefix-filter)
 - [Logical filter](#logical-filter)
 
-
 ### contains_all filter
 
 If it is needed to find logs, which contain all the given [words](#word) / phrases, then `v1 AND v2 ... AND vN` [logical filter](https://docs.victoriametrics.com/victorialogs/logsql/#logical-filter)
@@ -960,7 +951,6 @@ See also:
 - [`in` filter](#multi-exact-filter)
 - [`contains_any` filter](#contains_any-filter)
 
-
 ### contains_any filter
 
 Sometimes it is needed to find logs, which contain at least one [word](#word) or phrase out of many words / phrases.
@@ -981,14 +971,12 @@ foo OR "bar baz"
 It is possible to pass arbitrary [query](#query-syntax) inside `contains_any(...)` filter in order to match against the results of this query.
 See [these docs](#subquery-filter) for details.
 
-
 See also:
 
 - [word filter](#word-filter)
 - [phrase filter](#phrase-filter)
 - [`in` filter](#multi-exact-filter)
 - [`contains_all` filter](#contains_all-filter)
-
 
 ### Subquery filter
 
@@ -1030,7 +1018,6 @@ See also:
 - [`contains_any` filter](#contains_any-filter)
 - [`join` pipe](#join-pipe)
 - [`union` pipe](#union-pipe)
-
 
 ### Case-insensitive filter
 
@@ -1076,14 +1063,12 @@ Performance tips:
   when using [logical filter](#logical-filter).
 - See [other performance tips](#performance-tips).
 
-
 See also:
 
 - [Word filter](#word-filter)
 - [Phrase filter](#phrase-filter)
 - [Exact-filter](#exact-filter)
 - [Logical filter](#logical-filter)
-
 
 ### Sequence filter
 
@@ -1122,7 +1107,6 @@ See also:
 - [Phrase filter](#phrase-filter)
 - [Exact-filter](#exact-filter)
 - [Logical filter](#logical-filter)
-
 
 ### Regexp filter
 
@@ -1183,7 +1167,6 @@ See also:
 - [Case-insensitive filter](#case-insensitive-filter)
 - [Logical filter](#logical-filter)
 
-
 ### Range filter
 
 If you need to filter log message by some field containing only numeric values, then the `range()` filter can be used.
@@ -1227,7 +1210,6 @@ See also:
 - [String range filter](#string-range-filter)
 - [Length range filter](#length-range-filter)
 - [Logical filter](#logical-filter)
-
 
 ### IPv4 range filter
 
@@ -1279,7 +1261,6 @@ See also:
 - [Length range filter](#length-range-filter)
 - [Logical filter](#logical-filter)
 
-
 ### String range filter
 
 If you need to filter log message by some field with string values in some range, then `string_range()` filter can be used.
@@ -1299,7 +1280,6 @@ See also:
 - [IPv4 range filter](#ipv4-range-filter)
 - [Length range filter](#length-range-filter)
 - [Logical filter](#logical-filter)
-
 
 ### Length range filter
 
@@ -1347,7 +1327,6 @@ See also:
 - [Range filter](#range-filter)
 - [Logical filter](#logical-filter)
 
-
 ### value_type filter
 
 VictoriaLogs automatically detects types for the ingested [log fields](https://docs.victoriametrics.com/victorialogs/keyconcepts/#data-model) and stores log field values
@@ -1364,7 +1343,6 @@ See also:
 
 - [`block_stats` pipe](#block_stats-pipe)
 - [Logical filter](#logical-filter)
-
 
 ### eq_field filter
 
@@ -1385,7 +1363,6 @@ See also:
 - [`le_field` filter](#le_field-filter)
 - [`lt_field` filter](#lt_field-filter)
 
-
 ### le_field filter
 
 Sometimes it is needed to find logs where one [field](https://docs.victoriametrics.com/victorialogs/keyconcepts/#data-model) value doesn't exceed the other field value.
@@ -1405,7 +1382,6 @@ See also:
 - [`lt_field` filter](#lt_field-filter)
 - [`eq_field` filter](#eq_field-filter)
 
-
 ### lt_field filter
 
 Sometimes it is needed to find logs where one [field](https://docs.victoriametrics.com/victorialogs/keyconcepts/#data-model) value is smaller than the other field value.
@@ -1424,7 +1400,6 @@ See also:
 - [range comparison filter](#range-comparison-filter)
 - [`le_field` filter](#le_field-filter)
 - [`eq_field` filter](#eq_field-filter)
-
 
 ### Logical filter
 
@@ -1446,7 +1421,6 @@ Basic LogsQL [filters](#filters) can be combined into more complex filters with 
   For example, `-info` and `!info` are equivalent to `NOT info`.
   The `!` must be used instead of `-` in front of [`=`](https://docs.victoriametrics.com/victorialogs/logsql/#exact-filter)
   and [`~`](https://docs.victoriametrics.com/victorialogs/logsql/#regexp-filter) filters like `!=` and `!~`.
-
 
 The `NOT` operation has the highest priority, `AND` has the middle priority and `OR` has the lowest priority.
 The priority order can be changed with parentheses. For example, `NOT info OR debug` is interpreted as `(NOT info) OR debug`,
@@ -1728,7 +1702,6 @@ See also:
 - [`filter` pipe](#filter-pipe)
 - [`extract` pipe](#extract-pipe)
 
-
 ### extract pipe
 
 `<q> | extract "pattern" from field_name` [pipe](#pipes) extracts text into output fields according to the [`pattern`](#format-for-extract-pipe-pattern) from the given
@@ -1791,7 +1764,7 @@ See also:
 
 #### Format for extract pipe pattern
 
-The `pattern` part from [`extract ` pipe](#extract-pipe) has the following format:
+The `pattern` part from [`extract` pipe](#extract-pipe) has the following format:
 
 ```
 text1<field1>text2<field2>...textN<fieldN>textN+1
@@ -2108,7 +2081,6 @@ See also:
 - [`last` pipe](#last-pipe)
 - [`sort` pipe](#sort-pipe)
 
-
 ### format pipe
 
 `<q> | format "pattern" as result_field` [pipe](#pipes) combines [log fields](https://docs.victoriametrics.com/victorialogs/keyconcepts/#data-model)
@@ -2174,7 +2146,7 @@ String fields can be formatted with the following additional formatting rules:
 Numeric fields can be transformed into the following string representation at `format` pipe:
 
 - [RFC3339 time](https://www.rfc-editor.org/rfc/rfc3339) - by adding `time:` in front of the corresponding field name
-  containing [Unix timestamp](https://en.wikipedia.org/wiki/Unix_time). 
+  containing [Unix timestamp](https://en.wikipedia.org/wiki/Unix_time).
   The numeric timestamp can be in seconds, milliseconds, microseconds, or nanoseconds — the precision is automatically detected based on the value.
   Both integer and floating-point values are supported.
   For example, `format "time=<time:timestamp>"`.
@@ -2210,7 +2182,6 @@ See also:
 - [`replace` pipe](#replace-pipe)
 - [`replace_regexp` pipe](#replace_regexp-pipe)
 - [`extract` pipe](#extract-pipe)
-
 
 #### Conditional format
 
@@ -2459,7 +2430,6 @@ See also:
 - [`extract` pipe](#extract-pipe)
 - [`format` pipe](#format-pipe)
 
-
 ### offset pipe
 
 If some selected logs must be skipped after [`sort`](#sort-pipe), then `| offset N` [pipe](#pipes) can be used, where `N` can contain any [supported integer numeric value](#numeric-values).
@@ -2523,7 +2493,6 @@ See also:
 
 - [`pack_logfmt` pipe](#pack_logfmt-pipe)
 - [`unpack_json` pipe](#unpack_json-pipe)
-
 
 ### pack_logfmt pipe
 
@@ -2882,7 +2851,6 @@ See also:
 - [`top` pipe](#top-pipe)
 - [`join` pipe](#join-pipe)
 
-
 #### Stats by fields
 
 The following LogsQL syntax can be used for calculating independent stats per group of log fields:
@@ -2977,7 +2945,6 @@ See also:
 - [`stats` pipe](#stats-pipe)
 - [`stats` pipe functions](#stats-pipe-functions)
 - [`math` pipe](#math-pipe)
-
 
 #### Stats by field buckets
 

--- a/docs/victorialogs/QuickStart.md
+++ b/docs/victorialogs/QuickStart.md
@@ -53,7 +53,6 @@ See also:
 - [How to ingest logs into VictoriaLogs](https://docs.victoriametrics.com/victorialogs/data-ingestion/)
 - [How to query VictoriaLogs](https://docs.victoriametrics.com/victorialogs/querying/)
 
-
 ### Docker image
 
 You can run VictoriaLogs in a Docker container. It is the easiest way to start using VictoriaLogs.
@@ -111,7 +110,6 @@ See also:
 - [How to ingest logs into VictoriaLogs](https://docs.victoriametrics.com/victorialogs/data-ingestion/)
 - [How to query VictoriaLogs](https://docs.victoriametrics.com/victorialogs/querying/)
 
-
 ## How to configure VictoriaLogs
 
 VictoriaLogs is configured via command-line flags. All the command-line flags have sane defaults,
@@ -153,5 +151,5 @@ Docker-compose demos that integrate VictoriaLogs and various log collectors:
 - [Promtail demo](https://github.com/VictoriaMetrics/VictoriaLogs/tree/master/deployment/docker/victorialogs/promtail)
 
 You can use [VictoriaLogs single](https://docs.victoriametrics.com/helm/victorialogs-single/)
-or [cluster](https://docs.victoriametrics.com/helm/victorialogs-cluster) helm charts as a demo for running Vector 
+or [cluster](https://docs.victoriametrics.com/helm/victorialogs-cluster) helm charts as a demo for running Vector
 in Kubernetes with VictoriaLogs.

--- a/docs/victorialogs/README.md
+++ b/docs/victorialogs/README.md
@@ -31,7 +31,7 @@ VictoriaLogs provides the following features:
 See also [articles about VictoriaLogs](https://docs.victoriametrics.com/victorialogs/articles/).
 
 If you have questions about VictoriaLogs, then read [this FAQ](https://docs.victoriametrics.com/victorialogs/faq/).
-Also feel free asking any questions at [VictoriaMetrics community Slack chat](https://victoriametrics.slack.com/), 
+Also feel free asking any questions at [VictoriaMetrics community Slack chat](https://victoriametrics.slack.com/),
 you can join it via [Slack Inviter](https://slack.victoriametrics.com/).
 
 See [quick start docs](https://docs.victoriametrics.com/victorialogs/quickstart/) for start working with VictoriaLogs.
@@ -41,10 +41,10 @@ then go to [VictoriaLogs demo playground](https://play-vmlogs.victoriametrics.co
 
 ## Tuning
 
-* No need in tuning for VictoriaLogs - it uses reasonable defaults for command-line flags, which are automatically adjusted for the available CPU and RAM resources.
-* No need in tuning for Operating System - VictoriaLogs is optimized for default OS settings.
+- No need in tuning for VictoriaLogs - it uses reasonable defaults for command-line flags, which are automatically adjusted for the available CPU and RAM resources.
+- No need in tuning for Operating System - VictoriaLogs is optimized for default OS settings.
   The only option is increasing the limit on [the number of open files in the OS](https://medium.com/@muhammadtriwibowo/set-permanently-ulimit-n-open-files-in-ubuntu-4d61064429a).
-* The recommended filesystem is `ext4`, the recommended persistent storage is [persistent HDD-based disk on GCP](https://cloud.google.com/compute/docs/disks/#pdspecs),
+- The recommended filesystem is `ext4`, the recommended persistent storage is [persistent HDD-based disk on GCP](https://cloud.google.com/compute/docs/disks/#pdspecs),
   since it is protected from hardware failures via internal replication and it can be [resized on the fly](https://cloud.google.com/compute/docs/disks/add-persistent-disk#resize_pd).
   If you plan to store more than 1TB of data on `ext4` partition or plan extending it to more than 16TB,
   then the following options are recommended to pass to `mkfs.ext4`:
@@ -77,10 +77,10 @@ It is also safe to downgrade to older versions unless [release notes](https://do
 
 The following steps must be performed during the upgrade / downgrade procedure:
 
-* Send `SIGINT` signal to VictoriaLogs process in order to gracefully stop it.
+- Send `SIGINT` signal to VictoriaLogs process in order to gracefully stop it.
   See [how to send signals to processes](https://stackoverflow.com/questions/33239959/send-signal-to-process-from-command-line).
-* Wait until the process stops. This can take a few seconds.
-* Start the upgraded VictoriaLogs.
+- Wait until the process stops. This can take a few seconds.
+- Start the upgraded VictoriaLogs.
 
 ## Retention
 
@@ -220,6 +220,7 @@ VictoriaLogs currently does not have a snapshot feature and a tool like vmbackup
 So backing up VictoriaLogs requires manually executing the `rsync` command.
 
 The files in VictoriaLogs have the following properties:
+
 - All the data files are immutable. Small metadata files can be modified.
 - Old data files are periodically merged into new data files.
 
@@ -333,21 +334,17 @@ via [VictoriaMetrics community channels](https://docs.victoriametrics.com/victor
 
 VictoriaLogs provides handlers for collecting the following [Go profiles](https://blog.golang.org/profiling-go-programs):
 
-* Memory profile. It can be collected with the following command (replace `0.0.0.0` with hostname if needed):
-
+- Memory profile. It can be collected with the following command (replace `0.0.0.0` with hostname if needed):
 
 ```sh
 curl http://0.0.0.0:9428/debug/pprof/heap > mem.pprof
 ```
 
-
-* CPU profile. It can be collected with the following command (replace `0.0.0.0` with hostname if needed):
-
+- CPU profile. It can be collected with the following command (replace `0.0.0.0` with hostname if needed):
 
 ```sh
 curl http://0.0.0.0:9428/debug/pprof/profile > cpu.pprof
 ```
-
 
 The command for collecting CPU profile waits for 30 seconds before returning.
 
@@ -360,371 +357,371 @@ Pass `-help` to VictoriaLogs in order to see the list of supported command-line 
 
 ```
   -blockcache.missesBeforeCaching int
-    	The number of cache misses before putting the block into cache. Higher values may reduce indexdb/dataBlocks cache size at the cost of higher CPU and disk read usage (default 2)
+        The number of cache misses before putting the block into cache. Higher values may reduce indexdb/dataBlocks cache size at the cost of higher CPU and disk read usage (default 2)
   -datadog.ignoreFields array
-    	Comma-separated list of fields to ignore for logs ingested via DataDog protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/datadog-agent/#dropping-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Comma-separated list of fields to ignore for logs ingested via DataDog protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/datadog-agent/#dropping-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -datadog.maxRequestSize size
-    	The maximum size in bytes of a single DataDog request
-    	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
+        The maximum size in bytes of a single DataDog request
+        Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
   -datadog.streamFields array
-    	Comma-separated list of fields to use as log stream fields for logs ingested via DataDog protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/datadog-agent/#stream-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Comma-separated list of fields to use as log stream fields for logs ingested via DataDog protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/datadog-agent/#stream-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -defaultMsgValue string
-    	Default value for _msg field if the ingested log entry doesn't contain it; see https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field (default "missing _msg field; see https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field")
+        Default value for _msg field if the ingested log entry doesn't contain it; see https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field (default "missing _msg field; see https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field")
   -elasticsearch.version string
-    	Elasticsearch version to report to client (default "8.9.0")
+        Elasticsearch version to report to client (default "8.9.0")
   -enableTCP6
-    	Whether to enable IPv6 for listening and dialing. By default, only IPv4 TCP and UDP are used
+        Whether to enable IPv6 for listening and dialing. By default, only IPv4 TCP and UDP are used
   -envflag.enable
-    	Whether to enable reading flags from environment variables in addition to the command line. Command line flag values have priority over values from environment vars. Flags are read only from the command line if this flag isn't set. See https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#environment-variables for more details
+        Whether to enable reading flags from environment variables in addition to the command line. Command line flag values have priority over values from environment vars. Flags are read only from the command line if this flag isn't set. See https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#environment-variables for more details
   -envflag.prefix string
-    	Prefix for environment variables if -envflag.enable is set
+        Prefix for environment variables if -envflag.enable is set
   -filestream.disableFadvise
-    	Whether to disable fadvise() syscall when reading large data files. The fadvise() syscall prevents from eviction of recently accessed data from OS page cache during background merges and backups. In some rare cases it is better to disable the syscall if it uses too much CPU
+        Whether to disable fadvise() syscall when reading large data files. The fadvise() syscall prevents from eviction of recently accessed data from OS page cache during background merges and backups. In some rare cases it is better to disable the syscall if it uses too much CPU
   -flagsAuthKey value
-    	Auth key for /flags endpoint. It must be passed via authKey query arg. It overrides -httpAuth.*
-    	Flag value can be read from the given file when using -flagsAuthKey=file:///abs/path/to/file or -flagsAuthKey=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -flagsAuthKey=http://host/path or -flagsAuthKey=https://host/path
+        Auth key for /flags endpoint. It must be passed via authKey query arg. It overrides -httpAuth.*
+        Flag value can be read from the given file when using -flagsAuthKey=file:///abs/path/to/file or -flagsAuthKey=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -flagsAuthKey=http://host/path or -flagsAuthKey=https://host/path
   -forceFlushAuthKey value
-    	authKey, which must be passed in query string to /internal/force_flush . It overrides -httpAuth.* . See https://docs.victoriametrics.com/victorialogs/#forced-flush
-    	Flag value can be read from the given file when using -forceFlushAuthKey=file:///abs/path/to/file or -forceFlushAuthKey=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -forceFlushAuthKey=http://host/path or -forceFlushAuthKey=https://host/path
+        authKey, which must be passed in query string to /internal/force_flush . It overrides -httpAuth.* . See https://docs.victoriametrics.com/victorialogs/#forced-flush
+        Flag value can be read from the given file when using -forceFlushAuthKey=file:///abs/path/to/file or -forceFlushAuthKey=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -forceFlushAuthKey=http://host/path or -forceFlushAuthKey=https://host/path
   -forceMergeAuthKey value
-    	authKey, which must be passed in query string to /internal/force_merge . It overrides -httpAuth.* . See https://docs.victoriametrics.com/victorialogs/#forced-merge
-    	Flag value can be read from the given file when using -forceMergeAuthKey=file:///abs/path/to/file or -forceMergeAuthKey=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -forceMergeAuthKey=http://host/path or -forceMergeAuthKey=https://host/path
+        authKey, which must be passed in query string to /internal/force_merge . It overrides -httpAuth.* . See https://docs.victoriametrics.com/victorialogs/#forced-merge
+        Flag value can be read from the given file when using -forceMergeAuthKey=file:///abs/path/to/file or -forceMergeAuthKey=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -forceMergeAuthKey=http://host/path or -forceMergeAuthKey=https://host/path
   -fs.disableMmap
-    	Whether to use pread() instead of mmap() for reading data files. By default, mmap() is used for 64-bit arches and pread() is used for 32-bit arches, since they cannot read data files bigger than 2^32 bytes in memory. mmap() is usually faster for reading small data chunks than pread()
+        Whether to use pread() instead of mmap() for reading data files. By default, mmap() is used for 64-bit arches and pread() is used for 32-bit arches, since they cannot read data files bigger than 2^32 bytes in memory. mmap() is usually faster for reading small data chunks than pread()
   -futureRetention value
-    	Log entries with timestamps bigger than now+futureRetention are rejected during data ingestion; see https://docs.victoriametrics.com/victorialogs/#retention
-    	The following optional suffixes are supported: s (second), h (hour), d (day), w (week), y (year). If suffix isn't set, then the duration is counted in months (default 2d)
+        Log entries with timestamps bigger than now+futureRetention are rejected during data ingestion; see https://docs.victoriametrics.com/victorialogs/#retention
+        The following optional suffixes are supported: s (second), h (hour), d (day), w (week), y (year). If suffix isn't set, then the duration is counted in months (default 2d)
   -http.connTimeout duration
-    	Incoming connections to -httpListenAddr are closed after the configured timeout. This may help evenly spreading load among a cluster of services behind TCP-level load balancer. Zero value disables closing of incoming connections (default 2m0s)
+        Incoming connections to -httpListenAddr are closed after the configured timeout. This may help evenly spreading load among a cluster of services behind TCP-level load balancer. Zero value disables closing of incoming connections (default 2m0s)
   -http.disableCORS
-    	Disable CORS for all origins (*)
+        Disable CORS for all origins (*)
   -http.disableKeepAlive
-    	Whether to disable HTTP keep-alive for incoming connections at -httpListenAddr
+        Whether to disable HTTP keep-alive for incoming connections at -httpListenAddr
   -http.disableResponseCompression
-    	Disable compression of HTTP responses to save CPU resources. By default, compression is enabled to save network bandwidth
+        Disable compression of HTTP responses to save CPU resources. By default, compression is enabled to save network bandwidth
   -http.header.csp string
-    	Value for 'Content-Security-Policy' header, recommended: "default-src 'self'"
+        Value for 'Content-Security-Policy' header, recommended: "default-src 'self'"
   -http.header.frameOptions string
-    	Value for 'X-Frame-Options' header
+        Value for 'X-Frame-Options' header
   -http.header.hsts string
-    	Value for 'Strict-Transport-Security' header, recommended: 'max-age=31536000; includeSubDomains'
+        Value for 'Strict-Transport-Security' header, recommended: 'max-age=31536000; includeSubDomains'
   -http.idleConnTimeout duration
-    	Timeout for incoming idle http connections (default 1m0s)
+        Timeout for incoming idle http connections (default 1m0s)
   -http.maxGracefulShutdownDuration duration
-    	The maximum duration for a graceful shutdown of the HTTP server. A highly loaded server may require increased value for a graceful shutdown (default 7s)
+        The maximum duration for a graceful shutdown of the HTTP server. A highly loaded server may require increased value for a graceful shutdown (default 7s)
   -http.pathPrefix string
-    	An optional prefix to add to all the paths handled by http server. For example, if '-http.pathPrefix=/foo/bar' is set, then all the http requests will be handled on '/foo/bar/*' paths. This may be useful for proxied requests. See https://www.robustperception.io/using-external-urls-and-proxies-with-prometheus
+        An optional prefix to add to all the paths handled by http server. For example, if '-http.pathPrefix=/foo/bar' is set, then all the http requests will be handled on '/foo/bar/*' paths. This may be useful for proxied requests. See https://www.robustperception.io/using-external-urls-and-proxies-with-prometheus
   -http.shutdownDelay duration
-    	Optional delay before http server shutdown. During this delay, the server returns non-OK responses from /health page, so load balancers can route new requests to other servers
+        Optional delay before http server shutdown. During this delay, the server returns non-OK responses from /health page, so load balancers can route new requests to other servers
   -httpAuth.password value
-    	Password for HTTP server's Basic Auth. The authentication is disabled if -httpAuth.username is empty
-    	Flag value can be read from the given file when using -httpAuth.password=file:///abs/path/to/file or -httpAuth.password=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -httpAuth.password=http://host/path or -httpAuth.password=https://host/path
+        Password for HTTP server's Basic Auth. The authentication is disabled if -httpAuth.username is empty
+        Flag value can be read from the given file when using -httpAuth.password=file:///abs/path/to/file or -httpAuth.password=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -httpAuth.password=http://host/path or -httpAuth.password=https://host/path
   -httpAuth.username string
-    	Username for HTTP server's Basic Auth. The authentication is disabled if empty. See also -httpAuth.password
+        Username for HTTP server's Basic Auth. The authentication is disabled if empty. See also -httpAuth.password
   -httpListenAddr array
-    	TCP address to listen for incoming http requests. See also -httpListenAddr.useProxyProtocol
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        TCP address to listen for incoming http requests. See also -httpListenAddr.useProxyProtocol
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -httpListenAddr.useProxyProtocol array
-    	Whether to use proxy protocol for connections accepted at the given -httpListenAddr . See https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt . With enabled proxy protocol http server cannot serve regular /metrics endpoint. Use -pushmetrics.url for metrics pushing
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to false.
+        Whether to use proxy protocol for connections accepted at the given -httpListenAddr . See https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt . With enabled proxy protocol http server cannot serve regular /metrics endpoint. Use -pushmetrics.url for metrics pushing
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to false.
   -inmemoryDataFlushInterval duration
-    	The interval for guaranteed saving of in-memory data to disk. The saved data survives unclean shutdowns such as OOM crash, hardware reset, SIGKILL, etc. Bigger intervals may help increase the lifetime of flash storage with limited write cycles (e.g. Raspberry PI). Smaller intervals increase disk IO load. Minimum supported value is 1s (default 5s)
+        The interval for guaranteed saving of in-memory data to disk. The saved data survives unclean shutdowns such as OOM crash, hardware reset, SIGKILL, etc. Bigger intervals may help increase the lifetime of flash storage with limited write cycles (e.g. Raspberry PI). Smaller intervals increase disk IO load. Minimum supported value is 1s (default 5s)
   -insert.concurrency int
-    	The average number of concurrent data ingestion requests, which can be sent to every -storageNode (default 2)
+        The average number of concurrent data ingestion requests, which can be sent to every -storageNode (default 2)
   -insert.disable
-    	Whether to disable /insert/* HTTP endpoints
+        Whether to disable /insert/* HTTP endpoints
   -insert.disableCompression
-    	Whether to disable compression when sending the ingested data to -storageNode nodes. Disabled compression reduces CPU usage at the cost of higher network usage
+        Whether to disable compression when sending the ingested data to -storageNode nodes. Disabled compression reduces CPU usage at the cost of higher network usage
   -insert.maxFieldsPerLine int
-    	The maximum number of log fields per line, which can be read by /insert/* handlers; see https://docs.victoriametrics.com/victorialogs/faq/#how-many-fields-a-single-log-entry-may-contain (default 1000)
+        The maximum number of log fields per line, which can be read by /insert/* handlers; see https://docs.victoriametrics.com/victorialogs/faq/#how-many-fields-a-single-log-entry-may-contain (default 1000)
   -insert.maxLineSizeBytes size
-    	The maximum size of a single line, which can be read by /insert/* handlers; see https://docs.victoriametrics.com/victorialogs/faq/#what-length-a-log-record-is-expected-to-have
-    	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 262144)
+        The maximum size of a single line, which can be read by /insert/* handlers; see https://docs.victoriametrics.com/victorialogs/faq/#what-length-a-log-record-is-expected-to-have
+        Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 262144)
   -insert.maxQueueDuration duration
-    	The maximum duration to wait in the queue when -maxConcurrentInserts concurrent insert requests are executed (default 1m0s)
+        The maximum duration to wait in the queue when -maxConcurrentInserts concurrent insert requests are executed (default 1m0s)
   -internStringCacheExpireDuration duration
-    	The expiry duration for caches for interned strings. See https://en.wikipedia.org/wiki/String_interning . See also -internStringMaxLen and -internStringDisableCache (default 6m0s)
+        The expiry duration for caches for interned strings. See https://en.wikipedia.org/wiki/String_interning . See also -internStringMaxLen and -internStringDisableCache (default 6m0s)
   -internStringDisableCache
-    	Whether to disable caches for interned strings. This may reduce memory usage at the cost of higher CPU usage. See https://en.wikipedia.org/wiki/String_interning . See also -internStringCacheExpireDuration and -internStringMaxLen
+        Whether to disable caches for interned strings. This may reduce memory usage at the cost of higher CPU usage. See https://en.wikipedia.org/wiki/String_interning . See also -internStringCacheExpireDuration and -internStringMaxLen
   -internStringMaxLen int
-    	The maximum length for strings to intern. A lower limit may save memory at the cost of higher CPU usage. See https://en.wikipedia.org/wiki/String_interning . See also -internStringDisableCache and -internStringCacheExpireDuration (default 500)
+        The maximum length for strings to intern. A lower limit may save memory at the cost of higher CPU usage. See https://en.wikipedia.org/wiki/String_interning . See also -internStringDisableCache and -internStringCacheExpireDuration (default 500)
   -internalinsert.disable
-    	Whether to disable /internal/insert HTTP endpoint
+        Whether to disable /internal/insert HTTP endpoint
   -internalinsert.maxRequestSize size
-    	The maximum size in bytes of a single request, which can be accepted at /internal/insert HTTP endpoint
-    	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
+        The maximum size in bytes of a single request, which can be accepted at /internal/insert HTTP endpoint
+        Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
   -internalselect.disable
-    	Whether to disable /internal/select/* HTTP endpoints
+        Whether to disable /internal/select/* HTTP endpoints
   -journald.ignoreFields array
-    	Comma-separated list of fields to ignore for logs ingested over journald protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/journald/#dropping-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Comma-separated list of fields to ignore for logs ingested over journald protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/journald/#dropping-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -journald.includeEntryMetadata
-    	Include journal entry fields, which with double underscores.
+        Include journal entry fields, which with double underscores.
   -journald.streamFields array
-    	Comma-separated list of fields to use as log stream fields for logs ingested over journald protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/journald/#stream-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Comma-separated list of fields to use as log stream fields for logs ingested over journald protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/journald/#stream-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -journald.tenantID string
-    	TenantID for logs ingested via the Journald endpoint. See https://docs.victoriametrics.com/victorialogs/data-ingestion/journald/#multitenancy (default "0:0")
+        TenantID for logs ingested via the Journald endpoint. See https://docs.victoriametrics.com/victorialogs/data-ingestion/journald/#multitenancy (default "0:0")
   -journald.timeField string
-    	Field to use as a log timestamp for logs ingested via journald protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/journald/#time-field (default "__REALTIME_TIMESTAMP")
+        Field to use as a log timestamp for logs ingested via journald protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/journald/#time-field (default "__REALTIME_TIMESTAMP")
   -logIngestedRows
-    	Whether to log all the ingested log entries; this can be useful for debugging of data ingestion; see https://docs.victoriametrics.com/victorialogs/data-ingestion/ ; see also -logNewStreams
+        Whether to log all the ingested log entries; this can be useful for debugging of data ingestion; see https://docs.victoriametrics.com/victorialogs/data-ingestion/ ; see also -logNewStreams
   -logNewStreams
-    	Whether to log creation of new streams; this can be useful for debugging of high cardinality issues with log streams; see https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields ; see also -logIngestedRows
+        Whether to log creation of new streams; this can be useful for debugging of high cardinality issues with log streams; see https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields ; see also -logIngestedRows
   -loggerDisableTimestamps
-    	Whether to disable writing timestamps in logs
+        Whether to disable writing timestamps in logs
   -loggerErrorsPerSecondLimit int
-    	Per-second limit on the number of ERROR messages. If more than the given number of errors are emitted per second, the remaining errors are suppressed. Zero values disable the rate limit
+        Per-second limit on the number of ERROR messages. If more than the given number of errors are emitted per second, the remaining errors are suppressed. Zero values disable the rate limit
   -loggerFormat string
-    	Format for logs. Possible values: default, json (default "default")
+        Format for logs. Possible values: default, json (default "default")
   -loggerJSONFields string
-    	Allows renaming fields in JSON formatted logs. Example: "ts:timestamp,msg:message" renames "ts" to "timestamp" and "msg" to "message". Supported fields: ts, level, caller, msg
+        Allows renaming fields in JSON formatted logs. Example: "ts:timestamp,msg:message" renames "ts" to "timestamp" and "msg" to "message". Supported fields: ts, level, caller, msg
   -loggerLevel string
-    	Minimum level of errors to log. Possible values: INFO, WARN, ERROR, FATAL, PANIC (default "INFO")
+        Minimum level of errors to log. Possible values: INFO, WARN, ERROR, FATAL, PANIC (default "INFO")
   -loggerMaxArgLen int
-    	The maximum length of a single logged argument. Longer arguments are replaced with 'arg_start..arg_end', where 'arg_start' and 'arg_end' is prefix and suffix of the arg with the length not exceeding -loggerMaxArgLen / 2 (default 5000)
+        The maximum length of a single logged argument. Longer arguments are replaced with 'arg_start..arg_end', where 'arg_start' and 'arg_end' is prefix and suffix of the arg with the length not exceeding -loggerMaxArgLen / 2 (default 5000)
   -loggerOutput string
-    	Output for the logs. Supported values: stderr, stdout (default "stderr")
+        Output for the logs. Supported values: stderr, stdout (default "stderr")
   -loggerTimezone string
-    	Timezone to use for timestamps in logs. Timezone must be a valid IANA Time Zone. For example: America/New_York, Europe/Berlin, Etc/GMT+3 or Local (default "UTC")
+        Timezone to use for timestamps in logs. Timezone must be a valid IANA Time Zone. For example: America/New_York, Europe/Berlin, Etc/GMT+3 or Local (default "UTC")
   -loggerWarnsPerSecondLimit int
-    	Per-second limit on the number of WARN messages. If more than the given number of warns are emitted per second, then the remaining warns are suppressed. Zero values disable the rate limit
+        Per-second limit on the number of WARN messages. If more than the given number of warns are emitted per second, then the remaining warns are suppressed. Zero values disable the rate limit
   -loki.disableMessageParsing
-    	Whether to disable automatic parsing of JSON-encoded log fields inside Loki log message into distinct log fields
+        Whether to disable automatic parsing of JSON-encoded log fields inside Loki log message into distinct log fields
   -loki.maxRequestSize size
-    	The maximum size in bytes of a single Loki request
-    	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
+        The maximum size in bytes of a single Loki request
+        Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
   -maxConcurrentInserts int
-    	The maximum number of concurrent insert requests. Set higher value when clients send data over slow networks. Default value depends on the number of available CPU cores. It should work fine in most cases since it minimizes resource usage. See also -insert.maxQueueDuration (default 28)
+        The maximum number of concurrent insert requests. Set higher value when clients send data over slow networks. Default value depends on the number of available CPU cores. It should work fine in most cases since it minimizes resource usage. See also -insert.maxQueueDuration (default 28)
   -memory.allowedBytes size
-    	Allowed size of system memory VictoriaMetrics caches may occupy. This option overrides -memory.allowedPercent if set to a non-zero value. Too low a value may increase the cache miss rate usually resulting in higher CPU and disk IO usage. Too high a value may evict too much data from the OS page cache resulting in higher disk IO usage
-    	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 0)
+        Allowed size of system memory VictoriaMetrics caches may occupy. This option overrides -memory.allowedPercent if set to a non-zero value. Too low a value may increase the cache miss rate usually resulting in higher CPU and disk IO usage. Too high a value may evict too much data from the OS page cache resulting in higher disk IO usage
+        Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 0)
   -memory.allowedPercent float
-    	Allowed percent of system memory VictoriaMetrics caches may occupy. See also -memory.allowedBytes. Too low a value may increase cache miss rate usually resulting in higher CPU and disk IO usage. Too high a value may evict too much data from the OS page cache which will result in higher disk IO usage (default 60)
+        Allowed percent of system memory VictoriaMetrics caches may occupy. See also -memory.allowedBytes. Too low a value may increase cache miss rate usually resulting in higher CPU and disk IO usage. Too high a value may evict too much data from the OS page cache which will result in higher disk IO usage (default 60)
   -metrics.exposeMetadata
-    	Whether to expose TYPE and HELP metadata at the /metrics page, which is exposed at -httpListenAddr . The metadata may be needed when the /metrics page is consumed by systems, which require this information. For example, Managed Prometheus in Google Cloud - https://cloud.google.com/stackdriver/docs/managed-prometheus/troubleshooting#missing-metric-type
+        Whether to expose TYPE and HELP metadata at the /metrics page, which is exposed at -httpListenAddr . The metadata may be needed when the /metrics page is consumed by systems, which require this information. For example, Managed Prometheus in Google Cloud - https://cloud.google.com/stackdriver/docs/managed-prometheus/troubleshooting#missing-metric-type
   -metricsAuthKey value
-    	Auth key for /metrics endpoint. It must be passed via authKey query arg. It overrides -httpAuth.*
-    	Flag value can be read from the given file when using -metricsAuthKey=file:///abs/path/to/file or -metricsAuthKey=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -metricsAuthKey=http://host/path or -metricsAuthKey=https://host/path
+        Auth key for /metrics endpoint. It must be passed via authKey query arg. It overrides -httpAuth.*
+        Flag value can be read from the given file when using -metricsAuthKey=file:///abs/path/to/file or -metricsAuthKey=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -metricsAuthKey=http://host/path or -metricsAuthKey=https://host/path
   -mtls array
-    	Whether to require valid client certificate for https requests to the corresponding -httpListenAddr . This flag works only if -tls flag is set. See also -mtlsCAFile . This flag is available only in Enterprise binaries. See https://docs.victoriametrics.com/victoriametrics/enterprise/
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to false.
+        Whether to require valid client certificate for https requests to the corresponding -httpListenAddr . This flag works only if -tls flag is set. See also -mtlsCAFile . This flag is available only in Enterprise binaries. See https://docs.victoriametrics.com/victoriametrics/enterprise/
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to false.
   -mtlsCAFile array
-    	Optional path to TLS Root CA for verifying client certificates at the corresponding -httpListenAddr when -mtls is enabled. By default the host system TLS Root CA is used for client certificate verification. This flag is available only in Enterprise binaries. See https://docs.victoriametrics.com/victoriametrics/enterprise/
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional path to TLS Root CA for verifying client certificates at the corresponding -httpListenAddr when -mtls is enabled. By default the host system TLS Root CA is used for client certificate verification. This flag is available only in Enterprise binaries. See https://docs.victoriametrics.com/victoriametrics/enterprise/
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -opentelemetry.maxRequestSize size
-    	The maximum size in bytes of a single OpenTelemetry request
-    	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
+        The maximum size in bytes of a single OpenTelemetry request
+        Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
   -pprofAuthKey value
-    	Auth key for /debug/pprof/* endpoints. It must be passed via authKey query arg. It overrides -httpAuth.*
-    	Flag value can be read from the given file when using -pprofAuthKey=file:///abs/path/to/file or -pprofAuthKey=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -pprofAuthKey=http://host/path or -pprofAuthKey=https://host/path
+        Auth key for /debug/pprof/* endpoints. It must be passed via authKey query arg. It overrides -httpAuth.*
+        Flag value can be read from the given file when using -pprofAuthKey=file:///abs/path/to/file or -pprofAuthKey=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -pprofAuthKey=http://host/path or -pprofAuthKey=https://host/path
   -pushmetrics.disableCompression
-    	Whether to disable request body compression when pushing metrics to every -pushmetrics.url
+        Whether to disable request body compression when pushing metrics to every -pushmetrics.url
   -pushmetrics.extraLabel array
-    	Optional labels to add to metrics pushed to every -pushmetrics.url . For example, -pushmetrics.extraLabel='instance="foo"' adds instance="foo" label to all the metrics pushed to every -pushmetrics.url
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional labels to add to metrics pushed to every -pushmetrics.url . For example, -pushmetrics.extraLabel='instance="foo"' adds instance="foo" label to all the metrics pushed to every -pushmetrics.url
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -pushmetrics.header array
-    	Optional HTTP request header to send to every -pushmetrics.url . For example, -pushmetrics.header='Authorization: Basic foobar' adds 'Authorization: Basic foobar' header to every request to every -pushmetrics.url
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional HTTP request header to send to every -pushmetrics.url . For example, -pushmetrics.header='Authorization: Basic foobar' adds 'Authorization: Basic foobar' header to every request to every -pushmetrics.url
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -pushmetrics.interval duration
-    	Interval for pushing metrics to every -pushmetrics.url (default 10s)
+        Interval for pushing metrics to every -pushmetrics.url (default 10s)
   -pushmetrics.url array
-    	Optional URL to push metrics exposed at /metrics page. See https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#push-metrics . By default, metrics exposed at /metrics page aren't pushed to any remote storage
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional URL to push metrics exposed at /metrics page. See https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#push-metrics . By default, metrics exposed at /metrics page aren't pushed to any remote storage
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -retention.maxDiskSpaceUsageBytes size
-    	The maximum disk space usage at -storageDataPath before older per-day partitions are automatically dropped; see https://docs.victoriametrics.com/victorialogs/#retention-by-disk-space-usage ; see also -retentionPeriod
-    	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 0)
+        The maximum disk space usage at -storageDataPath before older per-day partitions are automatically dropped; see https://docs.victoriametrics.com/victorialogs/#retention-by-disk-space-usage ; see also -retentionPeriod
+        Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 0)
   -retentionPeriod value
-    	Log entries with timestamps older than now-retentionPeriod are automatically deleted; log entries with timestamps outside the retention are also rejected during data ingestion; the minimum supported retention is 1d (one day); see https://docs.victoriametrics.com/victorialogs/#retention ; see also -retention.maxDiskSpaceUsageBytes
-    	The following optional suffixes are supported: s (second), h (hour), d (day), w (week), y (year). If suffix isn't set, then the duration is counted in months (default 7d)
+        Log entries with timestamps older than now-retentionPeriod are automatically deleted; log entries with timestamps outside the retention are also rejected during data ingestion; the minimum supported retention is 1d (one day); see https://docs.victoriametrics.com/victorialogs/#retention ; see also -retention.maxDiskSpaceUsageBytes
+        The following optional suffixes are supported: s (second), h (hour), d (day), w (week), y (year). If suffix isn't set, then the duration is counted in months (default 7d)
   -search.maxConcurrentRequests int
-    	The maximum number of concurrent search requests. It shouldn't be high, since a single request can saturate all the CPU cores, while many concurrently executed requests may require high amounts of memory. See also -search.maxQueueDuration (default 14)
+        The maximum number of concurrent search requests. It shouldn't be high, since a single request can saturate all the CPU cores, while many concurrently executed requests may require high amounts of memory. See also -search.maxQueueDuration (default 14)
   -search.maxQueryDuration duration
-    	The maximum duration for query execution. It can be overridden to a smaller value on a per-query basis via 'timeout' query arg (default 30s)
+        The maximum duration for query execution. It can be overridden to a smaller value on a per-query basis via 'timeout' query arg (default 30s)
   -search.maxQueueDuration duration
-    	The maximum time the search request waits for execution when -search.maxConcurrentRequests limit is reached; see also -search.maxQueryDuration (default 10s)
+        The maximum time the search request waits for execution when -search.maxConcurrentRequests limit is reached; see also -search.maxQueryDuration (default 10s)
   -select.disable
-    	Whether to disable /select/* HTTP endpoints
+        Whether to disable /select/* HTTP endpoints
   -select.disableCompression
-    	Whether to disable compression for select query responses received from -storageNode nodes. Disabled compression reduces CPU usage at the cost of higher network usage
+        Whether to disable compression for select query responses received from -storageNode nodes. Disabled compression reduces CPU usage at the cost of higher network usage
   -storage.minFreeDiskSpaceBytes size
-    	The minimum free disk space at -storageDataPath after which the storage stops accepting new data
-    	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 10000000)
+        The minimum free disk space at -storageDataPath after which the storage stops accepting new data
+        Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 10000000)
   -storageDataPath string
-    	Path to directory where to store VictoriaLogs data; see https://docs.victoriametrics.com/victorialogs/#storage (default "victoria-logs-data")
+        Path to directory where to store VictoriaLogs data; see https://docs.victoriametrics.com/victorialogs/#storage (default "victoria-logs-data")
   -storageNode array
-    	Comma-separated list of TCP addresses for storage nodes to route the ingested logs to and to send select queries to. If the list is empty, then the ingested logs are stored and queried locally from -storageDataPath
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Comma-separated list of TCP addresses for storage nodes to route the ingested logs to and to send select queries to. If the list is empty, then the ingested logs are stored and queried locally from -storageDataPath
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -storageNode.bearerToken array
-    	Optional bearer auth token to use for the corresponding -storageNode
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional bearer auth token to use for the corresponding -storageNode
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -storageNode.bearerTokenFile array
-    	Optional path to bearer token file to use for the corresponding -storageNode. The token is re-read from the file every second
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional path to bearer token file to use for the corresponding -storageNode. The token is re-read from the file every second
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -storageNode.password array
-    	Optional basic auth password to use for the corresponding -storageNode
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional basic auth password to use for the corresponding -storageNode
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -storageNode.passwordFile array
-    	Optional path to basic auth password to use for the corresponding -storageNode. The file is re-read every second
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional path to basic auth password to use for the corresponding -storageNode. The file is re-read every second
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -storageNode.tls array
-    	Whether to use TLS (HTTPS) protocol for communicating with the corresponding -storageNode. By default communication is performed via HTTP
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to false.
+        Whether to use TLS (HTTPS) protocol for communicating with the corresponding -storageNode. By default communication is performed via HTTP
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to false.
   -storageNode.tlsCAFile array
-    	Optional path to TLS CA file to use for verifying connections to the corresponding -storageNode. By default, system CA is used
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional path to TLS CA file to use for verifying connections to the corresponding -storageNode. By default, system CA is used
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -storageNode.tlsCertFile array
-    	Optional path to client-side TLS certificate file to use when connecting to the corresponding -storageNode
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional path to client-side TLS certificate file to use when connecting to the corresponding -storageNode
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -storageNode.tlsInsecureSkipVerify array
-    	Whether to skip tls verification when connecting to the corresponding -storageNode
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to false.
+        Whether to skip tls verification when connecting to the corresponding -storageNode
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to false.
   -storageNode.tlsKeyFile array
-    	Optional path to client-side TLS certificate key to use when connecting to the corresponding -storageNode
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional path to client-side TLS certificate key to use when connecting to the corresponding -storageNode
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -storageNode.tlsServerName array
-    	Optional TLS server name to use for connections to the corresponding -storageNode. By default, the server name from -storageNode is used
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional TLS server name to use for connections to the corresponding -storageNode. By default, the server name from -storageNode is used
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -storageNode.username array
-    	Optional basic auth username to use for the corresponding -storageNode
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional basic auth username to use for the corresponding -storageNode
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.compressMethod.tcp array
-    	Compression method for syslog messages received at the corresponding -syslog.listenAddr.tcp. Supported values: none, gzip, deflate. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#compression
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Compression method for syslog messages received at the corresponding -syslog.listenAddr.tcp. Supported values: none, gzip, deflate. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#compression
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.compressMethod.udp array
-    	Compression method for syslog messages received at the corresponding -syslog.listenAddr.udp. Supported values: none, gzip, deflate. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#compression
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Compression method for syslog messages received at the corresponding -syslog.listenAddr.udp. Supported values: none, gzip, deflate. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#compression
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.decolorizeFields.tcp array
-    	Fields to remove ANSI color codes across logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#decolorizing-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Fields to remove ANSI color codes across logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#decolorizing-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.decolorizeFields.udp array
-    	Fields to remove ANSI color codes across logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#decolorizing-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Fields to remove ANSI color codes across logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#decolorizing-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.extraFields.tcp array
-    	Fields to add to logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#adding-extra-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Fields to add to logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#adding-extra-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.extraFields.udp array
-    	Fields to add to logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#adding-extra-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Fields to add to logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#adding-extra-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.ignoreFields.tcp array
-    	Fields to ignore at logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#dropping-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Fields to ignore at logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#dropping-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.ignoreFields.udp array
-    	Fields to ignore at logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#dropping-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Fields to ignore at logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#dropping-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.listenAddr.tcp array
-    	Comma-separated list of TCP addresses to listen to for Syslog messages. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Comma-separated list of TCP addresses to listen to for Syslog messages. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.listenAddr.udp array
-    	Comma-separated list of UDP address to listen to for Syslog messages. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Comma-separated list of UDP address to listen to for Syslog messages. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.streamFields.tcp array
-    	Fields to use as log stream labels for logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#stream-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Fields to use as log stream labels for logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#stream-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.streamFields.udp array
-    	Fields to use as log stream labels for logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#stream-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Fields to use as log stream labels for logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#stream-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.tenantID.tcp array
-    	TenantID for logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#multitenancy
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        TenantID for logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#multitenancy
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.tenantID.udp array
-    	TenantID for logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#multitenancy
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        TenantID for logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#multitenancy
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.timezone string
-    	Timezone to use when parsing timestamps in RFC3164 syslog messages. Timezone must be a valid IANA Time Zone. For example: America/New_York, Europe/Berlin, Etc/GMT+3 . See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/ (default "Local")
+        Timezone to use when parsing timestamps in RFC3164 syslog messages. Timezone must be a valid IANA Time Zone. For example: America/New_York, Europe/Berlin, Etc/GMT+3 . See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/ (default "Local")
   -syslog.tls array
-    	Whether to enable TLS for receiving syslog messages at the corresponding -syslog.listenAddr.tcp. The corresponding -syslog.tlsCertFile and -syslog.tlsKeyFile must be set if -syslog.tls is set. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to false.
+        Whether to enable TLS for receiving syslog messages at the corresponding -syslog.listenAddr.tcp. The corresponding -syslog.tlsCertFile and -syslog.tlsKeyFile must be set if -syslog.tls is set. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to false.
   -syslog.tlsCertFile array
-    	Path to file with TLS certificate for the corresponding -syslog.listenAddr.tcp if the corresponding -syslog.tls is set. Prefer ECDSA certs instead of RSA certs as RSA certs are slower. The provided certificate file is automatically re-read every second, so it can be dynamically updated. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Path to file with TLS certificate for the corresponding -syslog.listenAddr.tcp if the corresponding -syslog.tls is set. Prefer ECDSA certs instead of RSA certs as RSA certs are slower. The provided certificate file is automatically re-read every second, so it can be dynamically updated. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.tlsCipherSuites array
-    	Optional list of TLS cipher suites for -syslog.listenAddr.tcp if -syslog.tls is set. See the list of supported cipher suites at https://pkg.go.dev/crypto/tls#pkg-constants . See also https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional list of TLS cipher suites for -syslog.listenAddr.tcp if -syslog.tls is set. See the list of supported cipher suites at https://pkg.go.dev/crypto/tls#pkg-constants . See also https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.tlsKeyFile array
-    	Path to file with TLS key for the corresponding -syslog.listenAddr.tcp if the corresponding -syslog.tls is set. The provided key file is automatically re-read every second, so it can be dynamically updated. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Path to file with TLS key for the corresponding -syslog.listenAddr.tcp if the corresponding -syslog.tls is set. The provided key file is automatically re-read every second, so it can be dynamically updated. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.tlsMinVersion string
-    	The minimum TLS version to use for -syslog.listenAddr.tcp if -syslog.tls is set. Supported values: TLS10, TLS11, TLS12, TLS13. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security (default "TLS13")
+        The minimum TLS version to use for -syslog.listenAddr.tcp if -syslog.tls is set. Supported values: TLS10, TLS11, TLS12, TLS13. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security (default "TLS13")
   -syslog.useLocalTimestamp.tcp array
-    	Whether to use local timestamp instead of the original timestamp for the ingested syslog messages at the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#log-timestamps
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to false.
+        Whether to use local timestamp instead of the original timestamp for the ingested syslog messages at the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#log-timestamps
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to false.
   -syslog.useLocalTimestamp.udp array
-    	Whether to use local timestamp instead of the original timestamp for the ingested syslog messages at the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#log-timestamps
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to false.
+        Whether to use local timestamp instead of the original timestamp for the ingested syslog messages at the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#log-timestamps
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to false.
   -tls array
-    	Whether to enable TLS for incoming HTTP requests at the given -httpListenAddr (aka https). -tlsCertFile and -tlsKeyFile must be set if -tls is set. See also -mtls
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to false.
+        Whether to enable TLS for incoming HTTP requests at the given -httpListenAddr (aka https). -tlsCertFile and -tlsKeyFile must be set if -tls is set. See also -mtls
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to false.
   -tlsAutocertCacheDir string
-    	Directory to store TLS certificates issued via Let's Encrypt. Certificates are lost on restarts if this flag isn't set. This flag is available only in Enterprise binaries. See https://docs.victoriametrics.com/victoriametrics/enterprise/
+        Directory to store TLS certificates issued via Let's Encrypt. Certificates are lost on restarts if this flag isn't set. This flag is available only in Enterprise binaries. See https://docs.victoriametrics.com/victoriametrics/enterprise/
   -tlsAutocertEmail string
-    	Contact email for the issued Let's Encrypt TLS certificates. See also -tlsAutocertHosts and -tlsAutocertCacheDir .This flag is available only in Enterprise binaries. See https://docs.victoriametrics.com/victoriametrics/enterprise/
+        Contact email for the issued Let's Encrypt TLS certificates. See also -tlsAutocertHosts and -tlsAutocertCacheDir .This flag is available only in Enterprise binaries. See https://docs.victoriametrics.com/victoriametrics/enterprise/
   -tlsAutocertHosts array
-    	Optional hostnames for automatic issuing of Let's Encrypt TLS certificates. These hostnames must be reachable at -httpListenAddr . The -httpListenAddr must listen tcp port 443 . The -tlsAutocertHosts overrides -tlsCertFile and -tlsKeyFile . See also -tlsAutocertEmail and -tlsAutocertCacheDir . This flag is available only in Enterprise binaries. See https://docs.victoriametrics.com/victoriametrics/enterprise/
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional hostnames for automatic issuing of Let's Encrypt TLS certificates. These hostnames must be reachable at -httpListenAddr . The -httpListenAddr must listen tcp port 443 . The -tlsAutocertHosts overrides -tlsCertFile and -tlsKeyFile . See also -tlsAutocertEmail and -tlsAutocertCacheDir . This flag is available only in Enterprise binaries. See https://docs.victoriametrics.com/victoriametrics/enterprise/
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -tlsCertFile array
-    	Path to file with TLS certificate for the corresponding -httpListenAddr if -tls is set. Prefer ECDSA certs instead of RSA certs as RSA certs are slower. The provided certificate file is automatically re-read every second, so it can be dynamically updated. See also -tlsAutocertHosts
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Path to file with TLS certificate for the corresponding -httpListenAddr if -tls is set. Prefer ECDSA certs instead of RSA certs as RSA certs are slower. The provided certificate file is automatically re-read every second, so it can be dynamically updated. See also -tlsAutocertHosts
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -tlsCipherSuites array
-    	Optional list of TLS cipher suites for incoming requests over HTTPS if -tls is set. See the list of supported cipher suites at https://pkg.go.dev/crypto/tls#pkg-constants
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional list of TLS cipher suites for incoming requests over HTTPS if -tls is set. See the list of supported cipher suites at https://pkg.go.dev/crypto/tls#pkg-constants
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -tlsKeyFile array
-    	Path to file with TLS key for the corresponding -httpListenAddr if -tls is set. The provided key file is automatically re-read every second, so it can be dynamically updated. See also -tlsAutocertHosts
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Path to file with TLS key for the corresponding -httpListenAddr if -tls is set. The provided key file is automatically re-read every second, so it can be dynamically updated. See also -tlsAutocertHosts
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -tlsMinVersion array
-    	Optional minimum TLS version to use for the corresponding -httpListenAddr if -tls is set. Supported values: TLS10, TLS11, TLS12, TLS13
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional minimum TLS version to use for the corresponding -httpListenAddr if -tls is set. Supported values: TLS10, TLS11, TLS12, TLS13
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -version
-    	Show VictoriaMetrics version
+        Show VictoriaMetrics version
 ```

--- a/docs/victorialogs/Release-Guide.md
+++ b/docs/victorialogs/Release-Guide.md
@@ -16,6 +16,7 @@ aliases:
 ### For MacOS users
 
 Make sure you have GNU version of utilities `zip`, `tar`, `sha256sum`. To install them run the following commands:
+
 ```sh
 brew install coreutils
 brew install gnu-tar
@@ -23,12 +24,13 @@ export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
 ```
 
 Docker may need additional configuration changes:
-```sh 
+
+```sh
 docker buildx create --use --name=qemu
 docker buildx inspect --bootstrap  
 ```
 
-By default, docker on MacOS has limited amount of resources (CPU, mem) to use. 
+By default, docker on MacOS has limited amount of resources (CPU, mem) to use.
 Bumping the limits may significantly improve build speed.
 
 ## Release version and Docker images
@@ -49,11 +51,11 @@ Bumping the limits may significantly improve build speed.
       This step can be run manually with the command `make release` from the needed git tag.
    - b) Build and publish [multi-platform Docker images](https://docs.docker.com/build/buildx/multiplatform-images/) for the given `TAG`.
       The multi-platform Docker image is built for the following platforms:
-      * linux/amd64
-      * linux/arm64
-      * linux/arm
-      * linux/ppc64le
-      * linux/386
+      - linux/amd64
+      - linux/arm64
+      - linux/arm
+      - linux/ppc64le
+      - linux/386
       This step can be run manually with the command `make publish` from the needed git tag.
 
 1. Run `TAG=v1.xx.y make publish-latest` for publishing the `latest` tag for Docker images, which equals to the given `TAG`.
@@ -74,7 +76,7 @@ Bumping the limits may significantly improve build speed.
       - To run the command `TAG=v1.xx.y make github-create-release github-upload-assets`, so new release is created
         and all the needed assets are re-uploaded to it.
 
-1. Push the tag `v1.xx.y` created at the previous steps to public GitHub repository at https://github.com/VictoriaMetrics/VictoriaLogs :
+1. Push the tag `v1.xx.y` created at the previous steps to public GitHub repository at [https://github.com/VictoriaMetrics/VictoriaLogs](https://github.com/VictoriaMetrics/VictoriaLogs) :
 
    ```shell
    git push origin v1.xx.y
@@ -117,7 +119,7 @@ The helm chart repository [https://github.com/VictoriaMetrics/helm-charts/](http
 
 Bump `appVersion` field in `Chart.yaml` with new release version.
 Add new line to "Next release" section in `CHANGELOG.md` about version update (the line must always start with "`-`"). Do **NOT** change headers in `CHANGELOG.md`.
-Bump `version` field in `Chart.yaml` with incremental semver version (based on the `CHANGELOG.md` analysis). 
+Bump `version` field in `Chart.yaml` with incremental semver version (based on the `CHANGELOG.md` analysis).
 
 Do these updates to the following charts:
 

--- a/docs/victorialogs/cluster.md
+++ b/docs/victorialogs/cluster.md
@@ -90,9 +90,9 @@ For advanced setups, refer to the [multi-level cluster setup](#multi-level-clust
 
 In the cluster setup, the following rules apply:
 
-- The `vlselect` component requires **all relevant vlstorage nodes to be available** in order to return complete and correct query results. 
+- The `vlselect` component requires **all relevant vlstorage nodes to be available** in order to return complete and correct query results.
 
-  - If even one of the vlstorage nodes is temporarily unavailable, `vlselect` cannot safely return a full response, since some of the required data may reside on the missing node. Rather than risk delivering partial or misleading query results, which can cause confusion, trigger false alerts, or produce incorrect metrics, VictoriaLogs chooses to return an error instead. 
+  - If even one of the vlstorage nodes is temporarily unavailable, `vlselect` cannot safely return a full response, since some of the required data may reside on the missing node. Rather than risk delivering partial or misleading query results, which can cause confusion, trigger false alerts, or produce incorrect metrics, VictoriaLogs chooses to return an error instead.
 
 - The `vlinsert` component continues to function normally when some vlstorage nodes are unavailable. It automatically routes new logs to the remaining available nodes to ensure that data ingestion remains uninterrupted and newly received logs are not lost.
 
@@ -324,7 +324,7 @@ usage on systems with constrained resources:
 
 - `vlselect` requests compressed data from `vlstorage` nodes in order to reduce network bandwidth usage at the cost of slightly higher CPU usage
   at `vlselect` and `vlstorage` nodes. The compression can be disabled by passing `-select.disableCompression` command-line flag to `vlselect`.
-  This reduces CPU usage at `vlselect` and `vlstorage` nodes at the cost of significanlty higher network bandwidth usage.
+  This reduces CPU usage at `vlselect` and `vlstorage` nodes at the cost of significantly higher network bandwidth usage.
 
 ## Advanced usage
 

--- a/docs/victorialogs/data-ingestion/DataDogAgent.md
+++ b/docs/victorialogs/data-ingestion/DataDogAgent.md
@@ -76,7 +76,6 @@ for logs ingested via DataDog protocol. This can be done via the following optio
 - `-datadog.streamFields` command-line flag, which accepts comma-separated list of fields to use as log stream fields.
 - `_stream_fields` HTTP request query arg or `VL-Stream-Fields` HTTP request header. See [these docs](https://docs.victoriametrics.com/victorialogs/data-ingestion/#http-parameters) for details.
 
-
 See also:
 
 - [HTTP query args and HTTP headers, which can be set during data ingestion](https://docs.victoriametrics.com/victorialogs/data-ingestion/#http-parameters)

--- a/docs/victorialogs/data-ingestion/Logstash.md
+++ b/docs/victorialogs/data-ingestion/Logstash.md
@@ -13,6 +13,7 @@ aliases:
   - /victorialogs/data-ingestion/Logstash.html
 ---
 VictoriaLogs supports given below Logstash outputs:
+
 - [Elasticsearch](#elasticsearch)
 - [HTTP JSON](#http)
 

--- a/docs/victorialogs/data-ingestion/README.md
+++ b/docs/victorialogs/data-ingestion/README.md
@@ -369,4 +369,3 @@ Here is the list of log collectors and their ingestion formats supported by Vict
 | [Fluentd](https://docs.victoriametrics.com/victorialogs/data-ingestion/fluentd/) | [Yes](https://github.com/uken/fluent-plugin-elasticsearch) | [Yes](https://docs.fluentd.org/output/http) | [Yes](https://grafana.com/docs/loki/latest/send-data/fluentd/) | [Yes](https://github.com/fluent-plugins-nursery/fluent-plugin-remote_syslog) | No | No | No |
 | [Journald](https://docs.victoriametrics.com/victorialogs/data-ingestion/journald/) | No | No | No | No | No | Yes | No |
 | [DataDog Agent](https://docs.victoriametrics.com/victorialogs/data-ingestion/datadog-agent) | No | No | No | No | No | No | Yes |
-

--- a/docs/victorialogs/data-ingestion/Telegraf.md
+++ b/docs/victorialogs/data-ingestion/Telegraf.md
@@ -12,6 +12,7 @@ aliases:
   - /victorialogs/data-ingestion/Telegraf.html
 ---
 VictoriaLogs supports given below Telegraf outputs:
+
 - [Elasticsearch](#elasticsearch)
 - [HTTP JSON](#http)
 
@@ -50,7 +51,6 @@ for sending the collected logs to [VictoriaLogs](https://docs.victoriametrics.co
      metric_type = "logs"
      log_source = "telegraf"
 ```
-
 
 ## HTTP
 

--- a/docs/victorialogs/data-ingestion/opentelemetry.md
+++ b/docs/victorialogs/data-ingestion/opentelemetry.md
@@ -21,7 +21,7 @@ Consider the following example for Go SDK:
 
 ```go
 logExporter, err := otlploghttp.New(ctx,
-	otlploghttp.WithEndpointURL("http://victorialogs:9428/insert/opentelemetry/v1/logs"),
+  otlploghttp.WithEndpointURL("http://victorialogs:9428/insert/opentelemetry/v1/logs"),
 )
 ```
 
@@ -31,10 +31,10 @@ labels as log stream fields, while the remaining labels are stored as [regular l
 
 ```go
 logExporter, err := otlploghttp.New(ctx,
-	otlploghttp.WithEndpointURL("http://victorialogs:9428/insert/opentelemetry/v1/logs"),
-	otlploghttp.WithHeaders(map[string]string{
-		"VL-Stream-Fields": "host,app",
-	}),
+  otlploghttp.WithEndpointURL("http://victorialogs:9428/insert/opentelemetry/v1/logs"),
+  otlploghttp.WithHeaders(map[string]string{
+    "VL-Stream-Fields": "host,app",
+  }),
 )
 ```
 

--- a/docs/victorialogs/data-ingestion/syslog.md
+++ b/docs/victorialogs/data-ingestion/syslog.md
@@ -209,9 +209,11 @@ plus it accepts TLS-encrypted syslog messages via TCP port 6514 and stores them 
 
 1. Run VictoriaLogs with `-syslog.listenAddr.tcp=:29514` command-line flag.
 1. Put the following line to [rsyslog](https://www.rsyslog.com/) config (this config is usually located at `/etc/rsyslog.conf`):
+
    ```
    *.* @@victoria-logs-server:29514
    ```
+
    Where `victoria-logs-server` is the hostname where VictoriaLogs runs. See [these docs](https://www.rsyslog.com/sending-messages-to-a-remote-syslog-server/)
    for more details.
 
@@ -219,10 +221,12 @@ plus it accepts TLS-encrypted syslog messages via TCP port 6514 and stores them 
 
 1. Run VictoriaLogs with `-syslog.listenAddr.tcp=:29514` command-line flag.
 1. Put the following line to [syslog-ng](https://www.syslog-ng.com/) config:
+
    ```
    destination d_remote {
     tcp("victoria-logs-server" port(29514));
    };
    ```
+
    Where `victoria-logs-server` is the hostname where VictoriaLogs runs.
    See [these docs](https://support.oneidentity.com/technical-documents/syslog-ng-open-source-edition/3.19/administration-guide/29#TOPIC-1094570) for details.

--- a/docs/victorialogs/keyConcepts.md
+++ b/docs/victorialogs/keyConcepts.md
@@ -115,9 +115,9 @@ This enables [full-text search](https://docs.victoriametrics.com/victorialogs/lo
 
 VictoriaLogs supports the following special fields additionally to arbitrary [other fields](#other-fields):
 
-* [`_msg` field](#message-field)
-* [`_time` field](#time-field)
-* [`_stream` and `_stream_id` fields](#stream-fields)
+- [`_msg` field](#message-field)
+- [`_time` field](#time-field)
+- [`_stream` and `_stream_id` fields](#stream-fields)
 
 ### Message field
 
@@ -193,9 +193,11 @@ Every ingested log entry is associated with a log stream. Every log stream consi
   via [`_stream_id:...` filter](https://docs.victoriametrics.com/victorialogs/logsql/#_stream_id-filter).
 
 - `_stream` - this field contains stream labels in the format similar to [labels in Prometheus metrics](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#labels):
+
   ```
   {field1="value1", ..., fieldN="valueN"}
   ```
+
   For example, if `host` and `app` fields are associated with the stream, then the `_stream` field will have `{host="host-123",app="my-app"}` value
   for the log entry with `host="host-123"` and `app="my-app"` fields. The `_stream` field can be searched
   with [stream filters](https://docs.victoriametrics.com/victorialogs/logsql/#stream-filter).

--- a/docs/victorialogs/logsql-examples.md
+++ b/docs/victorialogs/logsql-examples.md
@@ -83,7 +83,6 @@ See also:
 - [Filtering by regular expression](https://docs.victoriametrics.com/victorialogs/logsql/#regexp-filter)
 - [Filtering by substring](https://docs.victoriametrics.com/victorialogs/logsql/#substring-filter)
 
-
 ## How to skip logs with the given word in log message?
 
 Use [`NOT` logical filter](https://docs.victoriametrics.com/victorialogs/logsql/#logical-filter). For example, the following query returns all the logs
@@ -124,7 +123,6 @@ See also:
 - [Filtering by prefix](https://docs.victoriametrics.com/victorialogs/logsql/#prefix-filter)
 - [Filtering by regular expression](https://docs.victoriametrics.com/victorialogs/logsql/#regexp-filter)
 - [Filtering by substring](https://docs.victoriametrics.com/victorialogs/logsql/#substring-filter)
-
 
 ## How to select logs with all the given words in log message?
 
@@ -170,7 +168,6 @@ See also:
 - [Filtering by regular expression](https://docs.victoriametrics.com/victorialogs/logsql/#regexp-filter)
 - [Filtering by substring](https://docs.victoriametrics.com/victorialogs/logsql/#substring-filter)
 
-
 ## How to select logs with some of the given words in log message?
 
 Put the needed [words](https://docs.victoriametrics.com/victorialogs/logsql/#word) into `(...)`, by delimiting them with ` or `.
@@ -215,7 +212,6 @@ See also:
 - [Filtering by regular expression](https://docs.victoriametrics.com/victorialogs/logsql/#regexp-filter)
 - [Filtering by substring](https://docs.victoriametrics.com/victorialogs/logsql/#substring-filter)
 
-
 ## How to select logs from the given application instance?
 
 Make sure the application is properly configured with [stream-level log fields](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields).
@@ -255,7 +251,6 @@ See also:
 
 - [How to determine applications with the most logs?](#how-to-determine-applications-with-the-most-logs)
 - [How to skip logs with the given word in log message?](#how-to-skip-logs-with-the-given-word-in-log-message)
-
 
 ## How to count the number of matching logs?
 
@@ -298,7 +293,6 @@ See also:
 - [How to calculate the number of logs per the given interval?](#how-to-calculate-the-number-of-logs-per-the-given-interval)
 - [How to select logs from the given application instance?](#how-to-select-logs-from-the-given-application-instance)
 
-
 ## How to parse JSON inside log message?
 
 It is better from performance and resource usage PoV to avoid storing JSON inside [log message](https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field).
@@ -315,7 +309,6 @@ _time:5m | unpack_json
 
 If you need to parse JSON array, then take a look at [`unroll` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#unroll-pipe).
 
-
 ## How to extract some data from text log message?
 
 Use [`extract`](https://docs.victoriametrics.com/victorialogs/logsql/#extract-pipe) or [`extract_regexp`](https://docs.victoriametrics.com/victorialogs/logsql/#extract_regexp-pipe) pipe.
@@ -328,7 +321,6 @@ _time:5m | extract "username=<username>, user_id=<user_id>,"
 See also:
 
 - [Replacing substrings in text fields](https://docs.victoriametrics.com/victorialogs/logsql/#replace-pipe)
-
 
 ## How to filter out data after stats calculation?
 
@@ -433,7 +425,6 @@ See also:
 - [How to select recently ingested logs?](#how-to-select-recently-ingested-logs)
 - [How to return last N logs for the given query?](#how-to-return-last-n-logs-for-the-given-query)
 
-
 ## How to calculate the share of error logs to the total number of logs?
 
 Use the following query:
@@ -449,7 +440,6 @@ This query uses the following [LogsQL](https://docs.victoriametrics.com/victoria
   for calculating the total number of logs and the number of logs with the `error` [word](https://docs.victoriametrics.com/victorialogs/logsql/#word) on the selected time range.
 - [`math` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#math-pipe) for calculating the share of logs with `error` [word](https://docs.victoriametrics.com/victorialogs/logsql/#word)
   comparing to the total number of logs.
-
 
 ## How to select logs for working hours and weekdays?
 
@@ -468,7 +458,6 @@ on [`_time` field](https://docs.victoriametrics.com/victorialogs/keyconcepts/#ti
 Use [`phrase filter`](https://docs.victoriametrics.com/victorialogs/logsql/#phrase-filter). For example, the following [LogsQL query](https://docs.victoriametrics.com/victorialogs/logsql/)
 returns logs with the `cannot open file` phrase over the last 5 minutes:
 
-
 ```logsql
 _time:5m "cannot open file"
 ```
@@ -482,7 +471,6 @@ plus up to 100 logs after the given log message:
 ```logsql
 _time:5m stacktrace | stream_context before 10 after 100
 ```
-
 
 ## How to get the duration since the last seen log entry matching the given filter?
 

--- a/docs/victorialogs/querying/README.md
+++ b/docs/victorialogs/querying/README.md
@@ -24,7 +24,6 @@ VictoriaLogs provides the following HTTP endpoints:
 - [`/select/logsql/field_names`](#querying-field-names) for querying [log field](https://docs.victoriametrics.com/victorialogs/keyconcepts/#data-model) names.
 - [`/select/logsql/field_values`](#querying-field-values) for querying [log field](https://docs.victoriametrics.com/victorialogs/keyconcepts/#data-model) values.
 
-
 ### Querying logs
 
 Logs stored in VictoriaLogs can be queried at the `/select/logsql/query` HTTP endpoint.
@@ -57,14 +56,18 @@ By default the `/select/logsql/query` returns all the log entries matching the g
 - By specifying the maximum number of log entries, which can be returned in the response via `limit` query arg. For example, the following command returns
   up to 10 most recently added log entries with the `error` [word](https://docs.victoriametrics.com/victorialogs/logsql/#word)
   in the [`_msg` field](https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field):
+
   ```sh
   curl http://localhost:9428/select/logsql/query -d 'query=error' -d 'limit=10'
   ```
+
 - By adding [`limit` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#limit-pipe) to the query. For example, the following command returns up to 10 **random** log entries
   with the `error` [word](https://docs.victoriametrics.com/victorialogs/logsql/#word) in the [`_msg` field](https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field):
+
   ```sh
   curl http://localhost:9428/select/logsql/query -d 'query=error | limit 10'
   ```
+
 - By adding [`_time` filter](https://docs.victoriametrics.com/victorialogs/logsql/#time-filter). The time range for the query can be specified via optional
   `start` and `end` query args formatted according to [these docs](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#timestamp-formats).
 - By adding more specific [filters](https://docs.victoriametrics.com/victorialogs/logsql/#filters) to the query, which select lower number of logs.
@@ -123,7 +126,6 @@ See also:
 - [Querying stream field values](#querying-stream-field-values)
 - [Querying field names](#querying-field-names)
 - [Querying field values](#querying-field-values)
-
 
 ### Live tailing
 
@@ -915,7 +917,6 @@ See also:
 - [Querying streams](#querying-streams)
 - [HTTP API](#http-api)
 
-
 ## Extra filters
 
 All the [HTTP querying APIs](#http-api) provided by VictoriaLogs support the following optional query args:
@@ -943,7 +944,6 @@ The `extra_filters` may contain also arbitrary [LogsQL filter](https://docs.vict
 
 The arg passed to `extra_filters` and `extra_stream_filters` must be properly encoded with [percent encoding](https://en.wikipedia.org/wiki/Percent-encoding).
 
-
 ## Web UI
 
 VictoriaLogs provides Web UI for logs [querying](https://docs.victoriametrics.com/victorialogs/logsql/) and exploration
@@ -958,7 +958,7 @@ There are three modes of displaying query results:
 
 See also [command line interface](#command-line).
 
-## Visualization in Grafana 
+## Visualization in Grafana
 
 [VictoriaLogs Grafana Datasource](https://docs.victoriametrics.com/victorialogs/victorialogs-datasource/) allows you to query and visualize VictoriaLogs data in Grafana
 

--- a/docs/victorialogs/querying/vlogscli.md
+++ b/docs/victorialogs/querying/vlogscli.md
@@ -57,7 +57,6 @@ can be set via `-accountID` and `-projectID` command-line flags:
 ./vlogscli -accountID=123 -projectID=456
 ```
 
-
 ## Querying
 
 After the start `vlogscli` provides a prompt for writing [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/) queries.
@@ -90,7 +89,6 @@ See also:
 - [scrolling query results](#scrolling-query-results)
 - [live tailing](#live-tailing)
 
-
 ## Scrolling query results
 
 If the query response exceeds vertical screen space, `vlogscli` pipes query response to `less` utility,
@@ -109,10 +107,9 @@ thanks to the way how `less` interacts with [`/select/logsql/query`](https://doc
 See also [`less` docs](https://man7.org/linux/man-pages/man1/less.1.html) and
 [command-line integration docs for VictoriaLogs](https://docs.victoriametrics.com/victorialogs/querying/#command-line).
 
-
 ## Live tailing
 
-`vlogscli` enters live tailing mode when the query is prepended with `\tail ` command. For example,
+`vlogscli` enters live tailing mode when the query is prepended with `\tail` command. For example,
 the following query shows all the newly ingested logs with `error` [word](https://docs.victoriametrics.com/victorialogs/logsql/#word)
 in real time:
 
@@ -124,7 +121,6 @@ By default `vlogscli` derives [the URL for live tailing](https://docs.victoriame
 by replacing `/query` with `/tail` at the end of `-datasource.url`. The URL for live tailing can be specified explicitly via `-tail.url` command-line flag.
 
 Live tailing can show query results in different formats - see [these docs](#output-modes).
-
 
 ## Query history
 
@@ -139,7 +135,6 @@ Press `Enter` when the needed query is found in order to execute it.
 Press `Ctrl+C` for exit from the `search history` mode.
 See also [other available shortcuts](https://github.com/chzyer/readline/blob/f533ef1caae91a1fcc90875ff9a5a030f0237c6a/doc/shortcut.md).
 
-
 ## Output modes
 
 By default `vlogscli` displays query results as prettified JSON object with every field on a separate line.
@@ -147,15 +142,14 @@ Fields in every JSON object are sorted in alphabetical order. This simplifies lo
 
 `vlogscli` supports the following output modes:
 
-* A single JSON line per every result. Type `\s` and press `enter` for this mode.
-* Multiline JSON per every result. Type `\m` and press `enter` for this mode.
-* Compact output. Type `\c` and press `enter` for this mode.
+- A single JSON line per every result. Type `\s` and press `enter` for this mode.
+- Multiline JSON per every result. Type `\m` and press `enter` for this mode.
+- Compact output. Type `\c` and press `enter` for this mode.
   This mode shows field values as is if the response contains a single field
   (for example if [`fields _msg` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#fields-pipe) is used)
   plus optional [`_time` field](https://docs.victoriametrics.com/victorialogs/keyconcepts/#time-field).
   See also [docs about ANSI colors](#ansi-colors).
-* [Logfmt output](https://brandur.org/logfmt). Type `\logfmt` and press `enter` for this mode.
-
+- [Logfmt output](https://brandur.org/logfmt). Type `\logfmt` and press `enter` for this mode.
 
 ## Wrapping long lines
 
@@ -175,13 +169,13 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/data-ing
 
 ## TLS options
 
-`vlogscli` supports the following TLS-related command-line flags for connections to the `-datsource.url`:
+`vlogscli` supports the following TLS-related command-line flags for connections to the `-datasource.url`:
 
-* `-tlsCAFile` - optional path to TLS CA file to use for verifying connections to the `-datasource.url`. By default, system CA is used.
-* `-tlsCertFile` - optional path to client-side TLS certificate file to use when connecting to the `-datasource.url`.
-* `-tlsInsecureSkipVerify` - whether to skip tls verification when connecting to the `-datasource.url`.
-* `-tlsKeyFile` - optional path to client-side TLS certificate key to use when connecting to the `-datasource.url`.
-* `-tlsServerName` -  optional TLS server name to use for connections to the `-datasource.url`. By default, the server name from `-datasource.url` is used.
+- `-tlsCAFile` - optional path to TLS CA file to use for verifying connections to the `-datasource.url`. By default, system CA is used.
+- `-tlsCertFile` - optional path to client-side TLS certificate file to use when connecting to the `-datasource.url`.
+- `-tlsInsecureSkipVerify` - whether to skip tls verification when connecting to the `-datasource.url`.
+- `-tlsKeyFile` - optional path to client-side TLS certificate key to use when connecting to the `-datasource.url`.
+- `-tlsServerName` -  optional TLS server name to use for connections to the `-datasource.url`. By default, the server name from `-datasource.url` is used.
 
 See also [auth options](#auth-options).
 
@@ -189,9 +183,9 @@ See also [auth options](#auth-options).
 
 `vlogscli` supports the following auth-related command-line flags:
 
-* `-bearerToken` - optional bearer auth token to use for the `-datasource.url`.
-* `-username` - optional basic auth username to use for the `-datasource.url`.
-* `-password` - optional basic auth password to use for the `-datsource.url`.
+- `-bearerToken` - optional bearer auth token to use for the `-datasource.url`.
+- `-username` - optional basic auth username to use for the `-datasource.url`.
+- `-password` - optional basic auth password to use for the `-datasource.url`.
 
 The `-bearerToken` and `-password` command-line flags may refer local files or remote files via http(s). In this case the corresponding value of the flag is read from the file.
 For example, `-bearerToken=file:///abs/path/to/file`, `-bearerToken=file://./relative/path/to/file`, `-bearerToken=http://host/path` or `-bearerToken=https://host/path`.
@@ -204,80 +198,80 @@ The list of command-line flags with their descriptions is available by running `
 
 ```
   -accountID int
-    	Account ID to query; see https://docs.victoriametrics.com/victorialogs/#multitenancy
+      Account ID to query; see https://docs.victoriametrics.com/victorialogs/#multitenancy
   -bearerToken value
-    	Optional bearer auth token to use for the -datasource.url
-    	Flag value can be read from the given file when using -bearerToken=file:///abs/path/to/file or -bearerToken=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -bearerToken=http://host/path or -bearerToken=https://host/path
+      Optional bearer auth token to use for the -datasource.url
+      Flag value can be read from the given file when using -bearerToken=file:///abs/path/to/file or -bearerToken=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -bearerToken=http://host/path or -bearerToken=https://host/path
   -blockcache.missesBeforeCaching int
-    	The number of cache misses before putting the block into cache. Higher values may reduce indexdb/dataBlocks cache size at the cost of higher CPU and disk read usage (default 2)
+      The number of cache misses before putting the block into cache. Higher values may reduce indexdb/dataBlocks cache size at the cost of higher CPU and disk read usage (default 2)
   -datasource.url string
-    	URL for querying VictoriaLogs; see https://docs.victoriametrics.com/victorialogs/querying/#querying-logs . See also -tail.url (default "http://localhost:9428/select/logsql/query")
+      URL for querying VictoriaLogs; see https://docs.victoriametrics.com/victorialogs/querying/#querying-logs . See also -tail.url (default "http://localhost:9428/select/logsql/query")
   -enableTCP6
-    	Whether to enable IPv6 for listening and dialing. By default, only IPv4 TCP and UDP are used
+      Whether to enable IPv6 for listening and dialing. By default, only IPv4 TCP and UDP are used
   -envflag.enable
-    	Whether to enable reading flags from environment variables in addition to the command line. Command line flag values have priority over values from environment vars. Flags are read only from the command line if this flag isn't set. See https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#environment-variables for more details
+      Whether to enable reading flags from environment variables in addition to the command line. Command line flag values have priority over values from environment vars. Flags are read only from the command line if this flag isn't set. See https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#environment-variables for more details
   -envflag.prefix string
-    	Prefix for environment variables if -envflag.enable is set
+      Prefix for environment variables if -envflag.enable is set
   -filestream.disableFadvise
-    	Whether to disable fadvise() syscall when reading large data files. The fadvise() syscall prevents from eviction of recently accessed data from OS page cache during background merges and backups. In some rare cases it is better to disable the syscall if it uses too much CPU
+      Whether to disable fadvise() syscall when reading large data files. The fadvise() syscall prevents from eviction of recently accessed data from OS page cache during background merges and backups. In some rare cases it is better to disable the syscall if it uses too much CPU
   -fs.disableMmap
-    	Whether to use pread() instead of mmap() for reading data files. By default, mmap() is used for 64-bit arches and pread() is used for 32-bit arches, since they cannot read data files bigger than 2^32 bytes in memory. mmap() is usually faster for reading small data chunks than pread()
+      Whether to use pread() instead of mmap() for reading data files. By default, mmap() is used for 64-bit arches and pread() is used for 32-bit arches, since they cannot read data files bigger than 2^32 bytes in memory. mmap() is usually faster for reading small data chunks than pread()
   -header array
-    	Optional header to pass in request -datasource.url in the form 'HeaderName: value'
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+      Optional header to pass in request -datasource.url in the form 'HeaderName: value'
+      Supports an array of values separated by comma or specified via multiple flags.
+      Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -historyFile string
-    	Path to file with command history (default "vlogscli-history")
+      Path to file with command history (default "vlogscli-history")
   -internStringCacheExpireDuration duration
-    	The expiry duration for caches for interned strings. See https://en.wikipedia.org/wiki/String_interning . See also -internStringMaxLen and -internStringDisableCache (default 6m0s)
+      The expiry duration for caches for interned strings. See https://en.wikipedia.org/wiki/String_interning . See also -internStringMaxLen and -internStringDisableCache (default 6m0s)
   -internStringDisableCache
-    	Whether to disable caches for interned strings. This may reduce memory usage at the cost of higher CPU usage. See https://en.wikipedia.org/wiki/String_interning . See also -internStringCacheExpireDuration and -internStringMaxLen
+      Whether to disable caches for interned strings. This may reduce memory usage at the cost of higher CPU usage. See https://en.wikipedia.org/wiki/String_interning . See also -internStringCacheExpireDuration and -internStringMaxLen
   -internStringMaxLen int
-    	The maximum length for strings to intern. A lower limit may save memory at the cost of higher CPU usage. See https://en.wikipedia.org/wiki/String_interning . See also -internStringDisableCache and -internStringCacheExpireDuration (default 500)
+      The maximum length for strings to intern. A lower limit may save memory at the cost of higher CPU usage. See https://en.wikipedia.org/wiki/String_interning . See also -internStringDisableCache and -internStringCacheExpireDuration (default 500)
   -loggerDisableTimestamps
-    	Whether to disable writing timestamps in logs
+      Whether to disable writing timestamps in logs
   -loggerErrorsPerSecondLimit int
-    	Per-second limit on the number of ERROR messages. If more than the given number of errors are emitted per second, the remaining errors are suppressed. Zero values disable the rate limit
+      Per-second limit on the number of ERROR messages. If more than the given number of errors are emitted per second, the remaining errors are suppressed. Zero values disable the rate limit
   -loggerFormat string
-    	Format for logs. Possible values: default, json (default "default")
+      Format for logs. Possible values: default, json (default "default")
   -loggerJSONFields string
-    	Allows renaming fields in JSON formatted logs. Example: "ts:timestamp,msg:message" renames "ts" to "timestamp" and "msg" to "message". Supported fields: ts, level, caller, msg
+      Allows renaming fields in JSON formatted logs. Example: "ts:timestamp,msg:message" renames "ts" to "timestamp" and "msg" to "message". Supported fields: ts, level, caller, msg
   -loggerLevel string
-    	Minimum level of errors to log. Possible values: INFO, WARN, ERROR, FATAL, PANIC (default "INFO")
+      Minimum level of errors to log. Possible values: INFO, WARN, ERROR, FATAL, PANIC (default "INFO")
   -loggerMaxArgLen int
-    	The maximum length of a single logged argument. Longer arguments are replaced with 'arg_start..arg_end', where 'arg_start' and 'arg_end' is prefix and suffix of the arg with the length not exceeding -loggerMaxArgLen / 2 (default 5000)
+      The maximum length of a single logged argument. Longer arguments are replaced with 'arg_start..arg_end', where 'arg_start' and 'arg_end' is prefix and suffix of the arg with the length not exceeding -loggerMaxArgLen / 2 (default 5000)
   -loggerOutput string
-    	Output for the logs. Supported values: stderr, stdout (default "stderr")
+      Output for the logs. Supported values: stderr, stdout (default "stderr")
   -loggerTimezone string
-    	Timezone to use for timestamps in logs. Timezone must be a valid IANA Time Zone. For example: America/New_York, Europe/Berlin, Etc/GMT+3 or Local (default "UTC")
+      Timezone to use for timestamps in logs. Timezone must be a valid IANA Time Zone. For example: America/New_York, Europe/Berlin, Etc/GMT+3 or Local (default "UTC")
   -loggerWarnsPerSecondLimit int
-    	Per-second limit on the number of WARN messages. If more than the given number of warns are emitted per second, then the remaining warns are suppressed. Zero values disable the rate limit
+      Per-second limit on the number of WARN messages. If more than the given number of warns are emitted per second, then the remaining warns are suppressed. Zero values disable the rate limit
   -memory.allowedBytes size
-    	Allowed size of system memory VictoriaMetrics caches may occupy. This option overrides -memory.allowedPercent if set to a non-zero value. Too low a value may increase the cache miss rate usually resulting in higher CPU and disk IO usage. Too high a value may evict too much data from the OS page cache resulting in higher disk IO usage
-    	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 0)
+      Allowed size of system memory VictoriaMetrics caches may occupy. This option overrides -memory.allowedPercent if set to a non-zero value. Too low a value may increase the cache miss rate usually resulting in higher CPU and disk IO usage. Too high a value may evict too much data from the OS page cache resulting in higher disk IO usage
+      Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 0)
   -memory.allowedPercent float
-    	Allowed percent of system memory VictoriaMetrics caches may occupy. See also -memory.allowedBytes. Too low a value may increase cache miss rate usually resulting in higher CPU and disk IO usage. Too high a value may evict too much data from the OS page cache which will result in higher disk IO usage (default 60)
+      Allowed percent of system memory VictoriaMetrics caches may occupy. See also -memory.allowedBytes. Too low a value may increase cache miss rate usually resulting in higher CPU and disk IO usage. Too high a value may evict too much data from the OS page cache which will result in higher disk IO usage (default 60)
   -password value
-    	Optional basic auth password to use for the -datsource.url
-    	Flag value can be read from the given file when using -password=file:///abs/path/to/file or -password=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -password=http://host/path or -password=https://host/path
+      Optional basic auth password to use for the -datasource.url
+      Flag value can be read from the given file when using -password=file:///abs/path/to/file or -password=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -password=http://host/path or -password=https://host/path
   -projectID int
-    	Project ID to query; see https://docs.victoriametrics.com/victorialogs/#multitenancy
+      Project ID to query; see https://docs.victoriametrics.com/victorialogs/#multitenancy
   -tail.url string
-    	URL for live tailing queries to VictoriaLogs; see https://docs.victoriametrics.com/victorialogs/querying/#live-tailing .The url is automatically detected from -datasource.url by replacing /query with /tail at the end if -tail.url is empty
+      URL for live tailing queries to VictoriaLogs; see https://docs.victoriametrics.com/victorialogs/querying/#live-tailing .The url is automatically detected from -datasource.url by replacing /query with /tail at the end if -tail.url is empty
   -tlsCAFile string
-    	Optional path to TLS CA file to use for verifying connections to the -datasource.url. By default, system CA is used
+      Optional path to TLS CA file to use for verifying connections to the -datasource.url. By default, system CA is used
   -tlsCertFile string
-    	Optional path to client-side TLS certificate file to use when connecting to the -datasource.url
+      Optional path to client-side TLS certificate file to use when connecting to the -datasource.url
   -tlsInsecureSkipVerify
-    	Whether to skip tls verification when connecting to the -datasource.url
+      Whether to skip tls verification when connecting to the -datasource.url
   -tlsKeyFile string
-    	Optional path to client-side TLS certificate key to use when connecting to the -datasource.url
+      Optional path to client-side TLS certificate key to use when connecting to the -datasource.url
   -tlsServerName string
-    	Optional TLS server name to use for connections to the -datasource.url. By default, the server name from -datasource.url is used
+      Optional TLS server name to use for connections to the -datasource.url. By default, the server name from -datasource.url is used
   -username string
-    	Optional basic auth username to use for the -datasource.url
+      Optional basic auth username to use for the -datasource.url
   -version
-    	Show VictoriaMetrics version
+      Show VictoriaMetrics version
 ```
 
 ### Building from source code

--- a/docs/victorialogs/sql-to-logsql.md
+++ b/docs/victorialogs/sql-to-logsql.md
@@ -13,7 +13,6 @@ tags:
 This is a tutorial for the migration from SQL to [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/).
 It is expected you are familiar with SQL and know [how to execute queries at VictoriaLogs](https://docs.victoriametrics.com/victorialogs/querying/).
 
-
 ## data model
 
 SQL is usually used for querying relational tables. Every such table contains a pre-defined set of columns with pre-defined types.
@@ -68,31 +67,31 @@ See the [conversion rules](#conversion-rules) on how to convert SQL to LogsQL.
 
 The following rules must be used for converting SQL query into LogsQL query:
 
-* If the SQL query contains `WHERE`, then convert it into [LogsQL filters](https://docs.victoriametrics.com/victorialogs/logsql/#filters).
+- If the SQL query contains `WHERE`, then convert it into [LogsQL filters](https://docs.victoriametrics.com/victorialogs/logsql/#filters).
   Otherwise just start LogsQL query with [`*`](https://docs.victoriametrics.com/victorialogs/logsql/#any-value-filter).
   For example, `SELECT * FROM table WHERE field1=value1 AND field2<>value2` is converted into `field1:=value1 field2:!=value2`,
   while `SELECT * FROM table` is converted into `*`.
-* `IN` subqueries inside `WHERE` must be converted into [`in` filters](https://docs.victoriametrics.com/victorialogs/logsql/#multi-exact-filter).
+- `IN` subqueries inside `WHERE` must be converted into [`in` filters](https://docs.victoriametrics.com/victorialogs/logsql/#multi-exact-filter).
   For example, `SELECT * FROM table WHERE id IN (SELECT id2 FROM table)` is converted into `id:in(* | fields id2)`.
-* If the `SELECT` part isn't equal to `*` and there are no `GROUP BY` / aggregate functions in the SQL query, then enumerate
+- If the `SELECT` part isn't equal to `*` and there are no `GROUP BY` / aggregate functions in the SQL query, then enumerate
   the selected columns at [`fields` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#fields-pipe).
   For example, `SELECT field1, field2 FROM table` is converted into `* | fields field1, field2`.
-* If the SQL query contains `JOIN`, then convert it into [`join` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#join-pipe).
-* If the SQL query contains `GROUP BY` / aggregate functions, then convert them to [`stats` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#stats-pipe).
+- If the SQL query contains `JOIN`, then convert it into [`join` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#join-pipe).
+-- If the SQL query contains `GROUP BY` / aggregate functions, then convert them to [`stats` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#stats-pipe).
   For example, `SELECT count(*) FROM table` is converted into `* | count()`, while `SELECT user_id, count(*) FROM table GROUP BY user_id`
   is converted to `* | stats by (user_id) count()`. Note how the LogsQL query mentions the `GROUP BY` fields only once,
   while SQL forces mentioning these fields twice - at the `SELECT` and at the `GROUP BY`. How many times did you hit the discrepancy
   between `SELECT` and `GROUP BY` fields?
-* If the SQL query contains additional calculations and/or transformations at the `SELECT`, which aren't covered yet by `GROUP BY`,
+- If the SQL query contains additional calculations and/or transformations at the `SELECT`, which aren't covered yet by `GROUP BY`,
   then convert them into the corresponding [LogsQL pipes](https://docs.victoriametrics.com/victorialogs/logsql/#pipes).
   The most frequently used pipes are [`math`](https://docs.victoriametrics.com/victorialogs/logsql/#math-pipe)
   and [`format`](https://docs.victoriametrics.com/victorialogs/logsql/#format-pipe).
   For example, `SELECT field1 + 10 AS x, CONCAT("foo", field2) AS y FROM table` is converted into `* | math field1 + 10 as x | format "foo<field2>" as y | fields x, y`.
-* If the SQL query contains `HAVING`, then convert it into [`filter` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#filter-pipe).
+- If the SQL query contains `HAVING`, then convert it into [`filter` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#filter-pipe).
   For example, `SELECT user_id, count(*) AS c FROM table GROUP BY user_id HAVING c > 100` is converted into `* | stats by (user_id) count() c | filter c:>100`.
-* If the SQL query contains `ORDER BY`, `LIMIT` and `OFFSET`, then convert them into [`sort` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#sort-pipe).
+- If the SQL query contains `ORDER BY`, `LIMIT` and `OFFSET`, then convert them into [`sort` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#sort-pipe).
   For example, `SELECT * FROM table ORDER BY field1, field2 LIMIT 10 OFFSET 20` is converted into `* | sort by (field1, field2) limit 10 offset 20`.
-* If the SQL query contains `UNION`, then convert it into [`union` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#union-pipe).
+- If the SQL query contains `UNION`, then convert it into [`union` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#union-pipe).
   For example `SELECT * FROM table WHERE filters1 UNION ALL SELECT * FROM table WHERE filters2` is converted into `filters1 | union (filters2)`.
 
 SQL queries are frequently used for obtaining top N column values, which are the most frequently seen in the selected rows.

--- a/docs/victorialogs/vlagent.md
+++ b/docs/victorialogs/vlagent.md
@@ -17,7 +17,6 @@ aliases:
 and store them in [VictoriaLogs](https://docs.victoriametrics.com/victorialogs/).
 See [Quick Start](#quick-start) for details.
 
-
 ## Motivation
 
 While VictoriaLogs provides an efficient solution to store and observe logs, it lacks of replication out of box.
@@ -27,8 +26,8 @@ Previous solution was to configure clients to replicate log streams into multipl
 ## Features
 
 - It can accept logs from popular log collectors. See [these docs](https://docs.victoriametrics.com/victorialogs/data-ingestion/).
-* Can replicate collected logs simultaneously to multiple VictoriaLogs instances - see [these docs](#replication-and-high-availability).
-* Works smoothly in environments with unstable connections to remote storage. If the remote storage is unavailable, the collected logs
+- Can replicate collected logs simultaneously to multiple VictoriaLogs instances - see [these docs](#replication-and-high-availability).
+- Works smoothly in environments with unstable connections to remote storage. If the remote storage is unavailable, the collected logs
   are buffered at `-remoteWrite.tmpDataPath`. The buffered logs are sent to remote storage as soon as the connection
   to the remote storage is repaired. The maximum disk usage for the buffer can be limited with `-remoteWrite.maxDiskUsagePerURL`.
 
@@ -38,7 +37,7 @@ Please download and unpack `vlutils` archive from [releases page](https://github
 `vlagent` is also available in docker images [Docker Hub](https://hub.docker.com/r/victoriametrics/vlagent/tags) and [Quay](https://quay.io/repository/victoriametrics/vlagent?tab=tags)),
 unpack it and pass the following flags to the `vlagent` binary in order to start sending the data to the VictoriaLogs remote storage:
 
-* `-remoteWrite.url` with VictoriaLogs native protocol compatible remote storage endpoint, where to send the data to.
+- `-remoteWrite.url` with VictoriaLogs native protocol compatible remote storage endpoint, where to send the data to.
   The `-remoteWrite.url` may refer to [DNS SRV](https://en.wikipedia.org/wiki/SRV_record) address. See [these docs](#srv-urls) for details.
 
 Example command for writing the data received via [supported push-based protocols](#how-to-push-data-to-vlagent)
@@ -69,25 +68,25 @@ If you have suggestions for improvements or have found a bug - please open an is
 
 ## Troubleshooting
 
-* It is recommended [setting up the official Grafana dashboard](#monitoring) in order to monitor the state of `vlagent`.
+- It is recommended [setting up the official Grafana dashboard](#monitoring) in order to monitor the state of `vlagent`.
 
-* It is recommended increasing `-remoteWrite.queues` if `vlagent_remotewrite_pending_data_bytes` [metric](#monitoring)
+- It is recommended increasing `-remoteWrite.queues` if `vlagent_remotewrite_pending_data_bytes` [metric](#monitoring)
   grows constantly. It is also recommended increasing `-remoteWrite.maxBlockSize` command-line flags in this case.
   This can improve data ingestion performance to the configured remote storage systems at the cost of higher memory usage.
 
-* If you see gaps in the data pushed by `vlagent` to remote storage when `-remoteWrite.maxDiskUsagePerURL` is set,
+- If you see gaps in the data pushed by `vlagent` to remote storage when `-remoteWrite.maxDiskUsagePerURL` is set,
   try increasing `-remoteWrite.queues`. Such gaps may appear because `vlagent` cannot keep up with sending the collected data to remote storage.
   Therefore, it starts dropping the buffered data if the on-disk buffer size exceeds `-remoteWrite.maxDiskUsagePerURL`.
 
-* `vlagent` drops data blocks if remote storage replies with `400 Bad Request` and `404 Not Found` HTTP responses.
+- `vlagent` drops data blocks if remote storage replies with `400 Bad Request` and `404 Not Found` HTTP responses.
   The number of dropped blocks can be monitored via `vlagent_remotewrite_packets_dropped_total` metric exported at [/metrics page](#monitoring).
 
-* `vlagent` buffers scraped data at the `-remoteWrite.tmpDataPath` directory until it is sent to `-remoteWrite.url`.
+- `vlagent` buffers scraped data at the `-remoteWrite.tmpDataPath` directory until it is sent to `-remoteWrite.url`.
   The directory can grow large when remote storage is unavailable for extended periods of time and if the maximum directory size isn't limited
   with `-remoteWrite.maxDiskUsagePerURL` command-line flag.
   If you don't want to send all the buffered data from the directory to remote storage then simply stop `vlagent` and delete the directory.
 
-* By default `vlagent` masks `-remoteWrite.url` with `secret-url` values in logs and at `/metrics` page because
+- By default `vlagent` masks `-remoteWrite.url` with `secret-url` values in logs and at `/metrics` page because
   the url may contain sensitive information such as auth tokens or passwords.
   Pass `-remoteWrite.showURL` command-line flag when starting `vlagent` in order to see all the valid urls.
 
@@ -95,26 +94,21 @@ See also:
 
 - [General Troubleshooting](https://docs.victoriametrics.com/victoriametrics/troubleshooting/)
 
-
 ## Profiling
 
 `vlagent` provides handlers for collecting the following [Go profiles](https://blog.golang.org/profiling-go-programs):
 
-* Memory profile can be collected with the following command (replace `0.0.0.0` with hostname if needed):
-
+- Memory profile can be collected with the following command (replace `0.0.0.0` with hostname if needed):
 
 ```sh
 curl http://0.0.0.0:9429/debug/pprof/heap > mem.pprof
 ```
 
-
-* CPU profile can be collected with the following command (replace `0.0.0.0` with hostname if needed):
-
+- CPU profile can be collected with the following command (replace `0.0.0.0` with hostname if needed):
 
 ```sh
 curl http://0.0.0.0:9429/debug/pprof/profile > cpu.pprof
 ```
-
 
 The command for collecting CPU profile waits for 30 seconds before returning.
 
@@ -132,377 +126,377 @@ vlagent collects logs via popular data ingestion protocols and routes it to Vict
 See the docs at https://docs.victoriametrics.com/victorialogs/vlagent/ .
 
   -blockcache.missesBeforeCaching int
-    	The number of cache misses before putting the block into cache. Higher values may reduce indexdb/dataBlocks cache size at the cost of higher CPU and disk read usage (default 2)
+        The number of cache misses before putting the block into cache. Higher values may reduce indexdb/dataBlocks cache size at the cost of higher CPU and disk read usage (default 2)
   -datadog.ignoreFields array
-    	Comma-separated list of fields to ignore for logs ingested via DataDog protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/datadog-agent/#dropping-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Comma-separated list of fields to ignore for logs ingested via DataDog protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/datadog-agent/#dropping-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -datadog.maxRequestSize size
-    	The maximum size in bytes of a single DataDog request
-    	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
+        The maximum size in bytes of a single DataDog request
+        Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
   -datadog.streamFields array
-    	Comma-separated list of fields to use as log stream fields for logs ingested via DataDog protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/datadog-agent/#stream-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Comma-separated list of fields to use as log stream fields for logs ingested via DataDog protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/datadog-agent/#stream-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -defaultMsgValue string
-    	Default value for _msg field if the ingested log entry doesn't contain it; see https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field (default "missing _msg field; see https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field")
+        Default value for _msg field if the ingested log entry doesn't contain it; see https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field (default "missing _msg field; see https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field")
   -elasticsearch.version string
-    	Elasticsearch version to report to client (default "8.9.0")
+        Elasticsearch version to report to client (default "8.9.0")
   -enableTCP6
-    	Whether to enable IPv6 for listening and dialing. By default, only IPv4 TCP and UDP are used
+        Whether to enable IPv6 for listening and dialing. By default, only IPv4 TCP and UDP are used
   -envflag.enable
-    	Whether to enable reading flags from environment variables in addition to the command line. Command line flag values have priority over values from environment vars. Flags are read only from the command line if this flag isn't set. See https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#environment-variables for more details
+        Whether to enable reading flags from environment variables in addition to the command line. Command line flag values have priority over values from environment vars. Flags are read only from the command line if this flag isn't set. See https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#environment-variables for more details
   -envflag.prefix string
-    	Prefix for environment variables if -envflag.enable is set
+        Prefix for environment variables if -envflag.enable is set
   -filestream.disableFadvise
-    	Whether to disable fadvise() syscall when reading large data files. The fadvise() syscall prevents from eviction of recently accessed data from OS page cache during background merges and backups. In some rare cases it is better to disable the syscall if it uses too much CPU
+        Whether to disable fadvise() syscall when reading large data files. The fadvise() syscall prevents from eviction of recently accessed data from OS page cache during background merges and backups. In some rare cases it is better to disable the syscall if it uses too much CPU
   -flagsAuthKey value
-    	Auth key for /flags endpoint. It must be passed via authKey query arg. It overrides -httpAuth.*
-    	Flag value can be read from the given file when using -flagsAuthKey=file:///abs/path/to/file or -flagsAuthKey=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -flagsAuthKey=http://host/path or -flagsAuthKey=https://host/path
+        Auth key for /flags endpoint. It must be passed via authKey query arg. It overrides -httpAuth.*
+        Flag value can be read from the given file when using -flagsAuthKey=file:///abs/path/to/file or -flagsAuthKey=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -flagsAuthKey=http://host/path or -flagsAuthKey=https://host/path
   -fs.disableMmap
-    	Whether to use pread() instead of mmap() for reading data files. By default, mmap() is used for 64-bit arches and pread() is used for 32-bit arches, since they cannot read data files bigger than 2^32 bytes in memory. mmap() is usually faster for reading small data chunks than pread()
+        Whether to use pread() instead of mmap() for reading data files. By default, mmap() is used for 64-bit arches and pread() is used for 32-bit arches, since they cannot read data files bigger than 2^32 bytes in memory. mmap() is usually faster for reading small data chunks than pread()
   -http.connTimeout duration
-    	Incoming connections to -httpListenAddr are closed after the configured timeout. This may help evenly spreading load among a cluster of services behind TCP-level load balancer. Zero value disables closing of incoming connections (default 2m0s)
+        Incoming connections to -httpListenAddr are closed after the configured timeout. This may help evenly spreading load among a cluster of services behind TCP-level load balancer. Zero value disables closing of incoming connections (default 2m0s)
   -http.disableCORS
-    	Disable CORS for all origins (*)
+        Disable CORS for all origins (*)
   -http.disableKeepAlive
-    	Whether to disable HTTP keep-alive for incoming connections at -httpListenAddr
+        Whether to disable HTTP keep-alive for incoming connections at -httpListenAddr
   -http.disableResponseCompression
-    	Disable compression of HTTP responses to save CPU resources. By default, compression is enabled to save network bandwidth
+        Disable compression of HTTP responses to save CPU resources. By default, compression is enabled to save network bandwidth
   -http.header.csp string
-    	Value for 'Content-Security-Policy' header, recommended: "default-src 'self'"
+        Value for 'Content-Security-Policy' header, recommended: "default-src 'self'"
   -http.header.frameOptions string
-    	Value for 'X-Frame-Options' header
+        Value for 'X-Frame-Options' header
   -http.header.hsts string
-    	Value for 'Strict-Transport-Security' header, recommended: 'max-age=31536000; includeSubDomains'
+        Value for 'Strict-Transport-Security' header, recommended: 'max-age=31536000; includeSubDomains'
   -http.idleConnTimeout duration
-    	Timeout for incoming idle http connections (default 1m0s)
+        Timeout for incoming idle http connections (default 1m0s)
   -http.maxGracefulShutdownDuration duration
-    	The maximum duration for a graceful shutdown of the HTTP server. A highly loaded server may require increased value for a graceful shutdown (default 7s)
+        The maximum duration for a graceful shutdown of the HTTP server. A highly loaded server may require increased value for a graceful shutdown (default 7s)
   -http.pathPrefix string
-    	An optional prefix to add to all the paths handled by http server. For example, if '-http.pathPrefix=/foo/bar' is set, then all the http requests will be handled on '/foo/bar/*' paths. This may be useful for proxied requests. See https://www.robustperception.io/using-external-urls-and-proxies-with-prometheus
+        An optional prefix to add to all the paths handled by http server. For example, if '-http.pathPrefix=/foo/bar' is set, then all the http requests will be handled on '/foo/bar/*' paths. This may be useful for proxied requests. See https://www.robustperception.io/using-external-urls-and-proxies-with-prometheus
   -http.shutdownDelay duration
-    	Optional delay before http server shutdown. During this delay, the server returns non-OK responses from /health page, so load balancers can route new requests to other servers
+        Optional delay before http server shutdown. During this delay, the server returns non-OK responses from /health page, so load balancers can route new requests to other servers
   -httpAuth.password value
-    	Password for HTTP server's Basic Auth. The authentication is disabled if -httpAuth.username is empty
-    	Flag value can be read from the given file when using -httpAuth.password=file:///abs/path/to/file or -httpAuth.password=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -httpAuth.password=http://host/path or -httpAuth.password=https://host/path
+        Password for HTTP server's Basic Auth. The authentication is disabled if -httpAuth.username is empty
+        Flag value can be read from the given file when using -httpAuth.password=file:///abs/path/to/file or -httpAuth.password=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -httpAuth.password=http://host/path or -httpAuth.password=https://host/path
   -httpAuth.username string
-    	Username for HTTP server's Basic Auth. The authentication is disabled if empty. See also -httpAuth.password
+        Username for HTTP server's Basic Auth. The authentication is disabled if empty. See also -httpAuth.password
   -httpListenAddr array
-    	TCP address to listen for incoming http requests. Set this flag to empty value in order to disable listening on any port. This mode may be useful for running multiple vlagent instances on the same server. Note that /targets and /metrics pages aren't available if -httpListenAddr=''. See also -tls and -httpListenAddr.useProxyProtocol
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        TCP address to listen for incoming http requests. Set this flag to empty value in order to disable listening on any port. This mode may be useful for running multiple vlagent instances on the same server. Note that /targets and /metrics pages aren't available if -httpListenAddr=''. See also -tls and -httpListenAddr.useProxyProtocol
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -httpListenAddr.useProxyProtocol array
-    	Whether to use proxy protocol for connections accepted at the corresponding -httpListenAddr . See https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt . With enabled proxy protocol http server cannot serve regular /metrics endpoint. Use -pushmetrics.url for metrics pushing
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to false.
+        Whether to use proxy protocol for connections accepted at the corresponding -httpListenAddr . See https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt . With enabled proxy protocol http server cannot serve regular /metrics endpoint. Use -pushmetrics.url for metrics pushing
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to false.
   -insert.disable
-    	Whether to disable /insert/* HTTP endpoints
+        Whether to disable /insert/* HTTP endpoints
   -insert.maxFieldsPerLine int
-    	The maximum number of log fields per line, which can be read by /insert/* handlers; see https://docs.victoriametrics.com/victorialogs/faq/#how-many-fields-a-single-log-entry-may-contain (default 1000)
+        The maximum number of log fields per line, which can be read by /insert/* handlers; see https://docs.victoriametrics.com/victorialogs/faq/#how-many-fields-a-single-log-entry-may-contain (default 1000)
   -insert.maxLineSizeBytes size
-    	The maximum size of a single line, which can be read by /insert/* handlers; see https://docs.victoriametrics.com/victorialogs/faq/#what-length-a-log-record-is-expected-to-have
-    	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 262144)
+        The maximum size of a single line, which can be read by /insert/* handlers; see https://docs.victoriametrics.com/victorialogs/faq/#what-length-a-log-record-is-expected-to-have
+        Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 262144)
   -insert.maxQueueDuration duration
-    	The maximum duration to wait in the queue when -maxConcurrentInserts concurrent insert requests are executed (default 1m0s)
+        The maximum duration to wait in the queue when -maxConcurrentInserts concurrent insert requests are executed (default 1m0s)
   -internStringCacheExpireDuration duration
-    	The expiry duration for caches for interned strings. See https://en.wikipedia.org/wiki/String_interning . See also -internStringMaxLen and -internStringDisableCache (default 6m0s)
+        The expiry duration for caches for interned strings. See https://en.wikipedia.org/wiki/String_interning . See also -internStringMaxLen and -internStringDisableCache (default 6m0s)
   -internStringDisableCache
-    	Whether to disable caches for interned strings. This may reduce memory usage at the cost of higher CPU usage. See https://en.wikipedia.org/wiki/String_interning . See also -internStringCacheExpireDuration and -internStringMaxLen
+        Whether to disable caches for interned strings. This may reduce memory usage at the cost of higher CPU usage. See https://en.wikipedia.org/wiki/String_interning . See also -internStringCacheExpireDuration and -internStringMaxLen
   -internStringMaxLen int
-    	The maximum length for strings to intern. A lower limit may save memory at the cost of higher CPU usage. See https://en.wikipedia.org/wiki/String_interning . See also -internStringDisableCache and -internStringCacheExpireDuration (default 500)
+        The maximum length for strings to intern. A lower limit may save memory at the cost of higher CPU usage. See https://en.wikipedia.org/wiki/String_interning . See also -internStringDisableCache and -internStringCacheExpireDuration (default 500)
   -internalinsert.disable
-    	Whether to disable /internal/insert HTTP endpoint
+        Whether to disable /internal/insert HTTP endpoint
   -internalinsert.maxRequestSize size
-    	The maximum size in bytes of a single request, which can be accepted at /internal/insert HTTP endpoint
-    	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
+        The maximum size in bytes of a single request, which can be accepted at /internal/insert HTTP endpoint
+        Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
   -journald.ignoreFields array
-    	Comma-separated list of fields to ignore for logs ingested over journald protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/journald/#dropping-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Comma-separated list of fields to ignore for logs ingested over journald protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/journald/#dropping-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -journald.includeEntryMetadata
-    	Include Journald fields with double underscore prefixes
+        Include Journald fields with double underscore prefixes
   -journald.streamFields array
-    	Comma-separated list of fields to use as log stream fields for logs ingested over journald protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/journald/#stream-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Comma-separated list of fields to use as log stream fields for logs ingested over journald protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/journald/#stream-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -journald.tenantID string
-    	TenantID for logs ingested via the Journald endpoint. See https://docs.victoriametrics.com/victorialogs/data-ingestion/journald/#multitenancy (default "0:0")
+        TenantID for logs ingested via the Journald endpoint. See https://docs.victoriametrics.com/victorialogs/data-ingestion/journald/#multitenancy (default "0:0")
   -journald.timeField string
-    	Field to use as a log timestamp for logs ingested via journald protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/journald/#time-field (default "__REALTIME_TIMESTAMP")
+        Field to use as a log timestamp for logs ingested via journald protocol. See https://docs.victoriametrics.com/victorialogs/data-ingestion/journald/#time-field (default "__REALTIME_TIMESTAMP")
   -loggerDisableTimestamps
-    	Whether to disable writing timestamps in logs
+        Whether to disable writing timestamps in logs
   -loggerErrorsPerSecondLimit int
-    	Per-second limit on the number of ERROR messages. If more than the given number of errors are emitted per second, the remaining errors are suppressed. Zero values disable the rate limit
+        Per-second limit on the number of ERROR messages. If more than the given number of errors are emitted per second, the remaining errors are suppressed. Zero values disable the rate limit
   -loggerFormat string
-    	Format for logs. Possible values: default, json (default "default")
+        Format for logs. Possible values: default, json (default "default")
   -loggerJSONFields string
-    	Allows renaming fields in JSON formatted logs. Example: "ts:timestamp,msg:message" renames "ts" to "timestamp" and "msg" to "message". Supported fields: ts, level, caller, msg
+        Allows renaming fields in JSON formatted logs. Example: "ts:timestamp,msg:message" renames "ts" to "timestamp" and "msg" to "message". Supported fields: ts, level, caller, msg
   -loggerLevel string
-    	Minimum level of errors to log. Possible values: INFO, WARN, ERROR, FATAL, PANIC (default "INFO")
+        Minimum level of errors to log. Possible values: INFO, WARN, ERROR, FATAL, PANIC (default "INFO")
   -loggerMaxArgLen int
-    	The maximum length of a single logged argument. Longer arguments are replaced with 'arg_start..arg_end', where 'arg_start' and 'arg_end' is prefix and suffix of the arg with the length not exceeding -loggerMaxArgLen / 2 (default 5000)
+        The maximum length of a single logged argument. Longer arguments are replaced with 'arg_start..arg_end', where 'arg_start' and 'arg_end' is prefix and suffix of the arg with the length not exceeding -loggerMaxArgLen / 2 (default 5000)
   -loggerOutput string
-    	Output for the logs. Supported values: stderr, stdout (default "stderr")
+        Output for the logs. Supported values: stderr, stdout (default "stderr")
   -loggerTimezone string
-    	Timezone to use for timestamps in logs. Timezone must be a valid IANA Time Zone. For example: America/New_York, Europe/Berlin, Etc/GMT+3 or Local (default "UTC")
+        Timezone to use for timestamps in logs. Timezone must be a valid IANA Time Zone. For example: America/New_York, Europe/Berlin, Etc/GMT+3 or Local (default "UTC")
   -loggerWarnsPerSecondLimit int
-    	Per-second limit on the number of WARN messages. If more than the given number of warns are emitted per second, then the remaining warns are suppressed. Zero values disable the rate limit
+        Per-second limit on the number of WARN messages. If more than the given number of warns are emitted per second, then the remaining warns are suppressed. Zero values disable the rate limit
   -loki.disableMessageParsing
-    	Whether to disable automatic parsing of JSON-encoded log fields inside Loki log message into distinct log fields
+        Whether to disable automatic parsing of JSON-encoded log fields inside Loki log message into distinct log fields
   -loki.maxRequestSize size
-    	The maximum size in bytes of a single Loki request
-    	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
+        The maximum size in bytes of a single Loki request
+        Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
   -maxConcurrentInserts int
-    	The maximum number of concurrent insert requests. Set higher value when clients send data over slow networks. Default value depends on the number of available CPU cores. It should work fine in most cases since it minimizes resource usage. See also -insert.maxQueueDuration (default 20)
+        The maximum number of concurrent insert requests. Set higher value when clients send data over slow networks. Default value depends on the number of available CPU cores. It should work fine in most cases since it minimizes resource usage. See also -insert.maxQueueDuration (default 20)
   -memory.allowedBytes size
-    	Allowed size of system memory VictoriaMetrics caches may occupy. This option overrides -memory.allowedPercent if set to a non-zero value. Too low a value may increase the cache miss rate usually resulting in higher CPU and disk IO usage. Too high a value may evict too much data from the OS page cache resulting in higher disk IO usage
-    	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 0)
+        Allowed size of system memory VictoriaMetrics caches may occupy. This option overrides -memory.allowedPercent if set to a non-zero value. Too low a value may increase the cache miss rate usually resulting in higher CPU and disk IO usage. Too high a value may evict too much data from the OS page cache resulting in higher disk IO usage
+        Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 0)
   -memory.allowedPercent float
-    	Allowed percent of system memory VictoriaMetrics caches may occupy. See also -memory.allowedBytes. Too low a value may increase cache miss rate usually resulting in higher CPU and disk IO usage. Too high a value may evict too much data from the OS page cache which will result in higher disk IO usage (default 60)
+        Allowed percent of system memory VictoriaMetrics caches may occupy. See also -memory.allowedBytes. Too low a value may increase cache miss rate usually resulting in higher CPU and disk IO usage. Too high a value may evict too much data from the OS page cache which will result in higher disk IO usage (default 60)
   -metrics.exposeMetadata
-    	Whether to expose TYPE and HELP metadata at the /metrics page, which is exposed at -httpListenAddr . The metadata may be needed when the /metrics page is consumed by systems, which require this information. For example, Managed Prometheus in Google Cloud - https://cloud.google.com/stackdriver/docs/managed-prometheus/troubleshooting#missing-metric-type
+        Whether to expose TYPE and HELP metadata at the /metrics page, which is exposed at -httpListenAddr . The metadata may be needed when the /metrics page is consumed by systems, which require this information. For example, Managed Prometheus in Google Cloud - https://cloud.google.com/stackdriver/docs/managed-prometheus/troubleshooting#missing-metric-type
   -metricsAuthKey value
-    	Auth key for /metrics endpoint. It must be passed via authKey query arg. It overrides -httpAuth.*
-    	Flag value can be read from the given file when using -metricsAuthKey=file:///abs/path/to/file or -metricsAuthKey=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -metricsAuthKey=http://host/path or -metricsAuthKey=https://host/path
+        Auth key for /metrics endpoint. It must be passed via authKey query arg. It overrides -httpAuth.*
+        Flag value can be read from the given file when using -metricsAuthKey=file:///abs/path/to/file or -metricsAuthKey=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -metricsAuthKey=http://host/path or -metricsAuthKey=https://host/path
   -opentelemetry.maxRequestSize size
-    	The maximum size in bytes of a single OpenTelemetry request
-    	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
+        The maximum size in bytes of a single OpenTelemetry request
+        Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 67108864)
   -pprofAuthKey value
-    	Auth key for /debug/pprof/* endpoints. It must be passed via authKey query arg. It overrides -httpAuth.*
-    	Flag value can be read from the given file when using -pprofAuthKey=file:///abs/path/to/file or -pprofAuthKey=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -pprofAuthKey=http://host/path or -pprofAuthKey=https://host/path
+        Auth key for /debug/pprof/* endpoints. It must be passed via authKey query arg. It overrides -httpAuth.*
+        Flag value can be read from the given file when using -pprofAuthKey=file:///abs/path/to/file or -pprofAuthKey=file://./relative/path/to/file . Flag value can be read from the given http/https url when using -pprofAuthKey=http://host/path or -pprofAuthKey=https://host/path
   -pushmetrics.disableCompression
-    	Whether to disable request body compression when pushing metrics to every -pushmetrics.url
+        Whether to disable request body compression when pushing metrics to every -pushmetrics.url
   -pushmetrics.extraLabel array
-    	Optional labels to add to metrics pushed to every -pushmetrics.url . For example, -pushmetrics.extraLabel='instance="foo"' adds instance="foo" label to all the metrics pushed to every -pushmetrics.url
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional labels to add to metrics pushed to every -pushmetrics.url . For example, -pushmetrics.extraLabel='instance="foo"' adds instance="foo" label to all the metrics pushed to every -pushmetrics.url
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -pushmetrics.header array
-    	Optional HTTP request header to send to every -pushmetrics.url . For example, -pushmetrics.header='Authorization: Basic foobar' adds 'Authorization: Basic foobar' header to every request to every -pushmetrics.url
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional HTTP request header to send to every -pushmetrics.url . For example, -pushmetrics.header='Authorization: Basic foobar' adds 'Authorization: Basic foobar' header to every request to every -pushmetrics.url
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -pushmetrics.interval duration
-    	Interval for pushing metrics to every -pushmetrics.url (default 10s)
+        Interval for pushing metrics to every -pushmetrics.url (default 10s)
   -pushmetrics.url array
-    	Optional URL to push metrics exposed at /metrics page. See https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#push-metrics . By default, metrics exposed at /metrics page aren't pushed to any remote storage
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional URL to push metrics exposed at /metrics page. See https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#push-metrics . By default, metrics exposed at /metrics page aren't pushed to any remote storage
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -remoteWrite.basicAuth.password array
-    	Optional basic auth password to use for the corresponding -remoteWrite.url
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional basic auth password to use for the corresponding -remoteWrite.url
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -remoteWrite.basicAuth.passwordFile array
-    	Optional path to basic auth password to use for the corresponding -remoteWrite.url. The file is re-read every second
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional path to basic auth password to use for the corresponding -remoteWrite.url. The file is re-read every second
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -remoteWrite.basicAuth.username array
-    	Optional basic auth username to use for the corresponding -remoteWrite.url
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional basic auth username to use for the corresponding -remoteWrite.url
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -remoteWrite.bearerToken array
-    	Optional bearer auth token to use for the corresponding -remoteWrite.url
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional bearer auth token to use for the corresponding -remoteWrite.url
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -remoteWrite.bearerTokenFile array
-    	Optional path to bearer token file to use for the corresponding -remoteWrite.url. The token is re-read from the file every second
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional path to bearer token file to use for the corresponding -remoteWrite.url. The token is re-read from the file every second
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -remoteWrite.flushInterval duration
-    	Interval for flushing the data to remote storage. This option takes effect only when less than 2MB of data per second are pushed to -remoteWrite.url (default 1s)
+        Interval for flushing the data to remote storage. This option takes effect only when less than 2MB of data per second are pushed to -remoteWrite.url (default 1s)
   -remoteWrite.headers array
-    	Optional HTTP headers to send with each request to the corresponding -remoteWrite.url. For example, -remoteWrite.headers='My-Auth:foobar' would send 'My-Auth: foobar' HTTP header with every request to the corresponding -remoteWrite.url. Multiple headers must be delimited by '^^': -remoteWrite.headers='header1:value1^^header2:value2'
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional HTTP headers to send with each request to the corresponding -remoteWrite.url. For example, -remoteWrite.headers='My-Auth:foobar' would send 'My-Auth: foobar' HTTP header with every request to the corresponding -remoteWrite.url. Multiple headers must be delimited by '^^': -remoteWrite.headers='header1:value1^^header2:value2'
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -remoteWrite.maxBlockSize size
-    	The maximum block size to send to remote storage. Bigger blocks may improve performance at the cost of the increased memory usage.
-    	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 8388608)
+        The maximum block size to send to remote storage. Bigger blocks may improve performance at the cost of the increased memory usage.
+        Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 8388608)
   -remoteWrite.maxDiskUsagePerURL array
-    	The maximum file-based buffer size in bytes at -remoteWrite.tmpDataPath for each -remoteWrite.url. When buffer size reaches the configured maximum, then old data is dropped when adding new data to the buffer. Buffered data is stored in ~500MB chunks. It is recommended to set the value for this flag to a multiple of the block size 500MB. Disk usage is unlimited if the value is set to 0
-    	Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB. (default 0)
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to default value.
+        The maximum file-based buffer size in bytes at -remoteWrite.tmpDataPath for each -remoteWrite.url. When buffer size reaches the configured maximum, then old data is dropped when adding new data to the buffer. Buffered data is stored in ~500MB chunks. It is recommended to set the value for this flag to a multiple of the block size 500MB. Disk usage is unlimited if the value is set to 0
+        Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB. (default 0)
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to default value.
   -remoteWrite.oauth2.clientID array
-    	Optional OAuth2 clientID to use for the corresponding -remoteWrite.url
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional OAuth2 clientID to use for the corresponding -remoteWrite.url
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -remoteWrite.oauth2.clientSecret array
-    	Optional OAuth2 clientSecret to use for the corresponding -remoteWrite.url
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional OAuth2 clientSecret to use for the corresponding -remoteWrite.url
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -remoteWrite.oauth2.clientSecretFile array
-    	Optional OAuth2 clientSecretFile to use for the corresponding -remoteWrite.url
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional OAuth2 clientSecretFile to use for the corresponding -remoteWrite.url
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -remoteWrite.oauth2.endpointParams array
-    	Optional OAuth2 endpoint parameters to use for the corresponding -remoteWrite.url . The endpoint parameters must be set in JSON format: {"param1":"value1",...,"paramN":"valueN"}
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional OAuth2 endpoint parameters to use for the corresponding -remoteWrite.url . The endpoint parameters must be set in JSON format: {"param1":"value1",...,"paramN":"valueN"}
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -remoteWrite.oauth2.scopes array
-    	Optional OAuth2 scopes to use for the corresponding -remoteWrite.url. Scopes must be delimited by ';'
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional OAuth2 scopes to use for the corresponding -remoteWrite.url. Scopes must be delimited by ';'
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -remoteWrite.oauth2.tokenUrl array
-    	Optional OAuth2 tokenURL to use for the corresponding -remoteWrite.url
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional OAuth2 tokenURL to use for the corresponding -remoteWrite.url
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -remoteWrite.proxyURL array
-    	Optional proxy URL for writing data to the corresponding -remoteWrite.url. Supported proxies: http, https, socks5. Example: -remoteWrite.proxyURL=socks5://proxy:1234
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional proxy URL for writing data to the corresponding -remoteWrite.url. Supported proxies: http, https, socks5. Example: -remoteWrite.proxyURL=socks5://proxy:1234
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -remoteWrite.queues int
-    	The number of concurrent queues to each -remoteWrite.url. Set more queues if default number of queues isn't enough for sending high volume of collected data to remote storage. Default value depends on the number of available CPU cores. It should work fine in most cases since it minimizes resource usage (default 20)
+        The number of concurrent queues to each -remoteWrite.url. Set more queues if default number of queues isn't enough for sending high volume of collected data to remote storage. Default value depends on the number of available CPU cores. It should work fine in most cases since it minimizes resource usage (default 20)
   -remoteWrite.rateLimit array
-    	Optional rate limit in bytes per second for data sent to the corresponding -remoteWrite.url. By default, the rate limit is disabled. It can be useful for limiting load on remote storage when big amounts of buffered data  (default 0)
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to default value.
+        Optional rate limit in bytes per second for data sent to the corresponding -remoteWrite.url. By default, the rate limit is disabled. It can be useful for limiting load on remote storage when big amounts of buffered data  (default 0)
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to default value.
   -remoteWrite.retryMaxTime array
-    	The max time spent on retry attempts to send a block of data to the corresponding -remoteWrite.url. Change this value if it is expected for -remoteWrite.url to be unreachable for more than -remoteWrite.retryMaxTime. See also -remoteWrite.retryMinInterval (default 1m0s)
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to default value.
+        The max time spent on retry attempts to send a block of data to the corresponding -remoteWrite.url. Change this value if it is expected for -remoteWrite.url to be unreachable for more than -remoteWrite.retryMaxTime. See also -remoteWrite.retryMinInterval (default 1m0s)
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to default value.
   -remoteWrite.retryMinInterval array
-    	The minimum delay between retry attempts to send a block of data to the corresponding -remoteWrite.url. Every next retry attempt will double the delay to prevent hammering of remote database. See also -remoteWrite.retryMaxTime (default 1s)
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to default value.
+        The minimum delay between retry attempts to send a block of data to the corresponding -remoteWrite.url. Every next retry attempt will double the delay to prevent hammering of remote database. See also -remoteWrite.retryMaxTime (default 1s)
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to default value.
   -remoteWrite.sendTimeout array
-    	Timeout for sending a single block of data to the corresponding -remoteWrite.url (default 1m0s)
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to default value.
+        Timeout for sending a single block of data to the corresponding -remoteWrite.url (default 1m0s)
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to default value.
   -remoteWrite.showURL
-    	Whether to show -remoteWrite.url in the exported metrics. It is hidden by default, since it can contain sensitive info such as auth key
+        Whether to show -remoteWrite.url in the exported metrics. It is hidden by default, since it can contain sensitive info such as auth key
   -remoteWrite.tlsCAFile array
-    	Optional path to TLS CA file to use for verifying connections to the corresponding -remoteWrite.url. By default, system CA is used
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional path to TLS CA file to use for verifying connections to the corresponding -remoteWrite.url. By default, system CA is used
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -remoteWrite.tlsCertFile array
-    	Optional path to client-side TLS certificate file to use when connecting to the corresponding -remoteWrite.url
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional path to client-side TLS certificate file to use when connecting to the corresponding -remoteWrite.url
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -remoteWrite.tlsHandshakeTimeout array
-    	The timeout for establishing tls connections to the corresponding -remoteWrite.url (default 20s)
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to default value.
+        The timeout for establishing tls connections to the corresponding -remoteWrite.url (default 20s)
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to default value.
   -remoteWrite.tlsInsecureSkipVerify array
-    	Whether to skip tls verification when connecting to the corresponding -remoteWrite.url
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to false.
+        Whether to skip tls verification when connecting to the corresponding -remoteWrite.url
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to false.
   -remoteWrite.tlsKeyFile array
-    	Optional path to client-side TLS certificate key to use when connecting to the corresponding -remoteWrite.url
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional path to client-side TLS certificate key to use when connecting to the corresponding -remoteWrite.url
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -remoteWrite.tlsServerName array
-    	Optional TLS server name to use for connections to the corresponding -remoteWrite.url. By default, the server name from -remoteWrite.url is used
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional TLS server name to use for connections to the corresponding -remoteWrite.url. By default, the server name from -remoteWrite.url is used
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -remoteWrite.tmpDataPath string
-    	Path to directory for storing pending data, which isn't sent to the configured -remoteWrite.url . See also -remoteWrite.maxDiskUsagePerURL (default "vlagent-remotewrite-data")
+        Path to directory for storing pending data, which isn't sent to the configured -remoteWrite.url . See also -remoteWrite.maxDiskUsagePerURL (default "vlagent-remotewrite-data")
   -remoteWrite.url array
-    	Remote storage URL to write data to. It must support VictoriaLogs native protocol. Example url: http://<victorialogs-host>:9428/internal/insert. Pass multiple -remoteWrite.url options in order to replicate the collected data to multiple remote storage systems.
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Remote storage URL to write data to. It must support VictoriaLogs native protocol. Example url: http://<victorialogs-host>:9428/internal/insert. Pass multiple -remoteWrite.url options in order to replicate the collected data to multiple remote storage systems.
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.compressMethod.tcp array
-    	Compression method for syslog messages received at the corresponding -syslog.listenAddr.tcp. Supported values: none, gzip, deflate. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#compression
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Compression method for syslog messages received at the corresponding -syslog.listenAddr.tcp. Supported values: none, gzip, deflate. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#compression
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.compressMethod.udp array
-    	Compression method for syslog messages received at the corresponding -syslog.listenAddr.udp. Supported values: none, gzip, deflate. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#compression
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Compression method for syslog messages received at the corresponding -syslog.listenAddr.udp. Supported values: none, gzip, deflate. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#compression
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.decolorizeFields.tcp array
-    	Fields to remove ANSI color codes across logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#decolorizing-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Fields to remove ANSI color codes across logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#decolorizing-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.decolorizeFields.udp array
-    	Fields to remove ANSI color codes across logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#decolorizing-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Fields to remove ANSI color codes across logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#decolorizing-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.extraFields.tcp array
-    	Fields to add to logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#adding-extra-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Fields to add to logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#adding-extra-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.extraFields.udp array
-    	Fields to add to logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#adding-extra-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Fields to add to logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#adding-extra-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.ignoreFields.tcp array
-    	Fields to ignore at logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#dropping-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Fields to ignore at logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#dropping-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.ignoreFields.udp array
-    	Fields to ignore at logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#dropping-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Fields to ignore at logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#dropping-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.listenAddr.tcp array
-    	Comma-separated list of TCP addresses to listen to for Syslog messages. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Comma-separated list of TCP addresses to listen to for Syslog messages. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.listenAddr.udp array
-    	Comma-separated list of UDP address to listen to for Syslog messages. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Comma-separated list of UDP address to listen to for Syslog messages. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.streamFields.tcp array
-    	Fields to use as log stream labels for logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#stream-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Fields to use as log stream labels for logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#stream-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.streamFields.udp array
-    	Fields to use as log stream labels for logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#stream-fields
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Fields to use as log stream labels for logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#stream-fields
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.tenantID.tcp array
-    	TenantID for logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#multitenancy
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        TenantID for logs ingested via the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#multitenancy
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.tenantID.udp array
-    	TenantID for logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#multitenancy
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        TenantID for logs ingested via the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#multitenancy
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.timezone string
-    	Timezone to use when parsing timestamps in RFC3164 syslog messages. Timezone must be a valid IANA Time Zone. For example: America/New_York, Europe/Berlin, Etc/GMT+3 . See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/ (default "Local")
+        Timezone to use when parsing timestamps in RFC3164 syslog messages. Timezone must be a valid IANA Time Zone. For example: America/New_York, Europe/Berlin, Etc/GMT+3 . See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/ (default "Local")
   -syslog.tls array
-    	Whether to enable TLS for receiving syslog messages at the corresponding -syslog.listenAddr.tcp. The corresponding -syslog.tlsCertFile and -syslog.tlsKeyFile must be set if -syslog.tls is set. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to false.
+        Whether to enable TLS for receiving syslog messages at the corresponding -syslog.listenAddr.tcp. The corresponding -syslog.tlsCertFile and -syslog.tlsKeyFile must be set if -syslog.tls is set. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to false.
   -syslog.tlsCertFile array
-    	Path to file with TLS certificate for the corresponding -syslog.listenAddr.tcp if the corresponding -syslog.tls is set. Prefer ECDSA certs instead of RSA certs as RSA certs are slower. The provided certificate file is automatically re-read every second, so it can be dynamically updated. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Path to file with TLS certificate for the corresponding -syslog.listenAddr.tcp if the corresponding -syslog.tls is set. Prefer ECDSA certs instead of RSA certs as RSA certs are slower. The provided certificate file is automatically re-read every second, so it can be dynamically updated. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.tlsCipherSuites array
-    	Optional list of TLS cipher suites for -syslog.listenAddr.tcp if -syslog.tls is set. See the list of supported cipher suites at https://pkg.go.dev/crypto/tls#pkg-constants . See also https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional list of TLS cipher suites for -syslog.listenAddr.tcp if -syslog.tls is set. See the list of supported cipher suites at https://pkg.go.dev/crypto/tls#pkg-constants . See also https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.tlsKeyFile array
-    	Path to file with TLS key for the corresponding -syslog.listenAddr.tcp if the corresponding -syslog.tls is set. The provided key file is automatically re-read every second, so it can be dynamically updated. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Path to file with TLS key for the corresponding -syslog.listenAddr.tcp if the corresponding -syslog.tls is set. The provided key file is automatically re-read every second, so it can be dynamically updated. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -syslog.tlsMinVersion string
-    	The minimum TLS version to use for -syslog.listenAddr.tcp if -syslog.tls is set. Supported values: TLS10, TLS11, TLS12, TLS13. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security (default "TLS13")
+        The minimum TLS version to use for -syslog.listenAddr.tcp if -syslog.tls is set. Supported values: TLS10, TLS11, TLS12, TLS13. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#security (default "TLS13")
   -syslog.useLocalTimestamp.tcp array
-    	Whether to use local timestamp instead of the original timestamp for the ingested syslog messages at the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#log-timestamps
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to false.
+        Whether to use local timestamp instead of the original timestamp for the ingested syslog messages at the corresponding -syslog.listenAddr.tcp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#log-timestamps
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to false.
   -syslog.useLocalTimestamp.udp array
-    	Whether to use local timestamp instead of the original timestamp for the ingested syslog messages at the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#log-timestamps
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to false.
+        Whether to use local timestamp instead of the original timestamp for the ingested syslog messages at the corresponding -syslog.listenAddr.udp. See https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#log-timestamps
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to false.
   -tls array
-    	Whether to enable TLS for incoming HTTP requests at the given -httpListenAddr (aka https). -tlsCertFile and -tlsKeyFile must be set if -tls is set. See also -mtls
-    	Supports array of values separated by comma or specified via multiple flags.
-    	Empty values are set to false.
+        Whether to enable TLS for incoming HTTP requests at the given -httpListenAddr (aka https). -tlsCertFile and -tlsKeyFile must be set if -tls is set. See also -mtls
+        Supports array of values separated by comma or specified via multiple flags.
+        Empty values are set to false.
   -tlsCertFile array
-    	Path to file with TLS certificate for the corresponding -httpListenAddr if -tls is set. Prefer ECDSA certs instead of RSA certs as RSA certs are slower. The provided certificate file is automatically re-read every second, so it can be dynamically updated. See also -tlsAutocertHosts
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Path to file with TLS certificate for the corresponding -httpListenAddr if -tls is set. Prefer ECDSA certs instead of RSA certs as RSA certs are slower. The provided certificate file is automatically re-read every second, so it can be dynamically updated. See also -tlsAutocertHosts
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -tlsCipherSuites array
-    	Optional list of TLS cipher suites for incoming requests over HTTPS if -tls is set. See the list of supported cipher suites at https://pkg.go.dev/crypto/tls#pkg-constants
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional list of TLS cipher suites for incoming requests over HTTPS if -tls is set. See the list of supported cipher suites at https://pkg.go.dev/crypto/tls#pkg-constants
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -tlsKeyFile array
-    	Path to file with TLS key for the corresponding -httpListenAddr if -tls is set. The provided key file is automatically re-read every second, so it can be dynamically updated. See also -tlsAutocertHosts
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Path to file with TLS key for the corresponding -httpListenAddr if -tls is set. The provided key file is automatically re-read every second, so it can be dynamically updated. See also -tlsAutocertHosts
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -tlsMinVersion array
-    	Optional minimum TLS version to use for the corresponding -httpListenAddr if -tls is set. Supported values: TLS10, TLS11, TLS12, TLS13
-    	Supports an array of values separated by comma or specified via multiple flags.
-    	Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
+        Optional minimum TLS version to use for the corresponding -httpListenAddr if -tls is set. Supported values: TLS10, TLS11, TLS12, TLS13
+        Supports an array of values separated by comma or specified via multiple flags.
+        Value can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -version
-    	Show VictoriaMetrics version
+        Show VictoriaMetrics version
 ```

--- a/docs/victorialogs/vmalert.md
+++ b/docs/victorialogs/vmalert.md
@@ -15,14 +15,15 @@ aliases:
 
 [vmalert](https://docs.victoriametrics.com/victoriametrics/vmalert/){{% available_from "v1.106.0" %}} integrates with VictoriaLogs {{% available_from "v0.36.0" "logs" %}} via stats APIs [`/select/logsql/stats_query`](https://docs.victoriametrics.com/victorialogs/querying/#querying-log-stats)
 and [`/select/logsql/stats_query_range`](https://docs.victoriametrics.com/victorialogs/querying/#querying-log-range-stats).
-These endpoints return the log stats in a format compatible with [Prometheus querying API](https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries). 
+These endpoints return the log stats in a format compatible with [Prometheus querying API](https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries).
 It allows using VictoriaLogs as the datasource in vmalert, creating alerting and recording rules via [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/).
 
-_Note: This page provides only integration instructions for vmalert and VictoriaLogs. See the full textbook for vmalert [here](https://docs.victoriametrics.com/victoriametrics/vmalert/)._
+_Note: This page provides only integration instructions for vmalert and VictoriaLogs. See the full textbook for vmalert [here](https://docs.victoriametrics.com/victoriametrics/vmalert/).
 
 ## Quick Start
 
 Run vmalert with the following settings:
+
 ```sh
 ./bin/vmalert -rule=alert.rules                  \  # Path to the files or http url with alerting and/or recording rules in YAML format
     -datasource.url=http://victorialogs:9428     \  # VictoriaLogs address
@@ -31,11 +32,11 @@ Run vmalert with the following settings:
     -remoteRead.url=http://victoriametrics:8428  \  # Prometheus HTTP API compatible datasource to restore alerts state from
 ```
 
-> Note: By default, vmalert assumes all configured rules have `prometheus` type and will validate them accordingly. 
-> For rules in [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/) specify `type: vlogs` on [Group level](#groups). 
+> Note: By default, vmalert assumes all configured rules have `prometheus` type and will validate them accordingly.
+> For rules in [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/) specify `type: vlogs` on [Group level](#groups).
 > Or set `-rule.defaultRuleType=vlogs` cmd-line flag to change the default rule type.
 
-Each `-rule` file may contain arbitrary number of [groups](https://docs.victoriametrics.com/victoriametrics/vmalert/#groups). 
+Each `-rule` file may contain arbitrary number of [groups](https://docs.victoriametrics.com/victoriametrics/vmalert/#groups).
 See examples in [Groups](#groups) section. See the full list of configuration flags and their descriptions in [configuration](#configuration) section.
 
 With configuration example above, vmalert will perform the following interactions:
@@ -52,7 +53,7 @@ With configuration example above, vmalert will perform the following interaction
 
 ### Flags
 
-For a complete list of command-line flags, visit https://docs.victoriametrics.com/victoriametrics/vmalert/#flags or execute `./vmalert --help` command.
+For a complete list of command-line flags, visit [https://docs.victoriametrics.com/victoriametrics/vmalert/#flags](https://docs.victoriametrics.com/victoriametrics/vmalert/#flags) or execute `./vmalert --help` command.
 The following are key flags related to integration with VictoriaLogs:
 
 ```shellhelp
@@ -98,6 +99,7 @@ Check the complete group attributes [here](https://docs.victoriametrics.com/vict
 #### Alerting rules
 
 Examples:
+
 ```yaml
 groups:
   - name: ServiceLog
@@ -122,6 +124,7 @@ groups:
 #### Recording rules
 
 Examples:
+
 ```yaml
 groups:
   - name: RequestCount
@@ -139,6 +142,7 @@ groups:
 It's recommended to omit the [time filter](https://docs.victoriametrics.com/victorialogs/logsql/#time-filter) in rule expression.
 By default, vmalert automatically appends the time filter `_time: <group_interval>` to the expression.
 For instance, the rule below will be evaluated every 5 minutes, and will return the result with logs from the last 5 minutes:
+
 ```yaml
 groups:
     - name: Requests
@@ -153,6 +157,7 @@ groups:
 
 User can specify a customized time filter if needed. For example, rule below will be evaluated every 5 minutes,
 but will calculate result over the logs from the last 10 minutes.
+
 ```yaml
 groups:
     - name: Requests
@@ -169,7 +174,8 @@ _Please note, vmalert doesn't support [backfilling](#rules-backfilling) for rule
 
 ## Rules backfilling
 
-vmalert supports alerting and recording rules backfilling (aka replay) against VictoriaLogs as the datasource. 
+vmalert supports alerting and recording rules backfilling (aka replay) against VictoriaLogs as the datasource.
+
 ```sh
 ./bin/vmalert -rule=path/to/your.rules \        # path to files with rules you usually use with vmalert
     -datasource.url=http://localhost:9428 \     # VictoriaLogs address
@@ -183,7 +189,7 @@ See more details about backfilling [here](https://docs.victoriametrics.com/victo
 
 ## Performance tip
 
-LogsQL allows users to obtain multiple stats from a single expression. For instance, the following query calculates 
+LogsQL allows users to obtain multiple stats from a single expression. For instance, the following query calculates
 50th, 90th and 99th percentiles for the `request_duration_seconds` field over logs for the last 5 minutes:
 
 ```logsql
@@ -194,6 +200,7 @@ _time:5m | stats
 ```
 
 This expression can also be used in recording rules as follows:
+
 ```yaml
 groups:
   - name: requestDuration
@@ -205,6 +212,7 @@ groups:
 ```
 
 This rule generates three metrics per service in each evaluation:
+
 ```
 requestDurationQuantile{stats_result="p50", service="service-1"}
 requestDurationQuantile{stats_result="p90", service="service-1"}
@@ -225,6 +233,7 @@ For additional tips on writing LogsQL, refer to this [doc](https://docs.victoria
 vmalert doesn't support multi-tenancy for VictoriaLogs in the same way as it [supports it for VictoriaMetrics in ENT version](https://docs.victoriametrics.com/victoriametrics/vmalert/#multitenancy).
 However, it is possible to specify the queried tenant from VictoriaLogs datasource via `headers` param in [Group config](https://docs.victoriametrics.com/victoriametrics/vmalert/#groups).
 For example, the following config will execute all the rules within the group against tenant with `AccountID=1` and `ProjectID=2`:
+
 ```yaml
     groups:
     - name: MyGroup
@@ -233,15 +242,20 @@ For example, the following config will execute all the rules within the group ag
       - "ProjectID: 2"
       rules: ...
 ```
+
 By default, vmalert persists all results to the specific tenant in VictoriaMetrics that specified by `-remotewrite.url`. For example, if the `-remotewrite.url=http://vminsert:8480/insert/0/prometheus/`, all data goes to tenant `0`.
 To persist different rule results to different tenants in VictoriaMetrics, there are following approaches:
-1. To use the [multitenant endpoint of vminsert](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenancy-via-labels) as the `-remoteWrite.url`, and add tenant labels under the group configuration. 
+
+1. To use the [multitenant endpoint of vminsert](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multitenancy-via-labels) as the `-remoteWrite.url`, and add tenant labels under the group configuration.
 
     For example, run vmalert with:
+
     ```
     ./bin/vmalert -datasource.url=http://localhost:9428 -remoteWrite.url=http://vminsert:8480/insert/multitenant/prometheus ...
     ```
+
     With the rules below, `recordingTenant123` will be queried from VictoriaLogs tenant `123` and persisted to tenant `123` in VictoriaMetrics, while `recordingTenant123-456:789` will be queried from VictoriaLogs tenant `124` and persisted to tenant `456:789` in VictoriaMetrics.
+
     ```
     groups:
       - name: recordingTenant123
@@ -268,10 +282,13 @@ To persist different rule results to different tenants in VictoriaMetrics, there
 2. To run [enterprise version of vmalert](https://docs.victoriametrics.com/victoriametrics/enterprise/) with `-clusterMode` enabled, and specify tenant parameter per each group.
 
     For example, run vmalert with:
+
     ```
     ./bin/vmalert -datasource.url=http://localhost:9428 -clusterMode=true -remoteWrite.url=http://vminsert:8480/ ...
     ```
+
     With the rules below, `recordingTenant123` will be queried from VictoriaLogs tenant `123` and persisted to tenant `123` in VictoriaMetrics, while `recordingTenant123-456:789` will be queried from VictoriaLogs tenant `124` and persisted to tenant `456:789` in VictoriaMetrics.
+
     ```
     groups:
       - name: recordingTenant123
@@ -300,6 +317,7 @@ But only one `-datasource.url` cmd-line flag can be specified, so it can't be co
 VictoriaMetrics and VictoriaLogs datasources have different query path prefixes, so it is possible to use
 [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/) to route requests of different types between datasources.
 See example of vmauth config for such routing below:
+
 ```yaml
     unauthorized_user:
       url_map:
@@ -310,5 +328,6 @@ See example of vmauth config for such routing below:
           - "/select/logsql/.*"
           url_prefix: "http://victorialogs:9428"
 ```
-Now, vmalert can be configured with `--datasource.url=http://vmauth:8427/` to send queries to vmauth, 
+
+Now, vmalert can be configured with `--datasource.url=http://vmauth:8427/` to send queries to vmauth,
 and vmauth will route them to the specified destinations as in configuration example above.

--- a/lib/logstorage/block.go
+++ b/lib/logstorage/block.go
@@ -162,7 +162,7 @@ func (c *column) mustWriteTo(ch *columnHeader, sw *streamWriters) {
 		bb.B = bloomFilterMarshalHashes(bb.B[:0], hashesBuf.A)
 		encoding.PutUint64s(hashesBuf)
 	} else {
-		// there is no need in ecoding bloom filter for dictionary type,
+		// there is no need in encoding bloom filter for dictionary type,
 		// since it isn't used during querying - all the dictionary values are available in ch.valuesDict
 		bb.B = bb.B[:0]
 	}

--- a/lib/logstorage/block_header.go
+++ b/lib/logstorage/block_header.go
@@ -398,7 +398,7 @@ func (csh *columnsHeader) resizeColumnHeaders(n int) []columnHeader {
 
 func (csh *columnsHeader) setColumnNames(cshIndex *columnsHeaderIndex, columnNames []string) error {
 	if len(cshIndex.columnHeadersRefs) != len(csh.columnHeaders) {
-		return fmt.Errorf("unpexected number of column headers; got %d; want %d", len(cshIndex.columnHeadersRefs), len(csh.columnHeaders))
+		return fmt.Errorf("unexpected number of column headers; got %d; want %d", len(cshIndex.columnHeadersRefs), len(csh.columnHeaders))
 	}
 	for i := range csh.columnHeaders {
 		columnNameID := cshIndex.columnHeadersRefs[i].columnNameID
@@ -959,7 +959,7 @@ type timestampsHeader struct {
 	// blockSize is the size of the timestamps block inside timestampsFilename file
 	blockSize uint64
 
-	// minTimestamp is the mimumum timestamp seen in the block in nanoseconds
+	// minTimestamp is the minimum timestamp seen in the block in nanoseconds
 	minTimestamp int64
 
 	// maxTimestamp is the maximum timestamp seen in the block in nanoseconds

--- a/lib/logstorage/block_stream_reader.go
+++ b/lib/logstorage/block_stream_reader.go
@@ -513,7 +513,7 @@ func (bsr *blockStreamReader) MustClose() {
 // getBlockStreamReader returns blockStreamReader.
 //
 // The returned blockStreamReader must be initialized with MustInit().
-// call putBlockStreamReader() when the retruend blockStreamReader is no longer needed.
+// call putBlockStreamReader() when the returned blockStreamReader is no longer needed.
 func getBlockStreamReader() *blockStreamReader {
 	v := blockStreamReaderPool.Get()
 	if v == nil {

--- a/lib/logstorage/consts.go
+++ b/lib/logstorage/consts.go
@@ -60,7 +60,7 @@ const maxColumnsHeaderIndexSize = 8 * 1024 * 1024
 
 // maxDictSizeBytes is the maximum length of all the keys in the valuesDict.
 //
-// Dict is stored in columnsHeader, which is read every time the corresponding block is scanned during search qieries.
+// Dict is stored in columnsHeader, which is read every time the corresponding block is scanned during search queries.
 // So it is better to store bigger values in regular columns in order to speed up search speed.
 const maxDictSizeBytes = 256
 

--- a/lib/logstorage/filter.go
+++ b/lib/logstorage/filter.go
@@ -9,7 +9,7 @@ type filter interface {
 	// String returns string representation of the filter
 	String() string
 
-	// udpdateNeededFields must update pf with fields needed for the filter
+	// updateNeededFields must update pf with fields needed for the filter
 	updateNeededFields(pf *prefixfilter.Filter)
 
 	// applyToBlockSearch must update bm according to the filter applied to the given bs block

--- a/lib/logstorage/filter_any_case_prefix.go
+++ b/lib/logstorage/filter_any_case_prefix.go
@@ -16,7 +16,7 @@ import (
 //
 // Example LogsQL: `fieldName:i(prefix*)` or `fieldName:i("some prefix"*)`
 //
-// A special case `fieldName:i(*)` equals to `fieldName:*` and matches non-emtpy value for the given `fieldName` field.
+// A special case `fieldName:i(*)` equals to `fieldName:*` and matches non-empty value for the given `fieldName` field.
 type filterAnyCasePrefix struct {
 	fieldName string
 	prefix    string

--- a/lib/logstorage/filter_or.go
+++ b/lib/logstorage/filter_or.go
@@ -9,7 +9,7 @@ import (
 
 // filterOr contains filters joined by OR operator.
 //
-// It is epxressed as `f1 OR f2 ... OR fN` in LogsQL.
+// It is expressed as `f1 OR f2 ... OR fN` in LogsQL.
 type filterOr struct {
 	filters []filter
 

--- a/lib/logstorage/filter_phrase.go
+++ b/lib/logstorage/filter_phrase.go
@@ -141,7 +141,7 @@ func matchIPv4ByPhrase(bs *blockSearch, ch *columnHeader, bm *bitmap, phrase str
 	}
 
 	// Slow path - the phrase may contain a part of IP address. For example, `1.23` should match `1.23.4.5` and `4.1.23.54`.
-	// We cannot compare binary represetnation of ip address and need converting
+	// We cannot compare binary representation of ip address and need converting
 	// the ip to string before searching for prefix there.
 	if !matchBloomFilterAllTokens(bs, ch, tokens) {
 		bm.resetBits()

--- a/lib/logstorage/filter_sequence.go
+++ b/lib/logstorage/filter_sequence.go
@@ -166,7 +166,7 @@ func matchIPv4BySequence(bs *blockSearch, ch *columnHeader, bm *bitmap, phrases 
 	}
 
 	// Slow path - phrases contain parts of IP address. For example, `1.23` should match `1.23.4.5` and `4.1.23.54`.
-	// We cannot compare binary represetnation of ip address and need converting
+	// We cannot compare binary representation of ip address and need converting
 	// the ip to string before searching for prefix there.
 	bb := bbPool.Get()
 	visitValues(bs, ch, bm, func(v string) bool {

--- a/lib/logstorage/filter_string_range.go
+++ b/lib/logstorage/filter_string_range.go
@@ -11,7 +11,7 @@ var maxStringRangeValue = string([]byte{255, 255, 255, 255})
 // filterStringRange matches tie given string range [minValue..maxValue)
 //
 // Note that the minValue is included in the range, while the maxValue isn't included in the range.
-// This simplifies querying distincts log sets with string_range(A, B), string_range(B, C), etc.
+// This simplifies querying distinct log sets with string_range(A, B), string_range(B, C), etc.
 //
 // Example LogsQL: `fieldName:string_range(minValue, maxValue)`
 type filterStringRange struct {

--- a/lib/logstorage/index_block_header.go
+++ b/lib/logstorage/index_block_header.go
@@ -16,7 +16,7 @@ type indexBlockHeader struct {
 	// streamID is the minimum streamID covered by the indexBlockHeader
 	streamID streamID
 
-	// minTimestamp is the mimumum timestamp seen across blocks covered by the indexBlockHeader
+	// minTimestamp is the minimum timestamp seen across blocks covered by the indexBlockHeader
 	minTimestamp int64
 
 	// maxTimestamp is the maximum timestamp seen across blocks covered by the indexBlockHeader

--- a/lib/logstorage/json_parser.go
+++ b/lib/logstorage/json_parser.go
@@ -68,7 +68,7 @@ func (p *JSONParser) ParseLogMessage(msg []byte) error {
 
 // ParseLogMessage parses the given JSON log message msg into p.Fields.
 //
-// Items in nested objects are flattenned with `k1.k2. ... .kN` key until its' length exceeds maxFieldNameLen.
+// Items in nested objects are flattened with `k1.k2. ... .kN` key until its' length exceeds maxFieldNameLen.
 //
 // The p.Fields remains valid until the next call to ParseLogMessage() or PutJSONParser().
 func (p *JSONParser) parseLogMessage(msg []byte, maxFieldNameLen int) error {

--- a/lib/logstorage/log_rows.go
+++ b/lib/logstorage/log_rows.go
@@ -548,7 +548,7 @@ func (lr *LogRows) GetRowString(idx int) string {
 // ignoreFields entries may end with '*'. In this case they match any fields with the prefix until '*'.
 //
 // decolorizeFields is a set of fields, which must be cleared from ANSI color escape sequences.
-// decolorizeFields enries may end with '*'. In this case they match any fields with the prefix until '*'.
+// decolorizeFields entries may end with '*'. In this case they match any fields with the prefix until '*'.
 //
 // extraFields is a set of fields, which must be added to all the logs passed to MustAdd().
 //

--- a/lib/logstorage/parser.go
+++ b/lib/logstorage/parser.go
@@ -596,7 +596,7 @@ func (q *Query) AddPipeLimit(n uint64) {
 	q.optimize()
 }
 
-// optimize applies various optimations to q.
+// optimize applies various optimizations to q.
 func (q *Query) optimize() {
 	q.visitSubqueries(func(q *Query) {
 		q.optimizeNoSubqueries()

--- a/lib/logstorage/parser_test.go
+++ b/lib/logstorage/parser_test.go
@@ -2876,7 +2876,7 @@ func TestQueryCanReturnLastNResults(t *testing.T) {
 		}
 		result := q.CanReturnLastNResults()
 		if result != resultExpected {
-			t.Fatalf("unexpected result for CanRetrurnLastNResults(%q); got %v; want %v", qStr, result, resultExpected)
+			t.Fatalf("unexpected result for CanReturnLastNResults(%q); got %v; want %v", qStr, result, resultExpected)
 		}
 	}
 
@@ -3161,7 +3161,7 @@ func TestQueryGetStatsByFields_Failure(t *testing.T) {
 			t.Fatalf("expecting non-nil error for ParseQuery(%q)", qStr)
 		}
 		if fields != nil {
-			t.Fatalf("expectig nil fields for ParseQuery(%q); got %q", qStr, fields)
+			t.Fatalf("expecting nil fields for ParseQuery(%q); got %q", qStr, fields)
 		}
 	}
 

--- a/lib/logstorage/pipe_copy_test.go
+++ b/lib/logstorage/pipe_copy_test.go
@@ -70,7 +70,7 @@ func TestPipeCopy(t *testing.T) {
 		},
 	})
 
-	// single row, copy from non-exsiting field
+	// single row, copy from non-existing field
 	f("copy x as b", [][]Field{
 		{
 			{"_msg", `{"foo":"bar"}`},

--- a/lib/logstorage/pipe_extract_test.go
+++ b/lib/logstorage/pipe_extract_test.go
@@ -159,7 +159,7 @@ func TestPipeExtract(t *testing.T) {
 		},
 	})
 
-	// single row, partial partern match
+	// single row, partial pattern match
 	f(`extract "foo=<bar> baz=<xx>" from x`, [][]Field{
 		{
 			{"x", `a foo="a\"b\\c" cde baz=aa`},

--- a/lib/logstorage/pipe_facets.go
+++ b/lib/logstorage/pipe_facets.go
@@ -17,7 +17,7 @@ import (
 // pipeFacetsDefaultLimit is the default number of entries pipeFacets returns per each log field.
 const pipeFacetsDefaultLimit = 10
 
-// pipeFacetsDefaulatMaxValuesPerField is the default number of unique values to track per each field.
+// pipeFacetsDefaultMaxValuesPerField is the default number of unique values to track per each field.
 const pipeFacetsDefaultMaxValuesPerField = 1000
 
 // pipeFacetsDefaultMaxValueLen is the default length of values in fields, which must be ignored when building facets.

--- a/lib/logstorage/pipe_rename_test.go
+++ b/lib/logstorage/pipe_rename_test.go
@@ -61,7 +61,7 @@ func TestPipeRename(t *testing.T) {
 		},
 	})
 
-	// single row, rename from non-exsiting field
+	// single row, rename from non-existing field
 	f("rename x as b", [][]Field{
 		{
 			{"_msg", `{"foo":"bar"}`},
@@ -168,7 +168,7 @@ func TestPipeRename(t *testing.T) {
 		},
 	})
 
-	// wildcard rename fields with some prefix to a signle field
+	// wildcard rename fields with some prefix to a single field
 	f("rename a* as foo", [][]Field{
 		{
 			{"_msg", `{"foo":"bar"}`},

--- a/lib/logstorage/pipe_stats.go
+++ b/lib/logstorage/pipe_stats.go
@@ -118,7 +118,7 @@ type statsProcessor interface {
 	// It must return the internal state size increase after the import.
 	importState(src []byte, stopCh <-chan struct{}) (int, error)
 
-	// finalizeStats must append string represetnation of the collected stats result to dst and return it.
+	// finalizeStats must append string representation of the collected stats result to dst and return it.
 	//
 	// finalizeStats must immediately return if stopCh is closed.
 	finalizeStats(sf statsFunc, dst []byte, stopCh <-chan struct{}) []byte

--- a/lib/logstorage/stats_count_uniq.go
+++ b/lib/logstorage/stats_count_uniq.go
@@ -64,7 +64,7 @@ type statsCountUniqProcessor struct {
 // the maximum number of values to track in statsCountUniqProcessor.uniqValues before switching to statsCountUniqProcessor.shards
 //
 // Too big value may slow down mergeState() across big number of CPU cores.
-// Too small value may significantly increase RAM usage when coun_uniq() is applied individually to big number of groups.
+// Too small value may significantly increase RAM usage when count_uniq() is applied individually to big number of groups.
 const statsCountUniqValuesMaxLen = 4 << 10
 
 type statsCountUniqSet struct {

--- a/lib/logstorage/stats_count_uniq_hash.go
+++ b/lib/logstorage/stats_count_uniq_hash.go
@@ -64,7 +64,7 @@ type statsCountUniqHashProcessor struct {
 // the maximum number of values to track in statsCountUniqHashProcessor.uniqValues before switching to statsCountUniqHashProcessor.shards
 //
 // Too big value may slow down mergeState() across big number of CPU cores.
-// Too small value may significantly increase RAM usage when coun_uniq_hash() is applied individually to big number of groups.
+// Too small value may significantly increase RAM usage when count_uniq_hash() is applied individually to big number of groups.
 const statsCountUniqHashValuesMaxLen = 4 << 10
 
 type statsCountUniqHashSet struct {

--- a/lib/logstorage/stream_id.go
+++ b/lib/logstorage/stream_id.go
@@ -58,7 +58,7 @@ func (sid *streamID) less(a *streamID) bool {
 	return sid.id.less(&a.id)
 }
 
-// equal returns true if sid equalt to a.
+// equal returns true if sid equals to a.
 func (sid *streamID) equal(a *streamID) bool {
 	if !sid.tenantID.equal(&a.tenantID) {
 		return false

--- a/lib/logstorage/tenant_id_test.go
+++ b/lib/logstorage/tenant_id_test.go
@@ -15,7 +15,7 @@ func TestTenantIDMarshalUnmarshal(t *testing.T) {
 			t.Fatalf("unexpected error at unmarshal(%s): %s", tid, err)
 		}
 		if len(tail) != 0 {
-			t.Fatalf("unexpected non-emtpy tail after unmarshal(%s): %X", tid, tail)
+			t.Fatalf("unexpected non-empty tail after unmarshal(%s): %X", tid, tail)
 		}
 		if !reflect.DeepEqual(tid, &tid2) {
 			t.Fatalf("unexpected value after unmarshal; got %s; want %s", &tid2, tid)

--- a/lib/logstorage/u128.go
+++ b/lib/logstorage/u128.go
@@ -27,7 +27,7 @@ func (u *u128) less(a *u128) bool {
 	return u.lo < a.lo
 }
 
-// equal returns true if u equalst to a.
+// equal returns true if u equals to a.
 func (u *u128) equal(a *u128) bool {
 	return u.hi == a.hi && u.lo == a.lo
 }

--- a/lib/logstorage/u128_test.go
+++ b/lib/logstorage/u128_test.go
@@ -18,7 +18,7 @@ func TestU128MarshalUnmarshal(t *testing.T) {
 			t.Fatalf("unexpected error at unmarshal(%s): %s", u, err)
 		}
 		if len(tail) != 0 {
-			t.Fatalf("unexpected non-emtpy tail after unmarshal(%s): %X", u, tail)
+			t.Fatalf("unexpected non-empty tail after unmarshal(%s): %X", u, tail)
 		}
 		if !reflect.DeepEqual(u, &u2) {
 			t.Fatalf("unexpected value obtained from unmarshal(%s); got %s; want %s", u, &u2, u)

--- a/lib/logstorage/values_encoder_test.go
+++ b/lib/logstorage/values_encoder_test.go
@@ -350,7 +350,7 @@ func TestTryParseDuration_Success(t *testing.T) {
 	f("1h5m", nsecsPerHour+5*nsecsPerMinute)
 	f("1.1h5m2.5s3_456ns", 1.1*nsecsPerHour+5*nsecsPerMinute+2.5*nsecsPerSecond+3456)
 
-	// nedgative duration
+	// negative duration
 	f("-1h5m3s", -(nsecsPerHour + 5*nsecsPerMinute + 3*nsecsPerSecond))
 
 	// max int duration


### PR DESCRIPTION
### Describe Your Changes

Fixing spelling in:
- comments
- displayable strings
- markdown 

Including common markdown standards for better consistent display and accessibility
(you should inc markdownlint as part of your CI, same one you promote in the nixpackage repo)

NO CODE was changed !

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
