### PR TITLE
switch from musl to glibc

### DIFF
--- a/deployment/docker/Makefile
+++ b/deployment/docker/Makefile
@@ -7,7 +7,7 @@ ROOT_IMAGE ?= alpine:3.22.1
 ROOT_IMAGE_SCRATCH ?= scratch
 CERTS_IMAGE := alpine:3.22.1
 
-GO_BUILDER_IMAGE := golang:1.24.6-alpine
+GO_BUILDER_IMAGE := golang:1.24.6
 BUILDER_IMAGE := local/builder:2.0.0-$(shell echo $(GO_BUILDER_IMAGE) | tr :/ __)-1
 BASE_IMAGE := local/base:1.1.4-$(shell echo $(ROOT_IMAGE) | tr :/ __)-$(shell echo $(CERTS_IMAGE) | tr :/ __)
 DOCKER ?= docker
@@ -43,7 +43,7 @@ app-via-docker: package-builder
 		$(BUILDER_IMAGE) \
 		go build $(RACE) -trimpath -buildvcs=false \
 			-ldflags "-extldflags '-static' $(GO_BUILDINFO)" \
-			-tags 'netgo osusergo musl' \
+			-tags 'netgo osusergo' \
 			-o bin/$(APP_NAME)$(APP_SUFFIX)-prod $(PKG_PREFIX)/app/$(APP_NAME)
 
 app-via-docker-windows: package-builder
@@ -158,11 +158,11 @@ app-via-docker-pure:
 	APP_SUFFIX='-pure' DOCKER_OPTS='--env CGO_ENABLED=0' $(MAKE) app-via-docker
 
 app-via-docker-linux-amd64:
-	EXTRA_DOCKER_ENVS='CC=/opt/cross-builder/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc' \
+	EXTRA_DOCKER_ENVS='CC=x86_64-linux-gnu-gcc' \
 	CGO_ENABLED=1 GOOS=linux GOARCH=amd64 $(MAKE) app-via-docker-goos-goarch
 
 app-via-docker-linux-arm64:
-	EXTRA_DOCKER_ENVS='CC=/opt/cross-builder/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc' \
+	EXTRA_DOCKER_ENVS='CC=aarch64-linux-gnu-gcc' \
 	CGO_ENABLED=1 GOOS=linux GOARCH=arm64 $(MAKE) app-via-docker-goos-goarch
 
 app-via-docker-linux-arm:
@@ -201,11 +201,11 @@ package-via-docker-pure:
 	APP_SUFFIX='-pure' DOCKER_OPTS='--env CGO_ENABLED=0' $(MAKE) package-via-docker
 
 package-via-docker-amd64:
-	EXTRA_DOCKER_ENVS='CC=/opt/cross-builder/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc' \
+	EXTRA_DOCKER_ENVS='CC=x86_64-linux-gnu-gcc' \
 	CGO_ENABLED=1 GOARCH=amd64 $(MAKE) package-via-docker-goarch
 
 package-via-docker-arm64:
-	EXTRA_DOCKER_ENVS='CC=/opt/cross-builder/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc' \
+	EXTRA_DOCKER_ENVS='CC=aarch64-linux-gnu-gcc' \
 	CGO_ENABLED=1 GOARCH=arm64 $(MAKE) package-via-docker-goarch
 
 package-via-docker-arm:

--- a/deployment/docker/builder/Dockerfile
+++ b/deployment/docker/builder/Dockerfile
@@ -1,14 +1,6 @@
 ARG go_builder_image=non-existing
 FROM $go_builder_image
 STOPSIGNAL SIGINT
-RUN apk add git gcc musl-dev make wget --no-cache && \
-    mkdir /opt/cross-builder && \
-    cd /opt/cross-builder && \
-    for arch in aarch64 x86_64; do \
-        wget \
-            https://github.com/VictoriaMetrics/muslcc-mirror/releases/download/v1.0.0/${arch}-linux-musl-cross.tgz \
-            -O /opt/cross-builder/${arch}-musl.tgz \
-            --no-verbose && \
-        tar zxf ${arch}-musl.tgz -C ./  && \
-        rm /opt/cross-builder/${arch}-musl.tgz; \
-    done
+RUN apt update && apt install -y \
+    gcc-x86-64-linux-gnu \
+    gcc-aarch64-linux-gnu


### PR DESCRIPTION
### Describe Your Changes

This PR changes VictoriaLogs components build to use gcc compiler instead of gcc-musl. This means that we will now use glibc library instead of musl.
This change was made because musl can negatively impact the performance of programs with a large number of CPU cores.
See for more details: https://github.com/VictoriaMetrics/VictoriaLogs/issues/517

The issue could have been resolved in another way – by replacing musl's allocator with another one such as jemalloc, but we chose to switch to glibc because it results in a smaller binary size.

---

VictoriaLogs based on glibc is available here: [victoriametrics/victoria-logs:heads-switch-to-glibc-0-ga20f107c8](https://hub.docker.com/layers/victoriametrics/victoria-logs/heads-switch-to-glibc-0-ga20f107c8-scratch/images/sha256-5904ba7f39e24152c2a1f7b46cd9b10475f489666c0b276950cef54072820b9a) (this image based on VictoriaLogs v1.28.0), so you can test the performance change to verify my results. I also recommend using [`vlogsgenerator`](https://github.com/VictoriaMetrics/VictoriaLogs/tree/master/app/vlogsgenerator) to generate the load. Use a server with more than 64 cores to reproduce the issue.