### PR TITLE
delete-api: panic when delete filter removes rows with the smallest timestamps

### DIFF
--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -21,6 +21,8 @@ according to the follosing docs:
 
 ## tip
 
+* BUGFIX: [logs deletion](https://docs.victoriametrics.com/victorialogs/#how-to-delete-logs): fix a panic that could occur during long-running delete tasks, when the delete filter removed rows with the smallest timestamps in a block, which then confused an internal timestamp ordering check during merge. Previously this could make VictoriaLogs crash and immediately restart the same delete task in a loop. See [#825](https://github.com/VictoriaMetrics/VictoriaLogs/issues/825).
+
 ## [v1.38.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.38.0)
 
 Released at 2025-11-14

--- a/lib/logstorage/block_stream_merger.go
+++ b/lib/logstorage/block_stream_merger.go
@@ -96,6 +96,10 @@ type blockStreamMerger struct {
 	// rowsTmp is temporary storage for log entries during merge.
 	rowsTmp rows
 
+	// firstBlockMinTimestamp is the minimum timestamp (according to block metadata)
+	// for log entries currently stored in rows.
+	firstBlockMinTimestamp int64
+
 	// uncompressedRowsSizeBytes is the current size of uncompressed rows.
 	//
 	// It is used for flushing rows to blocks when their size reaches maxUncompressedBlockSize
@@ -137,6 +141,7 @@ func (bsm *blockStreamMerger) resetRows() {
 	bsm.rowsTmp.reset()
 
 	bsm.uncompressedRowsSizeBytes = 0
+	bsm.firstBlockMinTimestamp = 0
 }
 
 func (bsm *blockStreamMerger) assertNoRows() {
@@ -232,7 +237,7 @@ func (bsm *blockStreamMerger) checkNextBlock(bd *blockData) {
 		}
 		return
 	}
-	minTimestamp := bsm.rows.timestamps[0]
+	minTimestamp := bsm.firstBlockMinTimestamp
 	if nextMinTimestamp < minTimestamp {
 		logger.Panicf("FATAL: cannot merge %s: the next block's minTimestamp=%d is smaller than the minTimestamp=%d for log entries for the current block",
 			bsm.ReadersPaths(), nextMinTimestamp, minTimestamp)
@@ -313,6 +318,9 @@ func (bsm *blockStreamMerger) mustUnmarshalRows(bd *blockData) {
 	}
 
 	td := &bd.timestampsData
+	if rowsLen == 0 {
+		bsm.firstBlockMinTimestamp = td.minTimestamp
+	}
 	if bsm.needDropRows(&bd.streamID, td.minTimestamp, td.maxTimestamp) {
 		stream, streamID := bsm.getStreamAndStreamID()
 		bsm.rows.skipRowsByDropFilter(bsm.dropFilter, &bsm.dropFilterFields, rowsLen, stream, streamID)


### PR DESCRIPTION
Fixes https://github.com/VictoriaMetrics/VictoriaLogs/issues/825

---

### Case 1: (encountered in the issue above)

Given two blocks for the same stream: 
- A: [10,20,40] 
- B: [15,25,50], 

A delete filter that drops the first two rows from A only (A→[40], B stays [15,25,50]), there clearly exists a valid merged result [15,25,40,50]. 

But, A is unpacked, filtered and merged into `bsm.rows`, so the first in‑memory row has timestamp `40`. When the next block B is checked in `checkNextBlock`, its metadata `minTimestamp` is still `15` (before applying the delete filter), so the assertion compares `nextMinTimestamp=15` with the current in‑memory `minTimestamp=40` and panics, 

```go
minTimestamp := bsm.rows.timestamps[0]
if nextMinTimestamp < minTimestamp {
	logger.Panicf("FATAL: cannot merge %s: the next block's minTimestamp=%d is smaller than the minTimestamp=%d for log entries for the current block",
		bsm.ReadersPaths(), nextMinTimestamp, minTimestamp)
}
```

even though after merging the actual rows the final output order is perfectly fine.

---

### Case 2: found a potential case that can lead to another panic

Given three blocks for the same stream: 

- A: [100,200,1000], 
- B: [200,300,500], 
- C: [300,301] 

A delete filter that drops the first two rows from A and B only (A→[1000], B→[500], C stays [300,301]), there clearly exists a valid merged result [300,301,500,1000]. But A and B may be unpacked, filtered, merged and **FLUSHED** into a first output block with timestamps [500,1000], and only afterwards C is processed into a second block with timestamps [300,301]. 

In this normal case, the per‑stream `minTimestamp` assertion in the writer will panic because the second block’s minTimestamp (300) is smaller than the first block’s (500).

```go
if isSeenSid && th.minTimestamp < bsw.minTimestampLast {
	logger.Panicf("BUG: the block for sid=%s cannot contain timestamp smaller than %d, but it contains timestamp %d", sid, bsw.minTimestampLast, th.minTimestamp)
}
```

---

### Solution

Using the block header's `minTimestamp` instead of `rows[0]` for the check. Otherwise, the merge mechanism needs to be redesigned.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
