### PR TITLE
storage: fix block merger panic on consecutive full blocks

### DIFF
--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -20,6 +20,8 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 * FEATURE: add an ability to delete stored logs. See [these docs](https://docs.victoriametrics.com/victorialogs/#how-to-delete-logs) and [#43](https://github.com/VictoriaMetrics/VictoriaLogs/issues/43). Thanks to @func25 for the initial idea and implementation at [#4](https://github.com/VictoriaMetrics/VictoriaLogs/pull/4).
 
+* BUGFIX: fix panic `BUG: bsm.bd must be empty` triggered by back-to-back full blocks during part merge. Background compaction could crash when the merger reused buffered block data without flushing it before the next full block arrived. See [#792](https://github.com/VictoriaMetrics/VictoriaLogs/issues/792).
+
 ## [v1.37.1](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.37.1)
 
 Released at 2025-11-01

--- a/lib/logstorage/block_stream_merger.go
+++ b/lib/logstorage/block_stream_merger.go
@@ -189,10 +189,7 @@ func (bsm *blockStreamMerger) mustWriteBlock(bd *blockData) {
 		bsm.mustFlushRows()
 		bsm.setStreamID(bd.streamID)
 		bsm.mustWriteBlockData(bd)
-	case bsm.uncompressedRowsSizeBytes == 0 && bd.uncompressedSizeBytes >= maxUncompressedBlockSize:
-		// The bsm is empty and the bd is full. Just write db to the output.
-		bsm.mustWriteBlockData(bd)
-	case bsm.uncompressedRowsSizeBytes == 0 && bd.uncompressedSizeBytes >= maxUncompressedBlockSize:
+	case bsm.uncompressedRowsSizeBytes == 0 && bsm.bd.rowsCount == 0 && bd.uncompressedSizeBytes >= maxUncompressedBlockSize:
 		// The bsm is empty and the bd is full. Just write db to the output.
 		bsm.mustWriteBlockData(bd)
 	case bsm.uncompressedRowsSizeBytes+bd.uncompressedSizeBytes >= 2*maxUncompressedBlockSize:


### PR DESCRIPTION
### Describe Your Changes

Related https://github.com/VictoriaMetrics/VictoriaLogs/issues/792

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
