### PR TITLE
app/vmui: properly show tenant info if AccountID and ProjectID headers are set by proxy or remove it completely

### DIFF
--- a/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/TenantsConfiguration/TenantsFields.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/TenantsConfiguration/TenantsFields.tsx
@@ -13,15 +13,17 @@ import TextField from "../../../Main/TextField/TextField";
 import useBoolean from "../../../../hooks/useBoolean";
 import useStateSearchParams from "../../../../hooks/useStateSearchParams";
 import { useSearchParams } from "react-router-dom";
+import { useAppState } from "../../../../state/common/StateContext";
 
 const TenantsFields: FC = () => {
+  const { tenantId } = useAppState();
   const appModeEnable = getAppModeEnable();
   const { isMobile } = useDeviceDetect();
   const timeDispatch = useTimeDispatch();
 
   const [searchParams, setSearchParams] = useSearchParams();
-  const [accountID, setAccountID] = useStateSearchParams("0", "accountID");
-  const [projectID, setProjectID] = useStateSearchParams("0", "projectID");
+  const [accountID, setAccountID] = useStateSearchParams(tenantId?.accountID || "0", "accountID");
+  const [projectID, setProjectID] = useStateSearchParams(tenantId?.projectID || "0", "projectID");
   const formattedTenant = `${accountID}:${projectID}`;
 
   const buttonRef = useRef<HTMLDivElement>(null);
@@ -41,8 +43,8 @@ const TenantsFields: FC = () => {
   };
 
   const handleReset = () => {
-    setAccountID(searchParams.get("accountID") || "0");
-    setProjectID(searchParams.get("projectID") || "0");
+    setAccountID(searchParams.get("accountID") || tenantId?.accountID || "0");
+    setProjectID(searchParams.get("projectID") || tenantId?.projectID || "0");
   };
 
   useEffect(() => {
@@ -50,98 +52,125 @@ const TenantsFields: FC = () => {
     handleReset();
   }, [openPopup]);
 
-  return (
-    <div className="vm-tenant-input">
-      <Tooltip title="Define Tenant ID if you need request to another storage">
-        <div ref={buttonRef}>
-          {isMobile ? (
-            <div
-              className="vm-mobile-option"
-              onClick={toggleOpenPopup}
-            >
-              <span className="vm-mobile-option__icon"><StorageIcon/></span>
-              <div className="vm-mobile-option-text">
-                <span className="vm-mobile-option-text__label">Tenant ID</span>
-                <span className="vm-mobile-option-text__value">{formattedTenant}</span>
-              </div>
-              <span className="vm-mobile-option__arrow"><ArrowDownIcon/></span>
-            </div>
-          ) : (
-            <Button
-              className={appModeEnable ? "" : "vm-header-button"}
-              variant="contained"
-              color="primary"
-              fullWidth
-              startIcon={<StorageIcon/>}
-              endIcon={(
-                <div
-                  className={classNames({
-                    "vm-execution-controls-buttons__arrow": true,
-                    "vm-execution-controls-buttons__arrow_open": openPopup,
-                  })}
-                >
-                  <ArrowDownIcon/>
-                </div>
-              )}
-              onClick={toggleOpenPopup}
-            >
-              {formattedTenant}
-            </Button>
+  const isTenantStatic = !!(tenantId?.accountID || tenantId?.projectID);
+  const tooltipMessage = isTenantStatic ? "Static tenant for a current user" : "Define Tenant ID if you need request to another storage";
+
+  const getTenantLabel = () => {
+    return (
+      <div ref={buttonRef}>
+        <div
+          className="vm-mobile-option"
+          onClick={isTenantStatic ? undefined : toggleOpenPopup}
+        >
+          <span className="vm-mobile-option__icon"><StorageIcon/></span>
+          <div className="vm-mobile-option-text">
+            {isMobile && (
+              <span className="vm-mobile-option-text__label">Tenant ID</span>
+            )}
+            <span className="vm-mobile-option-text__value">{formattedTenant}</span>
+          </div>
+          {!isTenantStatic && (
+            <span className="vm-mobile-option__arrow"><ArrowDownIcon/></span>
           )}
         </div>
-      </Tooltip>
-      <Popper
-        open={openPopup}
-        placement="bottom-right"
-        onClose={handleClosePopup}
-        buttonRef={buttonRef}
-        title={isMobile ? "Define Tenant ID" : undefined}
-      >
-        <div
-          className={classNames({
-            "vm-list vm-tenant-input-list": true,
-            "vm-list vm-tenant-input-list_mobile": isMobile,
-            "vm-tenant-input-list_inline": true,
-          })}
-        >
-          <TextField
-            autofocus
-            label="accountID"
-            value={accountID}
-            onChange={setAccountID}
-            type="number"
-          />
-          <TextField
-            autofocus
-            label="projectID"
-            value={projectID}
-            onChange={setProjectID}
-            type="number"
-          />
-          <div className="vm-tenant-input-list__buttons">
-            <Tooltip title="Multitenancy in VictoriaLogs documentation">
-              <a
-                href="https://docs.victoriametrics.com/victorialogs/#multitenancy"
-                target="_blank"
-                rel="help noreferrer"
+      </div>
+    );
+  };
+
+  return (
+    <div
+      className={classNames({
+        "vm-tenant-input": true,
+        "vm-tenant-input_disabled": isTenantStatic,
+        "vm-tenant-input_mobile": isMobile,
+      })}
+    >
+      {isMobile ? (
+        getTenantLabel()
+      ) : (
+        <Tooltip title={tooltipMessage}>
+          {isTenantStatic ? (
+            getTenantLabel()
+          ) : (
+            <div ref={buttonRef}>
+              <Button
+                className={appModeEnable ? "" : "vm-header-button"}
+                variant="contained"
+                color="primary"
+                fullWidth
+                startIcon={<StorageIcon/>}
+                endIcon={(
+                  <div
+                    className={classNames({
+                      "vm-execution-controls-buttons__arrow": true,
+                      "vm-execution-controls-buttons__arrow_open": openPopup,
+                    })}
+                  >
+                    <ArrowDownIcon/>
+                  </div>
+                )}
+                onClick={toggleOpenPopup}
               >
-                <Button
-                  variant="text"
-                  color="gray"
-                  startIcon={<QuestionIcon/>}
-                />
-              </a>
-            </Tooltip>
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={applyChanges}
-            >
-              Apply
-            </Button>
+                {formattedTenant}
+              </Button>
+            </div>
+          )}
+        </Tooltip>
+      )}
+      {!isTenantStatic && (
+        <Popper
+          open={openPopup}
+          placement="bottom-right"
+          onClose={handleClosePopup}
+          buttonRef={buttonRef}
+          title={isMobile ? "Define Tenant ID" : undefined}
+        >
+          <div
+            className={classNames({
+              "vm-list vm-tenant-input-list": true,
+              "vm-list vm-tenant-input-list_mobile": isMobile,
+              "vm-tenant-input-list_inline": true,
+            })}
+          >
+            <TextField
+              autofocus
+              label="accountID"
+              value={accountID}
+              onChange={setAccountID}
+              type="number"
+            />
+            <TextField
+              autofocus
+              label="projectID"
+              value={projectID}
+              onChange={setProjectID}
+              type="number"
+            />
+            <div className="vm-tenant-input-list__buttons">
+              <Tooltip title="Multitenancy in VictoriaLogs documentation">
+                <a
+                  href="https://docs.victoriametrics.com/victorialogs/#multitenancy"
+                  target="_blank"
+                  rel="help noreferrer"
+                >
+                  <Button
+                    variant="text"
+                    color="gray"
+                    startIcon={<QuestionIcon/>}
+                  />
+                </a>
+              </Tooltip>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={applyChanges}
+              >
+                Apply
+              </Button>
+            </div>
           </div>
-        </div>
-      </Popper>
+        </Popper>
+      )}
     </div>
   );
 };

--- a/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/TenantsConfiguration/style.scss
+++ b/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/TenantsConfiguration/style.scss
@@ -3,6 +3,31 @@
 .vm-tenant-input {
   position: relative;
 
+  &_disabled:not(&_mobile) {
+    .vm-mobile-option {
+      &__icon {
+        color: #fff;
+      }
+      &-text {
+        color: #fff;
+        &__value {
+          color: #fff;
+        }
+      }
+    }
+  }
+
+  &_disabled:is(&_mobile) {
+    .vm-mobile-option {
+      &__icon {
+        color: $color-text-disabled;
+      }
+      &-text {
+        color: $color-text-disabled;
+      }
+    }
+  }
+
   &-list {
     max-height: 300px;
     overflow: auto;

--- a/app/vmui/packages/vmui/src/components/Views/JsonView/JsonView.tsx
+++ b/app/vmui/packages/vmui/src/components/Views/JsonView/JsonView.tsx
@@ -12,7 +12,7 @@ export const JsonView: FC<Props> = ({ data }) => {
         return s;
       }
       return JSON.stringify(a);
-    }).join("\n")
+    }).join("\n");
   }, [data]);
   return (
     <pre style="line-height: 1.2em">{jsonStr}</pre>

--- a/app/vmui/packages/vmui/src/hooks/useFetchAppConfig.ts
+++ b/app/vmui/packages/vmui/src/hooks/useFetchAppConfig.ts
@@ -1,8 +1,9 @@
-import { useAppDispatch } from "../state/common/StateContext";
+import { useAppDispatch, useAppState } from "../state/common/StateContext";
 import { useEffect, useState } from "preact/compat";
 import { ErrorTypes } from "../types";
 
 const useFetchFlags = () => {
+  const { serverUrl } = useAppState();
   const dispatch = useAppDispatch();
 
   const [isLoading, setIsLoading] = useState(false);
@@ -14,9 +15,15 @@ const useFetchFlags = () => {
       setIsLoading(true);
 
       try {
-        const data = await fetch("./config.json");
+        const data = await fetch(`${serverUrl}/select/vmui/config.json`);
         const config = await data.json();
         dispatch({ type: "SET_APP_CONFIG", payload: config || {} });
+        const tenant = {
+          accountID: data.headers.get("AccountID") || "",
+          projectID: data.headers.get("ProjectID") || "",
+          disableTenantInfo: data.headers.get("VL-Disable-Tenant-Controls") == "true",
+        };
+        dispatch({ type: "SET_TENANT_ID", payload: tenant });
       } catch (e) {
         setIsLoading(false);
         if (e instanceof Error) setError(`${e.name}: ${e.message}`);
@@ -24,7 +31,7 @@ const useFetchFlags = () => {
     };
 
     fetchAppConfig();
-  }, []);
+  }, [serverUrl]);
 
   return { isLoading, error };
 };

