### PR TITLE
app/vlinsert: splunk support

### DIFF
--- a/app/vlinsert/main.go
+++ b/app/vlinsert/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaLogs/app/vlinsert/nativeinsert"
 	"github.com/VictoriaMetrics/VictoriaLogs/app/vlinsert/nativeinsert/nativemultitenant"
 	"github.com/VictoriaMetrics/VictoriaLogs/app/vlinsert/opentelemetry"
+	"github.com/VictoriaMetrics/VictoriaLogs/app/vlinsert/splunk"
 	"github.com/VictoriaMetrics/VictoriaLogs/app/vlinsert/syslog"
 )
 
@@ -29,6 +30,7 @@ var (
 func Init() {
 	syslog.MustInit()
 	journald.MustInit()
+	splunk.MustInit()
 }
 
 // Stop stops vlinsert
@@ -66,6 +68,13 @@ func RequestHandler(w http.ResponseWriter, r *http.Request) bool {
 		}
 
 		return datadog.RequestHandler(path, w, r)
+	case strings.HasPrefix(path, "/services/collector/"):
+		if *disableInsert {
+			httpserver.Errorf(w, r, "requests to /services/collector/* are disabled with -insert.disable command-line flag")
+			return true
+		}
+
+		return splunk.RequestHandler(path, w, r)
 	}
 
 	return false
