### PR TITLE
app/vmui: replace GET with POST for field_names and stream_field_names

### DIFF
--- a/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/LogsQL/useFetchLogsQLOptions.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/LogsQL/useFetchLogsQLOptions.tsx
@@ -78,9 +78,11 @@ export const useFetchLogsQLOptions = (contextData?: ContextData) => {
         return;
       }
 
-      const response = await fetch(`${serverUrl}/select/logsql/${urlSuffix}?${params}`, {
+      const response = await fetch(`${serverUrl}/select/logsql/${urlSuffix}`, {
         signal,
-        headers: { ...tenant }
+        method: "POST",
+        headers: { ...tenant },
+        body: params,
       });
 
       if (response.ok) {

--- a/app/vmui/packages/vmui/src/pages/OverviewPage/hooks/useFetchFieldNames.ts
+++ b/app/vmui/packages/vmui/src/pages/OverviewPage/hooks/useFetchFieldNames.ts
@@ -58,8 +58,12 @@ export const useFetchFieldNames = () => {
         return;
       }
 
-      const url = `${serverUrl}/select/logsql/field_names?${queryParams}`;
-      const response = await fetch(url, { headers });
+      const url = `${serverUrl}/select/logsql/field_names`;
+      const response = await fetch(url, {
+        method: "POST",
+        headers,
+        body: params,
+      });
 
       if (!response.ok) {
         const errorResponse = await response.text();

--- a/app/vmui/packages/vmui/src/pages/OverviewPage/hooks/useFetchStreamNames.ts
+++ b/app/vmui/packages/vmui/src/pages/OverviewPage/hooks/useFetchStreamNames.ts
@@ -8,7 +8,6 @@ interface FetchOptions {
   start: number;
   end: number;
   query?: string;
-  limit?: number;
   extraParams?: URLSearchParams;
 }
 
@@ -51,8 +50,12 @@ export const useFetchStreamFieldNames = () => {
         return;
       }
 
-      const url = `${serverUrl}/select/logsql/stream_field_names?${queryParams}`;
-      const response = await fetch(url, { headers });
+      const url = `${serverUrl}/select/logsql/stream_field_names`;
+      const response = await fetch(url, {
+        method: "POST",
+        headers,
+        body: params,
+      });
 
       if (!response.ok) {
         const errorResponse = await response.text();

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -28,6 +28,7 @@ according to [these docs](https://docs.victoriametrics.com/victorialogs/quicksta
 * BUGFIX: [Loki data ingestion](https://docs.victoriametrics.com/victorialogs/data-ingestion/promtail/): fix handling of `Content-Type` HTTP header in `/insert/loki/api/v1/push` endpoint to allow support Clients that send charset or additional information in header. See [#813](https://github.com/VictoriaMetrics/VictoriaLogs/pull/813).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix `/hits` graph showing the first point outside the selected time range. See [#737](https://github.com/VictoriaMetrics/VictoriaLogs/issues/737).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix `hits` chart not updating when changing the `group by` field. See [#788](https://github.com/VictoriaMetrics/VictoriaLogs/issues/788).
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): replace GET with POST for `field_names` and `stream_field_names` requests. See [#818](https://github.com/VictoriaMetrics/VictoriaLogs/issues/818).
 
 ## [v1.37.2](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.37.2)
 


### PR DESCRIPTION
### Describe Your Changes

Switch GET to POST for `field_names` and `stream_field_names` to match other endpoints and avoid issues with long query parameters.

Related issue: #818

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
