### PR TITLE
fix path to vlagent default data dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 /vmdocs
 /gocache-for-docker
 /victoria-logs-data
-/vlagent-remotewritewrite
+/vlagent-remotewrite-data
 .DS_store
 Gemfile.lock
 /_site


### PR DESCRIPTION
### Describe Your Changes

The default path to `remoteWrite.tmpDataPath` is incorrect in our `.gitignore` file: https://github.com/VictoriaMetrics/VictoriaLogs/blob/cc668c950e773554d055337e3aa5d8c461d7a38c/app/vlagent/remotewrite/remotewrite.go#L33

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
