### PR TITLE
internal/select: fix query streaming error aggregation

### DIFF
--- a/app/vlselect/internalselect/internalselect.go
+++ b/app/vlselect/internalselect/internalselect.go
@@ -153,7 +153,7 @@ func processQueryRequest(ctx context.Context, w http.ResponseWriter, r *http.Req
 		// Slow path - the bb must be sent to the client.
 		if err := sendBuf(bb); err != nil {
 			errGlobalLock.Lock()
-			if errGlobal != nil {
+			if errGlobal == nil {
 				errGlobal = err
 			}
 			errGlobalLock.Unlock()


### PR DESCRIPTION
I think it’s better to use `atomic.Pointer[error]`

```go
var errGlobal atomic.Pointer[error]

if err := sendBuf(bb); err != nil {
	_ = errGlobal.CompareAndSwap(nil, &err)
}

if err := errGlobal.Load(); err != nil {
    return *err
}
```

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
