### PR TITLE
fix typo in the error message

### DIFF
--- a/app/vlselect/logsql/logsql.go
+++ b/app/vlselect/logsql/logsql.go
@@ -1183,7 +1183,7 @@ func ProcessTenantIDsRequest(ctx context.Context, w http.ResponseWriter, r *http
 		// This allows enforcing the needed tenants at vmauth side, so they won't have access to /select/tenant_ids endpoint.
 		// See https://docs.victoriametrics.com/victoriametrics/vmauth/#modifying-http-headers
 		err := &httpserver.ErrorWithStatusCode{
-			Err:        fmt.Errorf("the /select/tenant_ids enpoint cannot be requested with non-empty AccountID=%q header", accountID),
+			Err:        fmt.Errorf("the /select/tenant_ids endpoint cannot be requested with non-empty AccountID=%q header", accountID),
 			StatusCode: http.StatusForbidden,
 		}
 		httpserver.Errorf(w, r, "%s", err)


### PR DESCRIPTION
### Describe Your Changes
Fixed typo in the error message for endpoint `/select/tenant_ids` if the request contains a Header with AccountID

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
