### PR TITLE
optimize(otel): Improve performance of otellog processing with `sync.Pool`

### DIFF
--- a/app/vlinsert/opentelemetry/opentelemetry.go
+++ b/app/vlinsert/opentelemetry/opentelemetry.go
@@ -3,6 +3,7 @@ package opentelemetry
 import (
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
@@ -74,20 +75,38 @@ var (
 	requestProtobufDuration = metrics.NewSummary(`vl_http_request_duration_seconds{path="/insert/opentelemetry/v1/logs",format="protobuf"}`)
 )
 
+var (
+	exportLogsReqPool = sync.Pool{
+		New: func() any {
+			return &pb.ExportLogsServiceRequest{}
+		},
+	}
+	fieldsPool = sync.Pool{
+		New: func() any {
+			s := make([]logstorage.Field, 0)
+			return &s
+		},
+	}
+)
+
 func pushProtobufRequest(data []byte, lmp insertutil.LogMessageProcessor, msgFields []string, useDefaultStreamFields bool) error {
-	var req pb.ExportLogsServiceRequest
+	req := getExportLogsReq()
+	defer putExportLogsReq(req)
+
 	if err := req.UnmarshalProtobuf(data); err != nil {
 		errorsTotal.Inc()
 		return fmt.Errorf("cannot unmarshal request from %d bytes: %w", len(data), err)
 	}
 
-	var commonFields []logstorage.Field
+	commonFields := getFields()
+	defer putFields(commonFields)
+
 	for _, rl := range req.ResourceLogs {
-		commonFields = commonFields[:0]
-		commonFields = appendKeyValues(commonFields, rl.Resource.Attributes, "")
-		commonFieldsLen := len(commonFields)
+		*commonFields = (*commonFields)[:0]
+		*commonFields = appendKeyValues(*commonFields, rl.Resource.Attributes, "")
+		commonFieldsLen := len(*commonFields)
 		for _, sc := range rl.ScopeLogs {
-			commonFields = pushFieldsFromScopeLogs(&sc, commonFields[:commonFieldsLen], lmp, msgFields, useDefaultStreamFields)
+			*commonFields = pushFieldsFromScopeLogs(&sc, (*commonFields)[:commonFieldsLen], lmp, msgFields, useDefaultStreamFields)
 		}
 	}
 
@@ -151,4 +170,30 @@ func appendKeyValues(fields []logstorage.Field, kvs []*pb.KeyValue, parentField 
 		}
 	}
 	return fields
+}
+
+func getExportLogsReq() *pb.ExportLogsServiceRequest {
+	req := exportLogsReqPool.Get().(*pb.ExportLogsServiceRequest)
+	if req == nil {
+		return &pb.ExportLogsServiceRequest{}
+	}
+	return req
+}
+
+func putExportLogsReq(req *pb.ExportLogsServiceRequest) {
+	req.ResourceLogs = req.ResourceLogs[:0]
+	exportLogsReqPool.Put(req)
+}
+
+func getFields() *[]logstorage.Field {
+	value := fieldsPool.Get()
+	if value == nil {
+		return &[]logstorage.Field{}
+	}
+	return value.(*[]logstorage.Field)
+}
+
+func putFields(fields *[]logstorage.Field) {
+	*fields = (*fields)[:0]
+	fieldsPool.Put(fields)
 }

--- a/app/vlinsert/opentelemetry/opentelemetry_test.go
+++ b/app/vlinsert/opentelemetry/opentelemetry_test.go
@@ -207,3 +207,42 @@ func TestPushProtoOk(t *testing.T) {
 func ptrTo[T any](s T) *T {
 	return &s
 }
+
+func BenchmarkPushProto(b *testing.B) {
+	f := func(src []pb.ResourceLogs, timestampsExpected []int64, resultExpected string) {
+		lr := pb.ExportLogsServiceRequest{
+			ResourceLogs: src,
+		}
+
+		pData := lr.MarshalProtobuf(nil)
+		tlp := &insertutil.TestLogMessageProcessor{}
+		if err := pushProtobufRequest(pData, tlp, nil, false); err != nil {
+			b.Fatalf("unexpected error: %s", err)
+		}
+
+		if err := tlp.Verify(timestampsExpected, resultExpected); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		// single line without resource attributes
+		f([]pb.ResourceLogs{
+			{
+				ScopeLogs: []pb.ScopeLogs{
+					{
+						LogRecords: []pb.LogRecord{
+							{Attributes: []*pb.KeyValue{}, TimeUnixNano: 1234, SeverityNumber: 1, Body: pb.AnyValue{StringValue: ptrTo("log-line-message")}},
+						},
+					},
+				},
+			},
+		},
+			[]int64{1234},
+			`{"_msg":"log-line-message","severity":"Trace"}`,
+		)
+	}
+}


### PR DESCRIPTION
### Describe Your Changes

Added two `sync.Pool` to reduce memory allocations

1. `exportLogsReqPool` for  `pb.ExportLogsServiceRequest{}` objects
2. ` fieldsPool` for ` []logstorage.Field slices`
```txt
goos: darwin
goarch: arm64
pkg: github.com/VictoriaMetrics/VictoriaLogs/app/vlinsert/opentelemetry
cpu: Apple M3
            │ before.txt  │             after.txt             │
            │   sec/op    │   sec/op     vs base              │
PushProto-8   711.5n ± 6%   656.0n ± 0%  -7.81% (p=0.002 n=6)

            │ before.txt │             after.txt             │
            │    B/op    │    B/op     vs base               │
PushProto-8   753.0 ± 0%   609.0 ± 0%  -19.12% (p=0.002 n=6)

            │ before.txt │             after.txt             │
            │ allocs/op  │ allocs/op   vs base               │
PushProto-8   21.00 ± 0%   18.00 ± 0%  -14.29% (p=0.002 n=6)
```
