### PR TITLE
query_stats: fix double counting BytesReadTimestamps

### DIFF
--- a/lib/logstorage/query_stats.go
+++ b/lib/logstorage/query_stats.go
@@ -58,7 +58,6 @@ func (qs *QueryStats) UpdateAtomic(src *QueryStats) {
 	atomic.AddUint64(&qs.BytesReadBloomFilters, src.BytesReadBloomFilters)
 	atomic.AddUint64(&qs.BytesReadValues, src.BytesReadValues)
 	atomic.AddUint64(&qs.BytesReadTimestamps, src.BytesReadTimestamps)
-	atomic.AddUint64(&qs.BytesReadTimestamps, src.BytesReadTimestamps)
 	atomic.AddUint64(&qs.BytesReadBlockHeaders, src.BytesReadBlockHeaders)
 
 	atomic.AddUint64(&qs.BlocksProcessed, src.BlocksProcessed)


### PR DESCRIPTION
### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
