### PR TITLE
dashboards: add VictoriaLogs internal state dashboard

### DIFF
--- a/dashboards/victorialogs-internal.json
+++ b/dashboards/victorialogs-internal.json
@@ -1809,7 +1809,7 @@
   "refresh": "",
   "schemaVersion": 42,
   "tags": [
-    "demo"
+    "victorialogs"
   ],
   "templating": {
     "list": [


### PR DESCRIPTION
Related: https://github.com/VictoriaMetrics/VictoriaLogs/issues/638

Preview: https://play-grafana.victoriametrics.com/d/be5zidev_vlogs2/victorialogs-logging-state-2?orgId=1&from=now-30m&to=now&timezone=browser&var-DS_VICTORIALOGS=PD775F2863313E6C7&var-filter=%2A&var-limit=20

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