--- a/app/vmui/packages/vmui/src/layouts/Footer/Footer.tsx
+++ b/app/vmui/packages/vmui/src/layouts/Footer/Footer.tsx
@@ -2,6 +2,7 @@ import { FC, memo } from "preact/compat";
 import { LogoShortIcon } from "../../components/Main/Icons";
 import "./style.scss";
 import { footerLinksToLogs } from "../../constants/footerLinks";
+import { useAppState } from "../../state/common/StateContext";
 
 interface Props {
   links?: {
@@ -13,10 +14,12 @@ interface Props {
 
 const Footer: FC<Props> = memo(({ links = footerLinksToLogs }) => {
   const copyrightYears = `2019-${new Date().getFullYear()}`;
+  const { appConfig } = useAppState();
+  const version = appConfig?.version;
 
   return <footer className="vm-footer">
     <a
-      className="vm-link vm-footer__website"
+      className="vm-link vm-footer__link"
       target="_blank"
       href="https://victoriametrics.com/"
       rel="me noreferrer"
@@ -37,7 +40,8 @@ const Footer: FC<Props> = memo(({ links = footerLinksToLogs }) => {
       </a>
     ))}
     <div className="vm-footer__copyright">
-      &copy; {copyrightYears} VictoriaMetrics
+      &copy; {copyrightYears} VictoriaMetrics.
+      {version && <span className="vm-footer__version">&nbsp;Version: {version}</span>}
     </div>
   </footer>;
 });

--- a/app/vmui/packages/vmui/src/layouts/Header/HeaderControls/HeaderControls.tsx
+++ b/app/vmui/packages/vmui/src/layouts/Header/HeaderControls/HeaderControls.tsx
@@ -55,7 +55,7 @@ const HeaderControls: FC<ControlsProps & HeaderProps> = ({
   if (isMobile) {
     return (
       <>
-        <div>
+        <div className="vm-header-controls">
           <Button
             className={classNames({
               "vm-header-button": !appModeEnable

--- a/app/vmui/packages/vmui/src/layouts/Header/HeaderNav/NavSubItem.tsx
+++ b/app/vmui/packages/vmui/src/layouts/Header/HeaderNav/NavSubItem.tsx
@@ -22,7 +22,7 @@ const NavSubItem: FC<NavItemProps> = ({
   color,
   background,
   submenu,
-  direction
+  direction = "row"
 }) => {
   const { pathname } = useLocation();
 
@@ -36,8 +36,9 @@ const NavSubItem: FC<NavItemProps> = ({
   } = useBoolean(false);
 
   const handleOpenSubmenu = () => {
-    setOpenSubmenu();
-    if (menuTimeout) clearTimeout(menuTimeout);
+    if (direction === "row" || !openSubmenu) setOpenSubmenu();
+    if (direction === "column" && openSubmenu) handleCloseSubmenu();
+    if (direction === "row" && menuTimeout) clearTimeout(menuTimeout);
   };
 
   const handleMouseLeave = () => {
@@ -54,50 +55,31 @@ const NavSubItem: FC<NavItemProps> = ({
     handleCloseSubmenu();
   }, [pathname]);
 
-  if (direction === "column") {
-    return (
-      <>
-        {submenu.map(sm => (
-          <NavItem
-            key={sm.value}
-            activeMenu={activeMenu}
-            value={sm.value || ""}
-            label={sm.label || ""}
-            type={sm.type || NavigationItemType.internalLink}
-          />
-        ))}
-      </>
-    );
-  }
-
   return (
     <div
       className={classNames({
-        "vm-header-nav-item": true,
-        "vm-header-nav-item_sub": true,
         "vm-header-nav-item_open": openSubmenu,
-        "vm-header-nav-item_active": submenu.find(m => m.value === activeMenu)
       })}
       style={{ color }}
-      onMouseEnter={handleOpenSubmenu}
-      onMouseLeave={handleMouseLeave}
+      onMouseEnter={direction === "column" ? undefined : handleOpenSubmenu}
+      onMouseLeave={direction === "column" ? undefined : handleMouseLeave}
+      onClick={direction === "column" ? handleOpenSubmenu : undefined}
       ref={buttonRef}
     >
-      {label}
-      <ArrowDropDownIcon/>
-
-      <Popper
-        open={openSubmenu}
-        placement="bottom-left"
-        offset={{ top: 12, left: 0 }}
-        onClose={handleCloseSubmenu}
-        buttonRef={buttonRef}
+      <div
+        className={classNames({
+          "vm-header-nav-item": true,
+          "vm-header-nav-item_sub": true,
+          "vm-header-nav-item_active": submenu.find(m => m.value === activeMenu),
+        })}
       >
+        {label}
+        <ArrowDropDownIcon/>
+      </div>
+      {direction === "column" ? (
         <div
           className="vm-header-nav-item-submenu"
           style={{ background }}
-          onMouseLeave={handleMouseLeave}
-          onMouseEnter={handleMouseEnterPopup}
         >
           {submenu.map(sm => (
             <NavItem
@@ -110,7 +92,33 @@ const NavSubItem: FC<NavItemProps> = ({
             />
           ))}
         </div>
-      </Popper>
+      ) : (
+        <Popper
+          open={openSubmenu}
+          placement="bottom-left"
+          offset={{ top: 12, left: 0 }}
+          onClose={handleCloseSubmenu}
+          buttonRef={buttonRef}
+        >
+          <div
+            className="vm-header-nav-item-submenu"
+            style={{ background }}
+            onMouseLeave={handleMouseLeave}
+            onMouseEnter={handleMouseEnterPopup}
+          >
+            {submenu.map(sm => (
+              <NavItem
+                key={sm.value}
+                activeMenu={activeMenu}
+                value={sm.value || ""}
+                label={sm.label || ""}
+                color={color}
+                type={sm.type || NavigationItemType.internalLink}
+              />
+            ))}
+          </div>
+        </Popper>
+      )}
     </div>
   );
 };

--- a/app/vmui/packages/vmui/src/layouts/Header/HeaderNav/style.scss
+++ b/app/vmui/packages/vmui/src/layouts/Header/HeaderNav/style.scss
@@ -20,6 +20,14 @@
     }
   }
 
+  &_column &-item-submenu {
+    display: none;
+  }
+
+  &_column &-item_open &-item-submenu {
+    display: grid;
+  }
+
   &-item {
     position: relative;
     padding: $padding-global $padding-small;
@@ -44,6 +52,7 @@
     }
 
     &_active {
+      padding: $padding-global $padding-small 10px $padding-small;
       border-bottom: 2px solid rgba($color-black, 0.2);
     }
 
@@ -60,7 +69,6 @@
 
     &-submenu {
       display: grid;
-      white-space: nowrap;
       padding: $padding-small;
       color: $color-white;
       border-radius: $border-radius-small;

--- a/app/vmui/packages/vmui/src/layouts/Header/SidebarNav/SidebarHeader.tsx
+++ b/app/vmui/packages/vmui/src/layouts/Header/SidebarNav/SidebarHeader.tsx
@@ -49,7 +49,7 @@ const SidebarHeader: FC<SidebarHeaderProps> = ({
         "vm-header-sidebar-menu_open": openMenu
       })}
     >
-      <div>
+      <div className="vm-header-sidebar-scrollable">
         <HeaderNav
           color={color}
           background={background}

--- a/app/vmui/packages/vmui/src/layouts/Header/SidebarNav/style.scss
+++ b/app/vmui/packages/vmui/src/layouts/Header/SidebarNav/style.scss
@@ -25,7 +25,13 @@ $sidebar-transition: cubic-bezier(0.280, 0.840, 0.420, 1);
       z-index: 102;
     }
   }
-
+  &-scrollable {
+    overflow-y: scroll;
+    scrollbar-width: none;
+  }
+  &-scrollable::-webkit-scrollbar {
+    display: none;
+  }
   &-menu {
     position: fixed;
     top: 0;

--- a/app/vmui/packages/vmui/src/layouts/Header/style.scss
+++ b/app/vmui/packages/vmui/src/layouts/Header/style.scss
@@ -22,15 +22,9 @@
   }
 
   &_sidebar {
-    display: grid;
-    grid-template-columns: 40px auto 1fr;
-    box-shadow: $color-background-body 0 1px 1px 0px;
-  }
-
-  &_mobile {
-    display: grid;
-    grid-template-columns: 33px 1fr 33px;
+    display: flex;
     justify-content: space-between;
+    box-shadow: $color-background-body 0 1px 1px 0px;
   }
 
   &_dark {

--- a/app/vmui/packages/vmui/src/layouts/LogsLayout/ControlsLogsLayout.tsx
+++ b/app/vmui/packages/vmui/src/layouts/LogsLayout/ControlsLogsLayout.tsx
@@ -5,9 +5,10 @@ import { ControlsProps } from "../Header/HeaderControls/HeaderControls";
 import { TimeSelector } from "../../components/Configurators/TimeRangeSettings/TimeSelector/TimeSelector";
 import TenantsFields from "../../components/Configurators/GlobalSettings/TenantsConfiguration/TenantsFields";
 import { ExecutionControls } from "../../components/Configurators/TimeRangeSettings/ExecutionControls/ExecutionControls";
+import { useAppState } from "../../state/common/StateContext";
 
 const ControlsLogsLayout: FC<ControlsProps> = ({ isMobile, headerSetup }) => {
-
+  const { tenantId } = useAppState();
   return (
     <div
       className={classNames({
@@ -16,7 +17,7 @@ const ControlsLogsLayout: FC<ControlsProps> = ({ isMobile, headerSetup }) => {
       })}
     >
 
-      {headerSetup?.tenant && <TenantsFields/>}
+      {headerSetup?.tenant && !tenantId?.disableTenantInfo && <TenantsFields/>}
       {headerSetup?.timeSelector && <TimeSelector/>}
       {headerSetup?.executionControls &&  <ExecutionControls/>}
       <GlobalSettings/>

--- a/app/vmui/packages/vmui/src/layouts/LogsLayout/LogsLayout.tsx
+++ b/app/vmui/packages/vmui/src/layouts/LogsLayout/LogsLayout.tsx
@@ -9,11 +9,14 @@ import { RouterOptions, routerOptions } from "../../router";
 import useDeviceDetect from "../../hooks/useDeviceDetect";
 import ControlsLogsLayout from "./ControlsLogsLayout";
 import { footerLinksToLogs } from "../../constants/footerLinks";
+import useFetchAppConfig from "../../hooks/useFetchAppConfig";
 
 const LogsLayout: FC = () => {
   const appModeEnable = getAppModeEnable();
   const { isMobile } = useDeviceDetect();
   const { pathname } = useLocation();
+
+  useFetchAppConfig();
 
   const setDocumentTitle = () => {
     const matchedEntry = Object.entries(routerOptions).find(([path]) => {

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/views/JsonView/JsonView.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBody/views/JsonView/JsonView.tsx
@@ -2,8 +2,6 @@ import { FC, useMemo, useCallback, createPortal, memo } from "preact/compat";
 import DownloadLogsButton from "../../../DownloadLogsButton/DownloadLogsButton";
 import { ViewProps } from "../../types";
 import EmptyLogs from "../components/EmptyLogs/EmptyLogs";
-import { useSearchParams } from "react-router-dom";
-import orderby from "lodash.orderby";
 import "./style.scss";
 import { Logs } from "../../../../../api/types";
 import ScrollToTopButton from "../../../../../components/ScrollToTopButton/ScrollToTopButton";
@@ -14,8 +12,6 @@ const MemoizedJsonView = memo(JsonViewComponent);
 
 const JsonView: FC<ViewProps> = ({ data, settingsRef }) => {
   const getLogs = useCallback(() => data, [data]);
-
-  const [searchParams] = useSearchParams();
 
   const fields = useMemo(() => {
     const keys = new Set(data.flatMap(Object.keys));

--- a/app/vmui/packages/vmui/src/state/common/reducer.ts
+++ b/app/vmui/packages/vmui/src/state/common/reducer.ts
@@ -1,13 +1,18 @@
 import { getDefaultServer } from "../../utils/default-server-url";
-import { getQueryStringValue } from "../../utils/query-string";
 import { getFromStorage, saveToStorage } from "../../utils/storage";
 import { AppConfig, Theme } from "../../types";
 import { isDarkTheme } from "../../utils/theme";
 import { removeTrailingSlash } from "../../utils/url";
 
+interface Tenant {
+  accountID: string;
+  projectID: string;
+  disableTenantInfo: boolean;
+}
+
 export interface AppState {
   serverUrl: string;
-  tenantId: string;
+  tenantId?: Tenant;
   theme: Theme;
   isDarkTheme: boolean | null;
   flags: Record<string, string | null>;
@@ -17,16 +22,14 @@ export interface AppState {
 export type Action =
   | { type: "SET_SERVER", payload: string }
   | { type: "SET_THEME", payload: Theme }
-  | { type: "SET_TENANT_ID", payload: string }
+  | { type: "SET_TENANT_ID", payload: Tenant }
   | { type: "SET_FLAGS", payload: Record<string, string | null> }
   | { type: "SET_APP_CONFIG", payload: AppConfig }
   | { type: "SET_DARK_THEME" }
 
-const tenantId = getQueryStringValue("g0.tenantID", "") as string;
-
 export const initialState: AppState = {
   serverUrl: removeTrailingSlash(getDefaultServer()),
-  tenantId,
+  tenantId: undefined,
   theme: (getFromStorage("THEME") || Theme.system) as Theme,
   isDarkTheme: null,
   flags: {},

--- a/app/vmui/packages/vmui/src/types/index.ts
+++ b/app/vmui/packages/vmui/src/types/index.ts
@@ -174,6 +174,10 @@ export interface AppConfig {
   license?: {
     type?: "enterprise" | "opensource";
   }
+  vmalert?: {
+    enabled: boolean;
+  };
+  version?: string;
 }
 
 export interface GroupLogsType {

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -19,6 +19,7 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 ## tip
 
 * FEATURE: proxy VMAlert requests at `/select/vmalert` path, when `-vmalert.proxyURL` flag is set. See [#8272](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8272).
+* FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): control tenant selector state on VMUI depending on headers that are passed to VictoriaLogs. With `AccountID` and `ProjectID` headers set VMUI shows tenant information as a static value, with `VL-Disable-Tenant-Controls` header set to `true` tenant information is not shown in VMUI. See [#656](https://github.com/VictoriaMetrics/VictoriaLogs/issues/656)
 
 * BUGFIX: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): allow using unquoted [pipe names](https://docs.victoriametrics.com/victorialogs/logsql/#pipes) inside [LogsQL filters](https://docs.victoriametrics.com/victorialogs/logsql/#filters). For example, `fields.foo:bar` is allowed now, while previously it should be written as `"fields.foo":bar`. See [#669](https://github.com/VictoriaMetrics/VictoriaLogs/issues/669).
 * BUGFIX: properly detele unneeded directories at [Ossfs2 filesystem](https://www.alibabacloud.com/help/en/oss/developer-reference/ossfs-2-0/). See [#649](https://github.com/VictoriaMetrics/VictoriaLogs/issues/649). Thanks to @xiaozongyang for [the initial pull request](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9709).


### PR DESCRIPTION
depends on https://github.com/VictoriaMetrics/VictoriaLogs/pull/5
fixes https://github.com/VictoriaMetrics/VictoriaLogs/issues/656

### Describe Your Changes

show properly tenant information based on response headers while querying `/select/vmui/config.json`:
* if `AccountID` and `ProjectID` response headers are set tenant information is displayed as a static label, which doesn't allow to select custom tenant
* if `VL-Disable-Tenant-Controls` response header is set to `true` tenant information is hidden on VMUI.

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
