### PR TITLE
Fix DirRemover should sync before delete mark file

### DIFF
--- a/vendor/github.com/VictoriaMetrics/VictoriaMetrics/lib/fs/dir_remover.go
+++ b/vendor/github.com/VictoriaMetrics/VictoriaMetrics/lib/fs/dir_remover.go
@@ -72,12 +72,12 @@ func MustRemoveDir(dirPath string) {
 	}
 	wg.Wait()
 
+	// Remove the deleteDirFilename file
+	MustRemovePath(deleteFilePath)
+
 	// Make sure the deleted names are properly synced to the dirPath,
 	// so they are no longer visible after unclean shutdown.
 	MustSyncPath(dirPath)
-
-	// Remove the deleteDirFilename file
-	MustRemovePath(deleteFilePath)
 
 	// Remove the dirPath itself
 	MustRemovePath(dirPath)


### PR DESCRIPTION
### Describe Your Changes
This PR is trying to fix https://github.com/VictoriaMetrics/VictoriaLogs/issues/649.

I deploy victorialogs in k8s, and mount a OSSFS2 persistent volume as the data directory. The vl pod meets the panic issue described in https://github.com/VictoriaMetrics/VictoriaLogs/issues/649.

And I read the source code of dir_remover.go, and I found that operation sequence is
1. sync dir path
2. remove delete file
3. remove dir

And When I use fuse-based cloud FS, there is a metadata cache. If removing the delete file is completed, the metadata is not newest, it will meet the `dir not empty` error.

So in this PR, I will change the opeartion sequece to
1. remove delete file
2. sync dir path
3. remove dir

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
