### PR TITLE
docs: fix the title of the security and load balancing docs

### DIFF
--- a/docs/victorialogs/security-and-lb.md
+++ b/docs/victorialogs/security-and-lb.md
@@ -4,7 +4,7 @@ menu:
   docs:
     parent: victorialogs
     weight: 12
-title: Security and LoadBalancing
+title: Security and Load Balancing
 tags:
   - logs
 ---


### PR DESCRIPTION
### Describe Your Changes

Rename the title 'LoadBalancing' to 'Load Balancing' since it isn't a term.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
