### PR TITLE
update vlagent dashboard external links

### DIFF
--- a/dashboards/vlagent.json
+++ b/dashboards/vlagent.json
@@ -67,7 +67,7 @@
       "targetBlank": true,
       "title": "Found a bug?",
       "type": "link",
-      "url": "https://github.com/VictoriaMetrics/VictoriaMetrics/issues"
+      "url": "https://github.com/VictoriaMetrics/VictoriaLogs/issues"
     },
     {
       "icon": "external link",
@@ -75,7 +75,7 @@
       "targetBlank": true,
       "title": "New releases",
       "type": "link",
-      "url": "https://github.com/VictoriaMetrics/VictoriaMetrics/releases"
+      "url": "https://github.com/VictoriaMetrics/VictoriaLogs/releases"
     },
     {
       "asDropdown": false,

--- a/dashboards/vm/vlagent.json
+++ b/dashboards/vm/vlagent.json
@@ -68,7 +68,7 @@
       "targetBlank": true,
       "title": "Found a bug?",
       "type": "link",
-      "url": "https://github.com/VictoriaMetrics/VictoriaMetrics/issues"
+      "url": "https://github.com/VictoriaMetrics/VictoriaLogs/issues"
     },
     {
       "icon": "external link",
@@ -76,7 +76,7 @@
       "targetBlank": true,
       "title": "New releases",
       "type": "link",
-      "url": "https://github.com/VictoriaMetrics/VictoriaMetrics/releases"
+      "url": "https://github.com/VictoriaMetrics/VictoriaLogs/releases"
     },
     {
       "asDropdown": false,


### PR DESCRIPTION
### Describe Your Changes

Since vlagent was moved from VictoriaMetrics repo the dashboard's external links need to be updated

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
