### PR TITLE
docs: add Environment variables section

### DIFF
--- a/docs/victorialogs/README.md
+++ b/docs/victorialogs/README.md
@@ -240,7 +240,7 @@ sending incremental file list
 victoria-logs-data/
 victoria-logs-data/flock.lock
               0 100%    0.00kB/s    0:00:00 (xfr#1, to-chk=78/80)
-              
+
 ...
 
 victoria-logs-data/partitions/20240809/indexdb/17E9ED7EF89BF422/metaindex.bin
@@ -350,6 +350,13 @@ The command for collecting CPU profile waits for 30 seconds before returning.
 
 The collected profiles may be analyzed with [go tool pprof](https://github.com/google/pprof).
 It is safe sharing the collected profiles from security point of view, since they do not contain sensitive information.
+
+## Environment variables
+
+All VictoriaLogs components support configuring command-line flags via environment variables.
+You can define flags using environment variables, and you can also
+reference environment variables as values, allowing you to reuse or dynamically inject configuration values at application startup.
+See [these docs](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#environment-variables) for details.
 
 ## List of command-line flags
 


### PR DESCRIPTION
### Describe Your Changes

Document the ability to set command-file flags using environment variables.

A detailed description of this functionality links to the VictoriaMetrics page, as this link is specified in the description of the `-envflag.enable` flag. To avoid confusing users with multiple sources of documentation, we should refer specifically to that documentation, instead of duplicating documentation.
