### PR TITLE
app/vmui: fix hits chart not updating on group by change

### DIFF
--- a/app/vmui/packages/vmui/src/pages/QueryPage/QueryPage.tsx
+++ b/app/vmui/packages/vmui/src/pages/QueryPage/QueryPage.tsx
@@ -35,6 +35,9 @@ const QueryPage: FC = () => {
   const { duration, relativeTime, period: periodState } = useTimeState();
   const { setSearchParamsFromKeys } = useSearchParamsFromObject();
   const { topHits, groupFieldHits } = useHitsChartConfig();
+  const prevTopHits = usePrevious(topHits);
+  const prevGroupFieldHits = usePrevious(groupFieldHits);
+
   const [searchParams] = useSearchParams();
 
   const hideChart = useMemo(() => Boolean(searchParams.get("hide_chart")), [searchParams]);
@@ -138,9 +141,15 @@ const QueryPage: FC = () => {
   }, [query, isUpdatingQuery]);
 
   useEffect(() => {
-    if (hideChart || !prevHideChart) return;
+    const topChanged = prevTopHits && (topHits !== prevTopHits);
+    const groupChanged = prevGroupFieldHits && (groupFieldHits !== prevGroupFieldHits);
+    const becameVisible = prevHideChart && !hideChart;
+
+    if (!(topChanged || groupChanged || becameVisible)) return;
+
+    dataLogHits.abortController.abort?.();
     fetchLogHits({ period, field: groupFieldHits, fieldsLimit: topHits });
-  }, [hideChart, prevHideChart, period, groupFieldHits, topHits, fetchLogHits]);
+  }, [hideChart, prevHideChart, period, groupFieldHits, prevGroupFieldHits, topHits, prevTopHits, fetchLogHits]);
 
   useEffect(() => {
     if (hideLogs || !prevHideLogs) return;

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -20,6 +20,8 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 * FEATURE: add an ability to delete stored logs. See [these docs](https://docs.victoriametrics.com/victorialogs/#how-to-delete-logs) and [#43](https://github.com/VictoriaMetrics/VictoriaLogs/issues/43). Thanks to @func25 for the initial idea and implementation at [#4](https://github.com/VictoriaMetrics/VictoriaLogs/pull/4).
 
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix `hits` chart not updating when changing the `group by` field. See [#788](https://github.com/VictoriaMetrics/VictoriaLogs/issues/788).
+
 ## [v1.37.2](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.37.2)
 
 Released at 2025-11-01


### PR DESCRIPTION
### Describe Your Changes

Fix `hits` chart not refreshing after changing the `group by` or `top hits` field.
Related issue: #788

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
