### PR TITLE
docs: fix styling for displaying note in vmalert docs

### DIFF
--- a/docs/victorialogs/vmalert.md
+++ b/docs/victorialogs/vmalert.md
@@ -18,7 +18,7 @@ and [`/select/logsql/stats_query_range`](https://docs.victoriametrics.com/victor
 These endpoints return the log stats in a format compatible with [Prometheus querying API](https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries).
 It allows using VictoriaLogs as the datasource in vmalert, creating alerting and recording rules via [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/).
 
-> Note: This page provides only integration instructions for vmalert and VictoriaLogs. See the full textbook for vmalert [here](https://docs.victoriametrics.com/victoriametrics/vmalert/).
+> This page provides only integration instructions for vmalert and VictoriaLogs. See the full textbook for vmalert [here](https://docs.victoriametrics.com/victoriametrics/vmalert/).
 
 ## Quick Start
 


### PR DESCRIPTION
Current render looks like this 
<img width="928" height="82" alt="image" src="https://github.com/user-attachments/assets/ad62cce1-591c-4342-94c4-d6dc4e3ff1e4" />

With change will start looking like this:
<img width="868" height="78" alt="image" src="https://github.com/user-attachments/assets/3ac2a7c9-f7ca-4c2a-b462-2f3dd3abcdc4" />
