### PR TITLE
lib/logstorage: avoid adding pipe "offset"

### DIFF
--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -22,7 +22,8 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 * FEATURE: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): add [pattern match filter](https://docs.victoriametrics.com/victorialogs/logsql/#pattern-match-filter) for searching logs by the given patterns such as `<DATETIME>: user_id=<N>, ip=<IP4>, trace_id=<UUID>`. These filters are needed for [#518](https://github.com/VictoriaMetrics/VictoriaLogs/issues/518).
 * FEATURE: [Syslog data ingestion](https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/): support for receiving Syslog messages from Unix sockets of `SOCK_STREAM` and `SOCK_DGRAM` types via `-syslog.listenAddr.unix=/path/to/socket` and `-syslog.listenAddr.unix=unixgram:/path/to/socket` command-line flags. See [#570](https://github.com/VictoriaMetrics/VictoriaLogs/issues/570).
 
-* BUGFIX: [querying](https://docs.victoriametrics.com/victorialogs/querying): `-search.maxQueryTimeRange` command-line flag now supports day (`d`), week (`w`) and year (`y`) suffixes additionally to the supported hour (`h`), minute (`m`) and second (`s`) suffixes. See [#50](https://github.com/VictoriaMetrics/VictoriaLogs/issues/50#issuecomment-3244097676)
+* BUGFIX: [querying](https://docs.victoriametrics.com/victorialogs/querying): `-search.maxQueryTimeRange` command-line flag now supports day (`d`), week (`w`) and year (`y`) suffixes additionally to the supported hour (`h`), minute (`m`) and second (`s`) suffixes. See [#50](https://github.com/VictoriaMetrics/VictoriaLogs/issues/50#issuecomment-3244097676).
+* BUGFIX: [querying](https://docs.victoriametrics.com/victorialogs/querying): properly handle the `offset` HTTP parameter when it is not set. This improves querying performance in VictoriaLogs cluster. See [#620](https://github.com/VictoriaMetrics/VictoriaLogs/issues/620).
 
 ## [v1.32.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.32.0)
 

--- a/lib/logstorage/parser.go
+++ b/lib/logstorage/parser.go
@@ -783,8 +783,10 @@ func (q *Query) AddPipeSortByTimeDesc() {
 // See https://docs.victoriametrics.com/victorialogs/logsql/#offset-pipe
 // and https://docs.victoriametrics.com/victorialogs/logsql/#limit-pipe
 func (q *Query) AddPipeOffsetLimit(offset, limit uint64) {
-	offsetStr := fmt.Sprintf("offset %d", offset)
-	q.mustAppendPipe(offsetStr)
+	if offset > 0 {
+		offsetStr := fmt.Sprintf("offset %d", offset)
+		q.mustAppendPipe(offsetStr)
+	}
 
 	limitStr := fmt.Sprintf("limit %d", limit)
 	q.mustAppendPipe(limitStr)


### PR DESCRIPTION
### Describe Your Changes

Avoid adding the pipe "offset" when offset is zero, as it prevents sending the pipe "limit" to a remote handler.
As a result, there can be redundant traffic, especially in the [last N rows optimization](https://github.com/VictoriaMetrics/VictoriaLogs/blob/be0f78e9c309a2170c7460df75cd09825f374e56/app/vlstorage/lastnoptimization.go#L14).

For more details, see also this function that prevents sending pipe "limit" to remote handler :
https://github.com/VictoriaMetrics/VictoriaLogs/blob/be0f78e9c309a2170c7460df75cd09825f374e56/lib/logstorage/net_query_runner.go#L87

Related issue: #620 

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
