### PR TITLE
docs/victorialogs: provide a hint where SELinux blocks journald upload

### DIFF
--- a/docs/victorialogs/data-ingestion/Journald.md
+++ b/docs/victorialogs/data-ingestion/Journald.md
@@ -20,6 +20,8 @@ URL=http://localhost:9428/insert/journald
 
 Substitute the `localhost:9428` address inside `endpoints` section with the real TCP address of VictoriaLogs.
 
+Port 9428 is not the default port associated with with `systemd-journal-upload` so on a system with SELinux in enforcing mode, it may be necessary to adjust the policy or assign the port, for example: `semanage port -a -t journal_remote_port_t -p tcp 9428`
+
 ## Time field
 
 VictoriaLogs uses the `__REALTIME_TIMESTAMP` field as [`_time` field](https://docs.victoriametrics.com/victorialogs/keyconcepts/#time-field)


### PR DESCRIPTION
With the default policies, `systemd-journald-upload.service` fails because it can't bind port 9428. That's unreserved by default so can be assigned. For other ports it may be necessary to change the policy. Adding a brief mention may help with identifying this failure cause.

### Describe Your Changes

This adds a very brief note to the documentation to point other users in the right direction and to provide a solution for the simple case. This would occur for a fairly default installation of RHEL so I can imagine I won't be the only person to hit the issue. For someone else it might be hard to diagnose. Admittedly, many people disable SELinux because they're too lazy to deal with cases like this.

The solution using `semanage` is specific to the use of an unreserved port like 9428. You don't want to be changing port 443 for example because that has an existing assignment. In that case you'd write a policy to grant `systemd_journal_upload_t` permission to connect to an `http_port_t`. This could also be relevant if you were to create a policy for victoria-logs as a whole where you'd likely create a new `_port_t` type for 9428.

### Checklist

The following checks are **mandatory**:

- [ X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