@@ -93,7 +102,8 @@ func insertHandler(w http.ResponseWriter, r *http.Request, path string) bool {
 	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8353
 	case strings.HasPrefix(path, "/insert/elasticsearch"):
 		return elasticsearch.RequestHandler(path, w, r)
-
+	case strings.HasPrefix(path, "/insert/splunk/"):
+		return splunk.RequestHandler(path, w, r)
 	case strings.HasPrefix(path, "/insert/loki/"):
 		return loki.RequestHandler(path, w, r)
 	case strings.HasPrefix(path, "/insert/opentelemetry/"):

--- a/app/vlinsert/splunk/splunk.go
+++ b/app/vlinsert/splunk/splunk.go
@@ -1,0 +1,186 @@
+package splunk
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/httpserver"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/protoparserutil"
+	"github.com/VictoriaMetrics/metrics"
+
+	"github.com/VictoriaMetrics/VictoriaLogs/app/vlinsert/insertutil"
+	"github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage"
+)
+
+var (
+	splunkStreamFields = flagutil.NewArrayString("splunk.streamFields", "Comma-separated list of fields to use as log stream fields for logs ingested over splunk protocol. "+
+		"See https://docs.victoriametrics.com/victorialogs/data-ingestion/splunk/#stream-fields")
+	splunkIgnoreFields = flagutil.NewArrayString("splunk.ignoreFields", "Comma-separated list of fields to ignore for logs ingested over splunk protocol. "+
+		"See https://docs.victoriametrics.com/victorialogs/data-ingestion/splunk/#dropping-fields")
+	splunkPreserveJSONKeys = flagutil.NewArrayString("splunk.preserveJSONKeys", "Comma-separated list of JSON keys that should be preserved from flattening. ")
+	splunkTimeField        = flag.String("splunk.timeField", "time", "Field to use as a log timestamp for logs ingested via splunk protocol. "+
+		"See https://docs.victoriametrics.com/victorialogs/data-ingestion/splunk/#time-field")
+	splunkMsgField = flagutil.NewArrayString("splunk.msgField", "Field to use as a log message for logs ingested via splunk protocol. "+
+		"See https://docs.victoriametrics.com/victorialogs/data-ingestion/splunk/#message-field")
+	splunkTenantID = flag.String("splunk.tenantID", "0:0", "TenantID for logs ingested via the Splunk endpoint. "+
+		"See https://docs.victoriametrics.com/victorialogs/data-ingestion/splunk/#multitenancy")
+	splunkMaxRequestSize = flagutil.NewBytes("splunk.maxRequestSize", 64*1024*1024, "The maximum size in bytes of a single Splunk request")
+)
+
+var tenantID logstorage.TenantID
+
+// MustInit initializes splunk parser
+//
+// This function must be called after flag.Parse().
+func MustInit() {
+	t, err := logstorage.ParseTenantID(*splunkTenantID)
+	if err != nil {
+		logger.Panicf("cannot parse -splunk.tenantID=%q for splunk: %v", *splunkTenantID, err)
+	}
+	tenantID = t
+}
+
+func getCommonParams(r *http.Request) (*insertutil.CommonParams, error) {
+	cp, err := insertutil.GetCommonParams(r)
+	if err != nil {
+		return nil, err
+	}
+	if cp.TenantID.AccountID == 0 && cp.TenantID.ProjectID == 0 {
+		cp.TenantID = tenantID
+	}
+
+	if !cp.IsTimeFieldSet {
+		cp.TimeFields = []string{*splunkTimeField}
+	}
+	if len(cp.StreamFields) == 0 {
+		cp.StreamFields = getStreamFields()
+	}
+	if len(cp.IgnoreFields) == 0 {
+		cp.IgnoreFields = *splunkIgnoreFields
+	}
+	if len(cp.MsgFields) == 0 {
+		cp.MsgFields = getMsgFields()
+	}
+	if len(cp.PreserveJSONKeys) == 0 {
+		cp.PreserveJSONKeys = *splunkPreserveJSONKeys
+	}
+	return cp, nil
+}
+
+func getMsgFields() []string {
+	if len(*splunkMsgField) > 0 {
+		return *splunkMsgField
+	}
+	return []string{
+		"event",
+		"event.log",
+		"event.line",
+		"event.message",
+	}
+}
+
+func getStreamFields() []string {
+	if len(*splunkStreamFields) > 0 {
+		return *splunkStreamFields
+	}
+	return defaultStreamFields
+}
+
+var defaultStreamFields = []string{
+	"sourcetype",
+	"host",
+	"source",
+}
+
+// RequestHandler processes splunk insert requests
+func RequestHandler(path string, w http.ResponseWriter, r *http.Request) bool {
+	switch path {
+	case "/insert/splunk/services/collector/health", "/services/collector/health":
+		w.WriteHeader(http.StatusOK)
+	case "/insert/splunk/services/collector/event", "/insert/splunk/services/collector/event/1.0", "/services/collector/event", "/services/collector/event/1.0":
+		requestHandler(w, r)
+	default:
+		return false
+	}
+	return true
+}
+
+func requestHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodOptions:
+		w.WriteHeader(http.StatusOK)
+		return
+	case http.MethodPost:
+		w.Header().Add("Content-Type", "application/json")
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	startTime := time.Now()
+	requestsTotal.Inc()
+
+	cp, err := getCommonParams(r)
+	if err != nil {
+		httpserver.Errorf(w, r, "%s", err)
+		return
+	}
+	if err := insertutil.CanWriteData(); err != nil {
+		httpserver.Errorf(w, r, "%s", err)
+		return
+	}
+
+	encoding := r.Header.Get("Content-Encoding")
+	err = protoparserutil.ReadUncompressedData(r.Body, encoding, splunkMaxRequestSize, func(data []byte) error {
+		lmp := cp.NewLogMessageProcessor("splunk", true)
+		defer lmp.MustClose()
+		return processEvent(data, lmp, cp.TimeFields, cp.MsgFields, cp.PreserveJSONKeys)
+	})
+	if err != nil {
+		httpserver.Errorf(w, r, "cannot read Splunk request: %s", err)
+		return
+	}
+
+	requestDuration.UpdateDuration(startTime)
+	fmt.Fprintf(w, `{"text":"Success","code":0}`)
+}
+
+func processEvent(data []byte, lmp insertutil.LogMessageProcessor, timeFields, msgFields, preserveKeys []string) error {
+	s := logstorage.GetJSONScanner()
+	defer logstorage.PutJSONScanner(s)
+
+	var n int
+
+	s.Init(data, preserveKeys, "")
+	for s.NextLogMessage() {
+		ts, err := insertutil.ExtractTimestampFromFields(timeFields, s.Fields)
+		if err != nil {
+			logger.Warnf("splunk: failed to parse JSON message #%d timestamp: %s", n+1, err)
+			errorsTotal.Add(1)
+			continue
+		}
+		logstorage.RenameField(s.Fields, msgFields, "_msg")
+		lmp.AddRow(ts, s.Fields, -1)
+		n++
+	}
+	if err := s.Error(); err != nil {
+		errorsTotal.Add(1)
+		if n > 0 {
+			logger.Warnf("splunk: failed to parse JSON message #%d: %s", n+1, err)
+			return nil
+		}
+		return fmt.Errorf("splunk: failed to parse whole event: %w", err)
+	}
+	return nil
+}
+
+var (
+	requestsTotal = metrics.NewCounter(`vl_http_requests_total{path="/insert/splunk"}`)
+	errorsTotal   = metrics.NewCounter(`vl_http_errors_total{path="/insert/splunk"}`)
+
+	requestDuration = metrics.NewSummary(`vl_http_request_duration_seconds{path="/insert/splunk"}`)
+)

