### PR TITLE
tokenizeString performance improved by 57%

### DIFF
--- a/lib/logstorage/hash_tokenizer.go
+++ b/lib/logstorage/hash_tokenizer.go
@@ -216,6 +216,7 @@ func (t *hashTokenizer) tokenizeString(dst []uint64, s string) []uint64 {
 		// Register the token.
 		token := unsafe.String((*byte)(unsafe.Add(ptr, start)), end-start)
 		if curUnicodeFlag == 1 {
+			// Only perform tokenizeStringUnicode on very short substrings if the string contains Unicode characters
 			dst = t.tokenizeStringUnicode(dst, token)
 			continue
 		}


### PR DESCRIPTION
### Describe Your Changes

1. Scan the string only once.
2. Avoid using isAscii() by checking whether the string contains Unicode.
3. Use a table lookup instead of a complex Boolean expression.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
