### PR TITLE
app/vmui: fix log rendering with Markdown enabled and collapse_nums

### DIFF
--- a/app/vmui/packages/vmui/src/constants/markedPlugins.ts
+++ b/app/vmui/packages/vmui/src/constants/markedPlugins.ts
@@ -4,3 +4,12 @@ import emojis from "./emojis";
 
 // TODO: Dynamically import the emoji map only if the emoji parser is active
 marked.use(markedEmoji({ emojis, renderer: (token) => token.emoji }));
+
+marked.use({
+  walkTokens(token) {
+    if (token.type === "html") {
+      token.type = "text";
+      token.text = token.raw ?? token.text ?? "";
+    }
+  },
+});

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -26,6 +26,7 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 * BUGFIX: [pattern_match filter](https://docs.victoriametrics.com/victorialogs/logsql/#pattern-match-filter): fix non-progress loop in `pattern_match(...)` filter when the pattern starts with a literal separator that occurs multiple times in the target string and the rest of the pattern doesn't match. Previously this could make queries spin indefinitely. Now the matcher advances correctly and returns no match as expected. See [#759](https://github.com/VictoriaMetrics/VictoriaLogs/pull/759).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix page not resetting after changing the query in the Group View tab. See [#753](https://github.com/VictoriaMetrics/VictoriaLogs/issues/753).
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix log rendering with `markdown` enabled and [`collapse_nums` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#collapse_nums-pipe). See [#647](https://github.com/VictoriaMetrics/VictoriaLogs/issues/647).
 
 ## [v1.36.1](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.36.1)
 


### PR DESCRIPTION
### Describe Your Changes

Fixes log message rendering issue when Markdown parsing was enabled together with the[`collapse_nums` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#collapse_nums-pipe).
Now the Markdown renderer ignores raw HTML tokens, preventing placeholders like `<IP4>` or `<N>` from being stripped.

Related issue: #647 

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
