### PR TITLE
app/vmui: fix hits graph showing first point outside selected range

### DIFF
--- a/app/vmui/packages/vmui/src/pages/QueryPage/hooks/useFetchLogHits.ts
+++ b/app/vmui/packages/vmui/src/pages/QueryPage/hooks/useFetchLogHits.ts
@@ -37,11 +37,12 @@ export const useFetchLogHits = (defaultQuery = "*") => {
   const url = useMemo(() => getLogHitsUrl(serverUrl), [serverUrl]);
 
   const getOptions = ({ query = defaultQuery, period, extraParams, signal, fieldsLimit, field }: OptionsParams) => {
-    const { start, end, step } = getHitsTimeParams(period);
+    const { start, end, step, offset } = getHitsTimeParams(period);
 
     const params = new URLSearchParams({
       query: query.trim(),
       step: `${step}ms`,
+      offset: `${offset}ms`,
       start: start.toISOString(),
       end: end.toISOString(),
       fields_limit: `${fieldsLimit || LOGS_LIMIT_HITS}`,

--- a/app/vmui/packages/vmui/src/utils/logs.ts
+++ b/app/vmui/packages/vmui/src/utils/logs.ts
@@ -12,9 +12,15 @@ export const getStreamPairs = (value: string): string[] => {
 export const getHitsTimeParams = (period: TimeParams) => {
   const start = dayjs(period.start * 1000);
   const end = dayjs(period.end * 1000);
-  const totalMs = end.diff(start, "milliseconds");
-  const step = Math.ceil(totalMs / LOGS_BARS_VIEW) || 1;
-  return { start, end, step };
+  const totalMs = Math.max(1, end.diff(start, "ms"));
+
+  let bars = Math.min(LOGS_BARS_VIEW, totalMs);
+  while (bars > 1 && (totalMs % bars) !== 0) bars--;
+
+  const step = Math.max(1, Math.floor(totalMs / bars));
+  const offset = ((start.valueOf() % step) + step) % step;
+
+  return { start, end, step, offset };
 };
 
 export const convertToFieldFilter = (value: string, field = LOGS_GROUP_BY) => {

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -20,6 +20,8 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 
 * FEATURE: add an ability to delete stored logs. See [these docs](https://docs.victoriametrics.com/victorialogs/#how-to-delete-logs) and [#43](https://github.com/VictoriaMetrics/VictoriaLogs/issues/43). Thanks to @func25 for the initial idea and implementation at [#4](https://github.com/VictoriaMetrics/VictoriaLogs/pull/4).
 
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix `/hits` graph showing the first point outside the selected time range. See [#737](https://github.com/VictoriaMetrics/VictoriaLogs/issues/737).
+
 ## [v1.37.2](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.37.2)
 
 Released at 2025-11-01


### PR DESCRIPTION
### Describe Your Changes

Align `/hits` bucket boundaries to the query start using `offset`.
Previously, when `offset` was omitted (`0s` by default), buckets were anchored to the Unix epoch, which could cause the first point on the “hits” graph to appear slightly **before** the selected range.

### Changes

* Compute `offset = start % step` in `getHitsTimeParams`.
* Pass `${offset}ms` to `/select/logsql/hits`.

Related issue: #737

| Before | After |
|-------|-------|
| <img width="1959" height="632" alt="image" src="https://github.com/user-attachments/assets/0db8808a-f1e0-449c-bb65-ad285ba3b9a6" /> | <img width="1959" height="632" alt="image" src="https://github.com/user-attachments/assets/b9f6f3f5-47d7-4ad2-a0ea-07d7b9f8507b" /> |


### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
