### PR TITLE
query: use underscore _ as the separator to detect numbers in the collapse_nums pipe.

### DIFF
--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -18,6 +18,7 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 ## tip
 
+* FEATURE: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): improve [`collapse_nums` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#collapse_nums-pipe) by treating `_` (underscore) as a separator for numeric tokens. This enables collapsing underscore‑delimited numbers (e.g. `temp_23_175863242537_93_98_` → `temp_<N>_<N>_<N>_<N>_`) for better normalization and grouping. See [#703](https://github.com/VictoriaMetrics/VictoriaLogs/issues/703).
 * FEATURE: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): expand [`equals_common_case` filter](https://docs.victoriametrics.com/victorialogs/logsql/#equals_common_case-filter) and [`contains_common_case` filter](https://docs.victoriametrics.com/victorialogs/logsql/#contains_common_case-filter), so they match phrases with whitespace in front of captial letters. For example, `_msg:contains_common_case("VictoriaMetrics")` now matches `Victoria Metrics`, `victoria metrics`, `VICTORIA METRICS`, `Victoria metrics` and `victoria Metrics` additionally to `VictoriaMetrics`, `victoriametrics`, `VICTORIAMETRICS`, `Victoriametrics` and `victoriaMetrics`.
 
 * BUGFIX: all components: restore sorting order of summary and quantile metrics exposed by VictoriaLogs components on `/metrics` page. See [metrics#105](https://github.com/VictoriaMetrics/metrics/pull/105) for details.

--- a/lib/logstorage/pipe_collapse_nums.go
+++ b/lib/logstorage/pipe_collapse_nums.go
@@ -157,7 +157,7 @@ func indexNumStart(s string, offset int) int {
 		if n == 0 {
 			return 0
 		}
-		if !isTokenChar(s[n-1]) || isSpecialNumStart(s[n-1]) {
+		if !isLetterOrDigit(s[n-1]) || isSpecialNumStart(s[n-1]) {
 			return n
 		}
 		n++
@@ -176,10 +176,16 @@ func indexNumEnd(s string, offset int) int {
 }
 
 func isValidNum(s string, start, end int) bool {
-	if end < len(s) && isTokenChar(s[end]) && !isSpecialNumEnd(s[end]) {
+	if end < len(s) && isLetterOrDigit(s[end]) && !isSpecialNumEnd(s[end]) {
 		return false
 	}
 	return canBeTreatedAsNum(s[start:end])
+}
+
+// isLetterOrDigit returns true for ASCII letters and digits; '_' is not treated as alphanumeric here
+// in order to act as a separator for collapse_nums boundaries.
+func isLetterOrDigit(c byte) bool {
+	return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9'
 }
 
 func appendPrettifyCollapsedNums(dst, src []byte) []byte {

--- a/lib/logstorage/pipe_collapse_nums_test.go
+++ b/lib/logstorage/pipe_collapse_nums_test.go
@@ -116,6 +116,17 @@ func TestPipeCollapseNums(t *testing.T) {
 			{"_msg", `<N>`},
 		},
 	})
+
+	// underscore-delimited numbers collapse
+	f(`collapse_nums`, [][]Field{
+		{
+			{"_msg", `temp_23_175863242537_93_98_ abc 123 test`},
+		},
+	}, [][]Field{
+		{
+			{"_msg", `temp_<N>_<N>_<N>_<N>_ abc <N> test`},
+		},
+	})
 }
 
 func TestPipeCollapseNumsUpdateNeededFields(t *testing.T) {


### PR DESCRIPTION
### Describe Your Changes

Related: https://github.com/VictoriaMetrics/VictoriaLogs/issues/703

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
