### PR TITLE
vlselect: `/select/logsql/query` endpoint excludes logs near right time boundary

### DIFF
--- a/app/vlstorage/lastnoptimization.go
+++ b/app/vlstorage/lastnoptimization.go
@@ -71,7 +71,7 @@ func getLastNQueryResults(qctx *logstorage.QueryContext, limit uint64) ([]logRow
 		}
 
 		if end/2-start/2 <= 0 {
-			// The [start ... end] time range doesn't exceed a nanosecond, e.g. it cannot be adjusted more.
+			// The [start ... end) time range doesn't exceed a nanosecond, e.g. it cannot be adjusted more.
 			// Return up to limit rows from the found rows and the last non-empty rows.
 			rowsFound = append(rowsFound, lastNonEmptyRows...)
 			rowsFound = append(rowsFound, rows...)
@@ -80,8 +80,8 @@ func getLastNQueryResults(qctx *logstorage.QueryContext, limit uint64) ([]logRow
 		}
 
 		if uint64(len(rows)) >= 2*n {
-			// The number of found rows on the [start ... end] time range exceeds 2*n,
-			// so search for the rows on the adjusted time range [start+(end/2-start/2) ... end].
+			// The number of found rows on the [start ... end) time range exceeds 2*n,
+			// so search for the rows on the adjusted time range [start+(end/2-start/2) ... end).
 			if !logstorage.CanApplyLastNResultsOptimization(start, end) {
 				// It is faster obtaining the last N logs as is on such a small time range instead of using binary search.
 				rows, err := getLogRowsLastN(qctx, start, end, n)
@@ -103,7 +103,7 @@ func getLastNQueryResults(qctx *logstorage.QueryContext, limit uint64) ([]logRow
 			return rowsFound, nil
 		}
 
-		// The number of found rows is below the limit. This means the [start ... end] time range
+		// The number of found rows is below the limit. This means the [start ... end) time range
 		// doesn't cover the needed logs, so it must be extended.
 		// Append the found rows to rowsFound, adjust n, so it doesn't take into account already found rows
 		// and adjust the time range to search logs at [start-(end/2-start/2) ... start).
@@ -111,7 +111,7 @@ func getLastNQueryResults(qctx *logstorage.QueryContext, limit uint64) ([]logRow
 		n -= uint64(len(rows))
 
 		d := end/2 - start/2
-		end = start - 1
+		end = start
 		start -= d
 	}
 }

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -23,6 +23,8 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix `hits` chart not updating when changing the `group by` field. See [#788](https://github.com/VictoriaMetrics/VictoriaLogs/issues/788).
 
+* BUGFIX: [`/select/logsql/query` endpoint](https://docs.victoriametrics.com/victorialogs/querying/#querying-logs): fix incorrect handling of the right time boundary when sorting query results. Logs located close to the right boundary could be excluded from the returned result. The bug has been introduced in [v1.36.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.36.0). See [#802](https://github.com/VictoriaMetrics/VictoriaLogs/issues/802).
+
 ## [v1.37.2](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.37.2)
 
 Released at 2025-11-01


### PR DESCRIPTION
### Describe Your Changes

When querying logs using the `/select/logsql/query` endpoint, some log entries located close to the right time boundary (end timestamp) may be incorrectly excluded from the results. The bug introduced in [v1.36.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.36.0).

Related: #802 

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
