### PR TITLE
logsql: fix pattern match infinite loop bug

### DIFF
--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -18,6 +18,8 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 ## tip
 
+* BUGFIX: [pattern_match filter](https://docs.victoriametrics.com/victorialogs/logsql/#pattern-match-filter): fix non-progress loop in `pattern_match(...)` filter when the pattern starts with a literal separator that occurs multiple times in the target string and the rest of the pattern doesn't match. Previously this could make queries spin indefinitely. Now the matcher advances correctly and returns no match as expected. See [#759](https://github.com/VictoriaMetrics/VictoriaLogs/pull/759).
+
 ## [v1.36.1](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.36.1)
 
 Released at 2025-09-27

--- a/lib/logstorage/pattern_matcher.go
+++ b/lib/logstorage/pattern_matcher.go
@@ -154,7 +154,11 @@ func (pm *patternMatcher) matchSubstring(s string) bool {
 
 func (pm *patternMatcher) indexPatternStart(s string, offset int) int {
 	if firstSep := pm.separators[0]; firstSep != "" {
-		return strings.Index(s[offset:], firstSep)
+		n := strings.Index(s[offset:], firstSep)
+		if n < 0 {
+			return n
+		}
+		return offset + n
 	}
 
 	placeholders := pm.placeholders

--- a/lib/logstorage/pattern_matcher_test.go
+++ b/lib/logstorage/pattern_matcher_test.go
@@ -120,4 +120,8 @@ func TestPatternMatcherMatch(t *testing.T) {
 
 	f(`"foo":<W>`, `{"foo":"bar", "baz": 123}`, false, true)
 	f(`"foo":<W>`, `{"foo":"bar", "baz": 123}`, true, false)
+
+	// regression: leading separator present many times but placeholder doesn't match after it
+	f("xx<N>", "xxxxxxxxxxxxxxxx", false, false)
+	f("xx<N>", "xxxxxx123", false, true)
 }


### PR DESCRIPTION
Fix non-progress loop in `pattern_match(...)` filter when the pattern starts with a literal separator that occurs multiple times in the target string and the rest of the pattern doesn't match. Previously this could make queries spin indefinitely.

Reported by @hagen1778 

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