--- a/app/vlinsert/splunk/splunk_test.go
+++ b/app/vlinsert/splunk/splunk_test.go
@@ -1,0 +1,74 @@
+package splunk
+
+import (
+	"testing"
+
+	"github.com/VictoriaMetrics/VictoriaLogs/app/vlinsert/insertutil"
+)
+
+func TestProcessDataSuccess(t *testing.T) {
+	f := func(data, timeField, msgField string, timestampsExpected []int64, resultExpected string) {
+		t.Helper()
+
+		timeFields := []string{timeField}
+		msgFields := []string{msgField}
+		tlp := &insertutil.TestLogMessageProcessor{}
+		if err := processEvent([]byte(data), tlp, timeFields, msgFields, nil); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if err := tlp.Verify(timestampsExpected, resultExpected); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	data := `{"@timestamp":"2023-06-06T04:48:11.735Z","event":"foobar","source":"docker","host":"localhost"}` +
+		`{"@timestamp":"2023-06-06T04:48:12.735+01:00","event":"baz"}` +
+		`{"event":"xyz","@timestamp":"2023-06-06 04:48:13.735Z","x":"y"}`
+	timeField := "@timestamp"
+	msgField := "event"
+	timestampsExpected := []int64{1686026891735000000, 1686023292735000000, 1686026893735000000}
+	resultExpected := `{"_msg":"foobar","source":"docker","host":"localhost"}
+{"_msg":"baz"}
+{"_msg":"xyz","x":"y"}`
+	f(data, timeField, msgField, timestampsExpected, resultExpected)
+
+	// Non-existing msgField
+	data = `{"@timestamp":"2023-06-06T04:48:11.735Z","log":{"offset":71770,"file":{"path":"/var/log/auth.log"}},"message":"foobar"}` +
+		`{"@timestamp":"2023-06-06T04:48:12.735+01:00","message":"baz"}`
+	timeField = "@timestamp"
+	msgField = "foobar"
+	timestampsExpected = []int64{1686026891735000000, 1686023292735000000}
+	resultExpected = `{"log.offset":"71770","log.file.path":"/var/log/auth.log","message":"foobar"}
+{"message":"baz"}`
+	f(data, timeField, msgField, timestampsExpected, resultExpected)
+}
+
+func TestProcessDataFailure(t *testing.T) {
+	f := func(data string) {
+		t.Helper()
+
+		tlp := &insertutil.TestLogMessageProcessor{}
+		if err := processEvent([]byte(data), tlp, []string{"time"}, nil, nil); err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+
+		if err := tlp.Verify(nil, ""); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+	}
+
+	// invalid json
+	f("foobar")
+
+	f(`foo
+bar`)
+
+	f(`
+foo
+
+`)
+
+	// contains invalid JSON
+	f(`{"time":"foobar}`)
+}

--- a/deployment/docker/victorialogs/fluentbit/README.md
+++ b/deployment/docker/victorialogs/fluentbit/README.md
@@ -6,6 +6,7 @@ The folder contains examples of [FluentBit](https://docs.fluentbit.io/manual) in
 * [loki](./loki)
 * [jsonline single node](./jsonline)
 * [otlp](./otlp)
+* [splunk](./splunk)
 
 ## Quick start
 
@@ -37,5 +38,6 @@ FluentBit configuration example can be found below:
 * [loki](./loki/fluent-bit.conf)
 * [jsonline single node](./jsonline/fluent-bit.conf)
 * [otlp](./otlp/fluent-bit.conf)
+* [splunk](./splunk/fluent-bit.conf)
 
 > Please, note that `_stream_fields` parameter must follow recommended [best practices](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields) to achieve better performance.

--- a/deployment/docker/victorialogs/fluentbit/splunk/compose.yml
+++ b/deployment/docker/victorialogs/fluentbit/splunk/compose.yml
@@ -1,0 +1,3 @@
+include:
+ - ../compose-base.yml
+name: fluentbit-splunk

--- a/deployment/docker/victorialogs/fluentbit/splunk/fluent-bit.conf
+++ b/deployment/docker/victorialogs/fluentbit/splunk/fluent-bit.conf
@@ -1,0 +1,40 @@
+[INPUT]
+    name             tail
+    tag              logs.tail
+    path             /var/lib/docker/containers/**/*.log
+    path_key         path
+    multiline.parser docker, cri
+    parser           docker
+    docker_mode      On
+
+[INPUT]
+    name     syslog
+    tag      logs.syslog
+    listen   0.0.0.0
+    port     5140
+    parser   syslog-rfc3164
+    mode     tcp
+
+[INPUT]
+    name            fluentbit_metrics
+    tag             metrics.internal
+    scrape_interval 2
+
+[SERVICE]
+    flush        1
+    parsers_file parsers.conf
+
+[OUTPUT]
+    name  prometheus_remote_write
+    match metrics.*
+    host  victoriametrics
+    port  8428
+    uri   /api/v1/write
+
+[OUTPUT]
+    name         splunk
+    match        logs.*
+    host         vlagent
+    port         9429
+    compress     gzip
+    splunk_token test

--- a/deployment/docker/victorialogs/vector/splunk/compose.yml
+++ b/deployment/docker/victorialogs/vector/splunk/compose.yml
@@ -1,0 +1,3 @@
+include:
+ - ../compose-base.yml
+name: vector-splunk

--- a/deployment/docker/victorialogs/vector/splunk/vector.yml
+++ b/deployment/docker/victorialogs/vector/splunk/vector.yml
@@ -1,0 +1,36 @@
+api:
+  enabled: true
+  address: 0.0.0.0:8686
+sources:
+  docker:
+    type: docker_logs
+  metrics:
+    type: internal_metrics
+transforms:
+  msg_parser:
+    type: remap
+    inputs:
+      - docker
+    source: |
+      .message = parse_json(.message) ?? .message
+sinks:
+  splunk:
+    type: splunk_hec_logs
+    inputs:
+      - msg_parser
+    endpoint: http://vlagent:9429/insert/splunk
+    indexed_fields:
+      - image
+    encoding:
+      codec: json
+    compression: gzip
+    default_token: test
+    healthcheck:
+      enabled: false
+  victoriametrics:
+    type: prometheus_remote_write
+    endpoint: http://victoriametrics:8428/api/v1/write
+    inputs: 
+      - metrics
+    healthcheck:
+      enabled: false

--- a/docs/victorialogs/data-ingestion/Splunk.md
+++ b/docs/victorialogs/data-ingestion/Splunk.md
@@ -1,0 +1,61 @@
+---
+weight: 14
+title: Splunk Setup
+disableToc: true
+menu:
+  docs:
+    parent: "victorialogs-data-ingestion"
+    weight: 14
+tags:
+  - logs
+---
+VictoriaLogs supports logs ingested using [Splunk HEC API](https://help.splunk.com/en/splunk-enterprise/get-started/get-data-in/9.0/get-data-with-http-event-collector/set-up-and-use-http-event-collector-in-splunk-web). Use `/insert/splunk/services/collector/event` or `/insert/splunk/services/collector/event/1.0` to ingest HEC events. Additionally paths without `/insert/splunk/` prefix are supported to simplify integration.
+
+## Collect docker logs using Splunk driver
+
+Docker Splunk driver can be configured to send data to VictoriaLogs without any additional agent:
+
+```
+services:
+  nginx:
+    image: nginx:1.27
+    logging:
+      driver: splunk
+      options:
+        splunk-url: http://victorialogs:9428
+        splunk-token: any-token
+```
+
+## Time field
+
+VictoriaLogs uses the `time` field as [`_time` field](https://docs.victoriametrics.com/victorialogs/keyconcepts/#time-field)
+for the logs ingested via Splunk endpoint. Other field can be used instead by setting `-splunk.timeField` command-line flag.
+
+## Message field
+
+By default VictoriaLogs uses the `event,event.log,event.line,event.message` field as [`_msg` field](https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field)
+for the logs ingested via Splunk endpoint. Other field can be used instead by passing a comma-separated list to `-splunk.msgField` command-line flag.
+
+## Stream fields
+
+VictoriaLogs uses `host,source,sourcetype` as [stream fields](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields)
+for logs ingested via splunk protocol. The list of log stream fields can be changed via `-splunk.streamFields` command-line flag if needed,
+by providing comma-separated list of fields.
+
+## Dropping fields
+
+VictoriaLogs can be configured for skipping the given [log fields](https://docs.victoriametrics.com/victorialogs/keyconcepts/#data-model)
+for logs ingested via splunk protocol, via `-splunk.ignoreFields` command-line flag, which accepts comma-separated list of log fields to ignore.
+This list can contain log field prefixes ending with `*` such as `some-prefix*`. In this case all the fields starting from `some-prefix` are ignored.
+
+## Multitenancy
+
+By default VictoriaLogs stores logs ingested via splunk protocol into `(AccountID=0, ProjectID=0)` [tenant](https://docs.victoriametrics.com/victorialogs/#multitenancy).
+This can be changed by passing the needed tenant in the format `AccountID:ProjectID` at the `-splunk.tenantID` command-line flag.
+For example, `-splunk.tenantID=123:456` would store logs ingested via splunk protocol into `(AccountID=123, ProjectID=456)` tenant.
+
+See also:
+
+- [Data ingestion troubleshooting](https://docs.victoriametrics.com/victorialogs/data-ingestion/#troubleshooting).
+- [How to query VictoriaLogs](https://docs.victoriametrics.com/victorialogs/querying/).
+- [Docker-compose demo for Splunk integration with VictoriaLogs](https://github.com/VictoriaMetrics/VictoriaLogs/tree/master/deployment/docker/victorialogs/vector/splunk).

--- a/lib/logstorage/json_parser.go
+++ b/lib/logstorage/json_parser.go
@@ -15,37 +15,10 @@ import (
 //
 // Use GetJSONParser() for obtaining the parser.
 type JSONParser struct {
-	// Fields contains the parsed JSON line after Parse() call
-	//
-	// The Fields are valid until the next call to ParseLogMessage()
-	// or until the parser is returned to the pool with PutJSONParser() call.
-	Fields []Field
+	commonJSON
 
 	// p is used for fast JSON parsing
 	p fastjson.Parser
-
-	// buf is used for holding the backing data for Fields
-	buf []byte
-
-	// prefixBuf is used for holding the current key prefix
-	// when it is composed from multiple keys.
-	prefixBuf []byte
-
-	preserveKeys    []string
-	fieldPrefix     string
-	maxFieldNameLen int
-}
-
-func (p *JSONParser) reset() {
-	clear(p.Fields)
-	p.Fields = p.Fields[:0]
-
-	p.buf = p.buf[:0]
-
-	p.prefixBuf = p.prefixBuf[:0]
-	p.preserveKeys = nil
-	p.fieldPrefix = ""
-	p.maxFieldNameLen = 0
 }
 
 // GetJSONParser returns JSONParser ready to parse JSON lines.
@@ -77,7 +50,7 @@ var parserPool sync.Pool
 //
 // The p.Fields remains valid until the next call to ParseLogMessage() or PutJSONParser().
 func (p *JSONParser) ParseLogMessage(msg []byte, preserveKeys []string, fieldPrefix string) error {
-	return p.parseLogMessage(msg, preserveKeys, fieldPrefix, maxFieldNameSize)
+	return p.parseLogMessage(msg, preserveKeys, maxFieldNameSize, fieldPrefix)
 }
 
 // parseLogMessage parses the given JSON log message msg into p.Fields.
@@ -86,7 +59,7 @@ func (p *JSONParser) ParseLogMessage(msg []byte, preserveKeys []string, fieldPre
 // or its length exceeds maxFieldNameLen.
 //
 // The p.Fields remains valid until the next call to ParseLogMessage() or PutJSONParser().
-func (p *JSONParser) parseLogMessage(msg []byte, preserveKeys []string, fieldPrefix string, maxFieldNameLen int) error {
+func (p *JSONParser) parseLogMessage(msg []byte, preserveKeys []string, maxFieldNameLen int, fieldPrefix string) error {
 	p.reset()
 
 	msgStr := bytesutil.ToUnsafeString(msg)
@@ -98,17 +71,55 @@ func (p *JSONParser) parseLogMessage(msg []byte, preserveKeys []string, fieldPre
 	if err != nil {
 		return err
 	}
-
-	p.maxFieldNameLen = maxFieldNameLen
-	p.preserveKeys = preserveKeys
-	p.fieldPrefix = fieldPrefix
+	p.init(preserveKeys, maxFieldNameLen, fieldPrefix)
 	p.appendLogFields(o)
 	return nil
 }
 
-func (p *JSONParser) appendLogFields(o *fastjson.Object) {
-	if p.isTooLongKey(o) || p.shouldPreserveKeyPrefix() {
-		p.appendPreservedLogField(o)
+type commonJSON struct {
+	// Fields contains the parsed JSON line after Scan() call
+	//
+	// The Fields are valid until the next call to ScanLogMessage()
+	// or until the parser is returned to the pool with PutJSONScanner() call.
+	Fields []Field
+
+	// buf is used for holding the backing data for Fields
+	buf []byte
+
+	// prefixBuf is used for holding the current key prefix
+	// when it is composed from multiple keys.
+	prefixBuf []byte
+
+	preserveKeys    []string
+	fieldPrefix     string
+	maxFieldNameLen int
+}
+
+func (c *commonJSON) reset() {
+	c.resetKeepSettings()
+	c.preserveKeys = nil
+	c.fieldPrefix = ""
+	c.maxFieldNameLen = 0
+}
+
+func (c *commonJSON) init(preserveKeys []string, maxFieldNameLen int, fieldPrefix string) {
+	c.preserveKeys = preserveKeys
+	c.fieldPrefix = fieldPrefix
+	c.maxFieldNameLen = maxFieldNameLen
+}
+
+func (c *commonJSON) resetKeepSettings() {
+	clear(c.Fields)
+	c.Fields = c.Fields[:0]
+
+	c.buf = c.buf[:0]
+
+	c.prefixBuf = c.prefixBuf[:0]
+}
+
+func (c *commonJSON) appendLogFields(o *fastjson.Object) {
+	if c.isTooLongKey(o) || c.shouldPreserveKeyPrefix() {
+		c.appendPreservedLogField(o)
 		return
 	}
 
@@ -126,72 +137,72 @@ func (p *JSONParser) appendLogFields(o *fastjson.Object) {
 				logger.Panicf("BUG: unexpected error: %s", err)
 			}
 
-			prefixLen := len(p.prefixBuf)
-			p.prefixBuf = append(p.prefixBuf, k...)
-			p.prefixBuf = append(p.prefixBuf, '.')
-			p.appendLogFields(o)
-			p.prefixBuf = p.prefixBuf[:prefixLen]
+			prefixLen := len(c.prefixBuf)
+			c.prefixBuf = append(c.prefixBuf, k...)
+			c.prefixBuf = append(c.prefixBuf, '.')
+			c.appendLogFields(o)
+			c.prefixBuf = c.prefixBuf[:prefixLen]
 		case fastjson.TypeArray, fastjson.TypeNumber, fastjson.TypeTrue, fastjson.TypeFalse:
 			// Convert JSON arrays, numbers, true and false values to their string representation
-			bufLen := len(p.buf)
-			p.buf = v.MarshalTo(p.buf)
-			value := p.buf[bufLen:]
-			p.appendLogField(k, value)
+			bufLen := len(c.buf)
+			c.buf = v.MarshalTo(c.buf)
+			value := c.buf[bufLen:]
+			c.appendLogField(k, value)
 		case fastjson.TypeString:
 			// Decode JSON strings
-			bufLen := len(p.buf)
-			p.buf = append(p.buf, v.GetStringBytes()...)
-			value := p.buf[bufLen:]
-			p.appendLogField(k, value)
+			bufLen := len(c.buf)
+			c.buf = append(c.buf, v.GetStringBytes()...)
+			value := c.buf[bufLen:]
+			c.appendLogField(k, value)
 		default:
 			logger.Panicf("BUG: unexpected JSON type: %s", t)
 		}
 	})
 }
 
-func (p *JSONParser) isTooLongKey(o *fastjson.Object) bool {
+func (c *commonJSON) isTooLongKey(o *fastjson.Object) bool {
 	maxKeyLen := 0
 	o.Visit(func(k []byte, _ *fastjson.Value) {
 		if len(k) > maxKeyLen {
 			maxKeyLen = len(k)
 		}
 	})
-	return len(p.prefixBuf)+maxKeyLen > p.maxFieldNameLen
+	return len(c.prefixBuf)+maxKeyLen > c.maxFieldNameLen
 }
 
-func (p *JSONParser) shouldPreserveKeyPrefix() bool {
-	if len(p.prefixBuf) == 0 {
+func (c *commonJSON) shouldPreserveKeyPrefix() bool {
+	if len(c.prefixBuf) == 0 {
 		return false
 	}
 
-	key := bytesutil.ToUnsafeString(p.prefixBuf)
+	key := bytesutil.ToUnsafeString(c.prefixBuf)
 
 	// Drop trailing dot
 	key = key[:len(key)-1]
 
-	return slices.Contains(p.preserveKeys, key)
+	return slices.Contains(c.preserveKeys, key)
 }
 
-func (p *JSONParser) appendPreservedLogField(o *fastjson.Object) {
-	prefixLen := len(p.prefixBuf)
+func (c *commonJSON) appendPreservedLogField(o *fastjson.Object) {
+	prefixLen := len(c.prefixBuf)
 	if prefixLen > 0 {
 		// Drop trailing dot
-		p.prefixBuf = p.prefixBuf[:prefixLen-1]
+		c.prefixBuf = c.prefixBuf[:prefixLen-1]
 	}
 
-	bufLen := len(p.buf)
-	p.buf = o.MarshalTo(p.buf)
-	value := p.buf[bufLen:]
-	p.appendLogField(nil, value)
-	p.prefixBuf = p.prefixBuf[:prefixLen]
+	bufLen := len(c.buf)
+	c.buf = o.MarshalTo(c.buf)
+	value := c.buf[bufLen:]
+	c.appendLogField(nil, value)
+	c.prefixBuf = c.prefixBuf[:prefixLen]
 }
 
-func (p *JSONParser) appendLogField(k, value []byte) {
-	bufLen := len(p.buf)
-	p.buf = append(p.buf, p.fieldPrefix...)
-	p.buf = append(p.buf, p.prefixBuf...)
-	p.buf = append(p.buf, k...)
-	name := p.buf[bufLen:]
+func (c *commonJSON) appendLogField(k, value []byte) {
+	bufLen := len(c.buf)
+	c.buf = append(c.buf, c.fieldPrefix...)
+	c.buf = append(c.buf, c.prefixBuf...)
+	c.buf = append(c.buf, k...)
+	name := c.buf[bufLen:]
 
 	nameStr := bytesutil.ToUnsafeString(name)
 	if nameStr == "" {
@@ -199,7 +210,7 @@ func (p *JSONParser) appendLogField(k, value []byte) {
 	}
 	valueStr := bytesutil.ToUnsafeString(value)
 
-	p.Fields = append(p.Fields, Field{
+	c.Fields = append(c.Fields, Field{
 		Name:  nameStr,
 		Value: valueStr,
 	})

--- a/lib/logstorage/json_parser_test.go
+++ b/lib/logstorage/json_parser_test.go
@@ -177,7 +177,7 @@ func TestJSONParserTooLongFieldName(t *testing.T) {
 		t.Helper()
 
 		p := GetJSONParser()
-		err := p.parseLogMessage([]byte(data), nil, "", maxFieldLen)
+		err := p.parseLogMessage([]byte(data), nil, maxFieldLen, "")
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}

--- a/lib/logstorage/json_scanner.go
+++ b/lib/logstorage/json_scanner.go
@@ -1,0 +1,68 @@
+package logstorage
+
+import (
+	"sync"
+
+	"github.com/valyala/fastjson"
+)
+
+// JSONScanner scans all existing JSON messages in a string.
+//
+// See https://docs.victoriametrics.com/victorialogs/keyconcepts/#data-model
+//
+// Use GetJSONScanner() for obtaining the scanner.
+type JSONScanner struct {
+	commonJSON
+
+	// s is used for fast JSON parsing
+	s fastjson.Scanner
+
+	// err contains parsing error
+	err error
+}
+
+// GetJSONScanner returns JSONScanner ready to parse JSON lines.
+//
+// Return the parser to the pool when it is no longer needed by calling PutJSONScanner().
+func GetJSONScanner() *JSONScanner {
+	v := scannerPool.Get()
+	if v == nil {
+		return &JSONScanner{}
+	}
+	return v.(*JSONScanner)
+}
+
+// PutJSONScanner returns the parser to the pool.
+//
+// The parser cannot be used after returning to the pool.
+func PutJSONScanner(s *JSONScanner) {
+	s.reset()
+	scannerPool.Put(s)
+}
+
+var scannerPool sync.Pool
+
+func (s *JSONScanner) Init(msg []byte, preserveKeys []string, fieldPrefix string) {
+	s.s.InitBytes(msg)
+	s.init(preserveKeys, maxFieldNameSize, fieldPrefix)
+}
+
+func (s *JSONScanner) NextLogMessage() bool {
+	s.resetKeepSettings()
+	if !s.s.Next() {
+		s.err = s.s.Error()
+		return false
+	}
+	v := s.s.Value()
+	o, err := v.Object()
+	if err != nil {
+		s.err = err
+		return false
+	}
+	s.appendLogFields(o)
+	return true
+}
+
+func (s *JSONScanner) Error() error {
+	return s.err
+}

--- a/lib/logstorage/json_scanner_test.go
+++ b/lib/logstorage/json_scanner_test.go
@@ -1,0 +1,54 @@
+package logstorage
+
+import (
+	"testing"
+)
+
+func TestJSONScannerFailure(t *testing.T) {
+	f := func(data string) {
+		t.Helper()
+
+		s := GetJSONScanner()
+		s.Init([]byte(data), nil, "")
+		for s.NextLogMessage() {
+		}
+		if err := s.Error(); err == nil {
+			t.Fatalf("expecting non-nil error")
+		}
+		PutJSONScanner(s)
+	}
+	f("{foo")
+	f("[1,2,3]")
+	f(`{"foo",}`)
+}
+
+func TestJSONScannerSuccess(t *testing.T) {
+	f := func(data string, fieldPrefix string, preserveKeys []string, outputExpected string) {
+		t.Helper()
+
+		s := GetJSONScanner()
+		s.Init([]byte(data), preserveKeys, fieldPrefix)
+		var output []byte
+		for s.NextLogMessage() {
+			output = MarshalFieldsToJSON(output, s.Fields)
+		}
+		if err := s.Error(); err != nil {
+			t.Fatalf("unexpected error error")
+		}
+
+		if string(output) != outputExpected {
+			t.Fatalf("unexpected fields;\ngot\n%s\nwant\n%s", output, outputExpected)
+		}
+		PutJSONScanner(s)
+	}
+
+	f("{}", "", nil, "{}")
+	f(`{"foo":{"bar":"baz"}}{"bar":{"baz":"bar"}}`, "", nil, `{"foo.bar":"baz"}{"bar.baz":"bar"}`)
+	f(`{"foo":{"bar":{"x":"y","z":["foo"]}},"a":1,"b":true,"c":[1,2],"d":false,"e":null}`, "", nil, `{"foo.bar.x":"y","foo.bar.z":"[\"foo\"]","a":"1","b":"true","c":"[1,2]","d":"false"}`)
+
+	// preserve foo
+	f(`{"foo":{"bar":{"x":"y","z":["foo"]}},"a":1,"b":true,"c":[1,2],"d":false,"e":null}`, "", []string{"foo"}, `{"foo":"{\"bar\":{\"x\":\"y\",\"z\":[\"foo\"]}}","a":"1","b":"true","c":"[1,2]","d":"false"}`)
+
+	// preserve foo.bar
+	f(`{"foo":{"bar":{"x":"y","z":["foo"]}},"a":1,"b":true,"c":[1,2],"d":false,"e":null}`, "", []string{"foo.bar"}, `{"foo.bar":"{\"x\":\"y\",\"z\":[\"foo\"]}","a":"1","b":"true","c":"[1,2]","d":"false"}`)
+}

--- a/lib/logstorage/pipe_unpack_json.go
+++ b/lib/logstorage/pipe_unpack_json.go
@@ -105,7 +105,7 @@ func (pu *pipeUnpackJSON) newPipeProcessor(_ int, _ <-chan struct{}, _ func(), p
 			return
 		}
 		p := GetJSONParser()
-		err := p.parseLogMessage(bytesutil.ToUnsafeBytes(s), pu.preserveKeys, "", math.MaxInt)
+		err := p.parseLogMessage(bytesutil.ToUnsafeBytes(s), pu.preserveKeys, math.MaxInt, "")
 		if err != nil {
 			for _, filter := range pu.fieldFilters {
 				if !prefixfilter.IsWildcardFilter(filter) {


### PR DESCRIPTION
### Describe Your Changes

- replaced fastjson.Parser with fastjson.Scanner, since one line can contains multiple log entries
- added separate endpoint for Splunk HEC events
- since no collector, that supports Splunk events provides an ability to set extra HTTP headers or extra args, `-splunk.*` cmd arguments were added

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
