### PR TITLE
live-tailing: increase the live-tailing default offset from 1 to 5 seconds

### DIFF
--- a/app/vlselect/logsql/logsql.go
+++ b/app/vlselect/logsql/logsql.go
@@ -522,7 +522,7 @@ func ProcessLiveTailRequest(ctx context.Context, w http.ResponseWriter, r *http.
 	}
 	startOffset := startOffsetMsecs * 1e6
 
-	offsetMsecs, err := httputil.GetDuration(r, "offset", 1000)
+	offsetMsecs, err := httputil.GetDuration(r, "offset", 5000)
 	if err != nil {
 		httpserver.Errorf(w, r, "%s", err)
 		return


### PR DESCRIPTION
Related: https://github.com/VictoriaMetrics/VictoriaLogs/issues/555