### PR TITLE
app/vmui: add millisecond zoom for Hits chart

### DIFF
--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsChart.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsChart.tsx
@@ -23,7 +23,7 @@ interface Props {
 
 const BarHitsChart: FC<Props> = ({ logHits, data: _data, period, setPeriod, onApplyFilter, durationMs }) => {
   const [graphOptions, setGraphOptions] = useState<GraphOptions>({
-    graphStyle: GRAPH_STYLES.LINE_STEPPED,
+    graphStyle: GRAPH_STYLES.BAR,
     stacked: false,
     fill: false,
     hideChart: false,

--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsPlot/BarHitsPlot.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsPlot/BarHitsPlot.tsx
@@ -15,6 +15,7 @@ import { TimeParams } from "../../../../types";
 import BarHitsLegend from "../BarHitsLegend/BarHitsLegend";
 import { sortLogHits } from "../../../../utils/logs";
 import { useAppState } from "../../../../state/common/StateContext";
+import { useTimeState } from "../../../../state/time/TimeStateContext";
 
 interface Props {
   logHits: LogHits[];
@@ -28,6 +29,7 @@ interface Props {
 
 const BarHitsPlot: FC<Props> = ({ graphOptions, logHits, totalHits, data: _data, period, setPeriod, onApplyFilter }: Props) => {
   const { isDarkTheme } = useAppState();
+  const { timezone } = useTimeState();
   const [containerRef, containerSize] = useElementSize();
   const uPlotRef = useRef<HTMLDivElement>(null);
   const [uPlotInst, setUPlotInst] = useState<uPlot>();
@@ -48,7 +50,8 @@ const BarHitsPlot: FC<Props> = ({ graphOptions, logHits, totalHits, data: _data,
     containerSize,
     onReadyChart,
     setPlotScale,
-    graphOptions
+    graphOptions,
+    timezone
   });
 
   const legendDetails: LegendLogHits[] = useMemo(() => {
@@ -98,7 +101,7 @@ const BarHitsPlot: FC<Props> = ({ graphOptions, logHits, totalHits, data: _data,
     const uplot = new uPlot(options, data, uPlotRef.current);
     setUPlotInst(uplot);
     return () => uplot.destroy();
-  }, [uPlotRef.current, isDarkTheme]);
+  }, [uPlotRef.current, isDarkTheme, timezone]);
 
   useEffect(() => {
     if (!uPlotInst) return;

--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsTooltip/BarHitsTooltip.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsTooltip/BarHitsTooltip.tsx
@@ -147,7 +147,7 @@ const BarHitsTooltip: FC<Props> = ({ data, focusDataIdx, uPlotInst }) => {
             />
             <p className="vm-bar-hits-tooltip-item">
               <span className="vm-bar-hits-tooltip-item__label">{item.label}</span>
-              <span>{item.value.toLocaleString("en-US")}</span>
+              <span>{item.value && item.value.toLocaleString("en-US")}</span>
             </p>
           </div>
         ))}

--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/hooks/useBarHitsOptions.ts
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/hooks/useBarHitsOptions.ts
@@ -1,7 +1,5 @@
 import { useMemo, useState } from "preact/compat";
 import { getAxes, getMinMaxBuffer, handleDestroy, setSelect } from "../../../../utils/uplot";
-import dayjs from "dayjs";
-import { dateFromSeconds, formatDateForNativeInput } from "../../../../utils/time";
 import uPlot, { AlignedData, Band, Options, Series } from "uplot";
 import { getCssVariable } from "../../../../utils/theme";
 import { useAppState } from "../../../../state/common/StateContext";
@@ -35,6 +33,7 @@ interface UseGetBarHitsOptionsArgs {
   setPlotScale: SetMinMax;
   onReadyChart: (u: uPlot) => void;
   graphOptions: GraphOptions;
+  timezone: string;
 }
 
 export const OTHER_HITS_LABEL = "other";
@@ -59,7 +58,8 @@ const useBarHitsOptions = ({
   containerSize,
   onReadyChart,
   setPlotScale,
-  graphOptions
+  graphOptions,
+  timezone,
 }: UseGetBarHitsOptionsArgs) => {
   const { isDarkTheme } = useAppState();
 
@@ -129,7 +129,7 @@ const useBarHitsOptions = ({
     },
     legend: { show: false },
     axes: getAxes([{}, { scale: "y" }]),
-    tzDate: ts => dayjs(formatDateForNativeInput(dateFromSeconds(ts))).local().toDate(),
+    tzDate: ts => uPlot.tzDate(new Date(Math.round(ts * 1000)), timezone),
   };
 
   return {

--- a/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBarChart/ExploreLogsBarChart.tsx
+++ b/app/vmui/packages/vmui/src/pages/ExploreLogs/ExploreLogsBarChart/ExploreLogsBarChart.tsx
@@ -12,6 +12,7 @@ import { TimeParams } from "../../../types";
 import LineLoader from "../../../components/Main/LineLoader/LineLoader";
 import { useSearchParams } from "react-router-dom";
 import { getHitsTimeParams } from "../../../utils/logs";
+import { toEpochSeconds } from "../../../utils/time";
 
 interface Props {
   query: string;
@@ -33,8 +34,7 @@ const ExploreLogsBarChart: FC<Props> = ({ logHits, period, error, isLoading, onA
     return logHits.map(hits => {
       const timestampValueMap = new Map();
       hits.timestamps.forEach((ts, idx) => {
-        const unixTime = dayjs(ts).unix();
-        timestampValueMap.set(unixTime, hits.values[idx] || null);
+        timestampValueMap.set(toEpochSeconds(ts), hits.values[idx] || null);
       });
 
       return timestamps.map(t => timestampValueMap.get(t) || null);
@@ -56,7 +56,8 @@ const ExploreLogsBarChart: FC<Props> = ({ logHits, period, error, isLoading, onA
     const totalSteps = Math.floor(end.diff(firstTimestamp, "milliseconds") / step);
 
     for (let i = 0; i <= totalSteps; i++) {
-      result.push(firstTimestamp.add(i * step, "milliseconds").unix());
+      const t = firstTimestamp.add(i * step, "milliseconds");
+      result.push(toEpochSeconds(t));
     }
 
     return result;

--- a/app/vmui/packages/vmui/src/utils/logs.ts
+++ b/app/vmui/packages/vmui/src/utils/logs.ts
@@ -12,8 +12,8 @@ export const getStreamPairs = (value: string): string[] => {
 export const getHitsTimeParams = (period: TimeParams) => {
   const start = dayjs(period.start * 1000);
   const end = dayjs(period.end * 1000);
-  const totalSeconds = end.diff(start, "milliseconds");
-  const step = Math.ceil(totalSeconds / LOGS_BARS_VIEW) || 1;
+  const totalMs = end.diff(start, "milliseconds");
+  const step = Math.ceil(totalMs / LOGS_BARS_VIEW) || 1;
   return { start, end, step };
 };
 

--- a/app/vmui/packages/vmui/src/utils/time.ts
+++ b/app/vmui/packages/vmui/src/utils/time.ts
@@ -321,3 +321,5 @@ export const formatDateWithNanoseconds = (dateStr: string, format: string): stri
   return `${base}.${fraction}`;
 };
 
+export const toEpochSeconds = (ts: number | dayjs.Dayjs | string) => dayjs(ts).valueOf()/1000;
+

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -19,9 +19,11 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 ## tip
 
 * FEATURE: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): improve [`collapse_nums` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#collapse_nums-pipe) by treating `_` (underscore) as a separator for numeric tokens. This enables collapsing underscore‑delimited numbers (e.g. `temp_23_175863242537_93_98_` → `temp_<N>_<N>_<N>_<N>_`) for better normalization and grouping. See [#703](https://github.com/VictoriaMetrics/VictoriaLogs/issues/703).
+* FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add support for zooming the Hits chart to millisecond precision. See [#112](https://github.com/VictoriaMetrics/VictoriaLogs/issues/112).
 
 * BUGFIX: [HTTP querying APIs](https://docs.victoriametrics.com/victorialogs/querying/#http-api): treat `end` query arg as exclusive bound for time ranges, i.e. use `[start, end)` instead of `[start, end]`, e.g. the first nanosecond at the `end` isn't included in the selected time range. This affects endpoints accepting `start`/`end` (e.g. `/select/logsql/query`, `/select/logsql/hits`, `/select/logsql/stats_query_range`, `/select/logsql/streams`, etc.). See [VictoriaMetrics#9753](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9753) and [#587](https://github.com/VictoriaMetrics/VictoriaLogs/issues/587) for more details.
 * BUGFIX: all components: restore sorting order of summary and quantile metrics exposed by VictoriaLogs components on `/metrics` page. See [metrics#105](https://github.com/VictoriaMetrics/metrics/pull/105) for details.
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix incorrect X-axis time labels after switching time zones; axis ticks now reflect the selected time zone correctly.
 
 ## [v1.35.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.35.0)
 


### PR DESCRIPTION
### Describe Your Changes

### Changes
- support zooming to millisecond precision.
- keep bars rendered on sub-second ranges.
- show sub-second ticks in X-axis and tooltips.
- fix X-axis time shift after timezone switch.

Ref issue: #112

### Screenshots

Before:
<img width="1257" height="297" alt="image" src="https://github.com/user-attachments/assets/33ff7cdc-3b21-452e-bdf0-521d2ec9ba57" />

After:
<img width="1257" height="297" alt="image" src="https://github.com/user-attachments/assets/56e1e728-7ab0-470a-857a-c0f14c0d5ade" />

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
