### PR TITLE
app/vmui: simplify the "Download logs" dialog (#789)

### DIFF
--- a/app/vmui/packages/vmui/src/components/DownloadLogs/style.scss
+++ b/app/vmui/packages/vmui/src/components/DownloadLogs/style.scss
@@ -13,7 +13,7 @@
       justify-content: flex-start;
       font-size: $font-size;
       font-weight: bold;
-      margin-bottom: $padding-global;
+      margin-bottom: $padding-small;
     }
   }
 
@@ -36,38 +36,6 @@
     color: $color-text-secondary;
     line-height: 130%;
   }
-
-  &-context {
-
-    &-item {
-      display: flex;
-      flex-wrap: wrap;
-
-      &__label,
-      &__value,
-      &__query {
-        padding-block: $padding-small;
-      }
-
-      &__label {
-        display: inline-block;
-        font-size: $font-size;
-        min-width: 90px;
-      }
-
-      &__query {
-        display: inline-block;
-        font-size: $font-size-small;
-        font-family: monospace;
-        white-space: pre-wrap;
-        padding-inline: $padding-global;
-        background-color: $color-hover-black;
-        border-radius: $border-radius-small;
-        line-height: 1.3;
-      }
-    }
-  }
-
 
   &-footer {
     display: flex;

--- a/app/vmui/packages/vmui/src/pages/QueryPage/QueryPageBody/QueryPageBody.tsx
+++ b/app/vmui/packages/vmui/src/pages/QueryPage/QueryPageBody/QueryPageBody.tsx
@@ -109,10 +109,7 @@ const QueryPageBody: FC<Props> = ({ data, queryParams, isLoading, isPreview }) =
           className="vm-query-page-body-header__settings"
           ref={settingsRef}
         />
-        <DownloadLogsModal
-          data={data}
-          queryParams={queryParams}
-        >
+        <DownloadLogsModal queryParams={queryParams}>
           <Tooltip title="Download Logs">
             <Button
               variant="text"

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -19,6 +19,7 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 ## tip
 
 * FEATURE: add an ability to delete stored logs. See [these docs](https://docs.victoriametrics.com/victorialogs/#how-to-delete-logs) and [#43](https://github.com/VictoriaMetrics/VictoriaLogs/issues/43). Thanks to @func25 for the initial idea and implementation at [#4](https://github.com/VictoriaMetrics/VictoriaLogs/pull/4).
+* FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): simplify "Download logs" dialog - show only file name field and description with time range and tenant. See [#789](https://github.com/VictoriaMetrics/VictoriaLogs/issues/789).
 
 ## [v1.37.2](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.37.2)
 


### PR DESCRIPTION
### Describe Your Changes

Simplify "Download logs" dialog - keep filename field and description with time range and tenant

<img width="691" height="313" alt="image" src="https://github.com/user-attachments/assets/ad5def2a-9e7a-440a-805d-e121cbe8ef72" />

Related issue: #789

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
