### PR TITLE
fix typo on checkProtocolVersion error message

### DIFF
--- a/app/vlselect/internalselect/internalselect.go
+++ b/app/vlselect/internalselect/internalselect.go
@@ -480,7 +480,7 @@ func getCommonParams(r *http.Request, expectedProtocolVersion string) (*commonPa
 func checkProtocolVersion(r *http.Request, expectedProtocolVersion string) error {
 	version := r.FormValue("version")
 	if version != expectedProtocolVersion {
-		return fmt.Errorf("unexpected protocol version=%q; want %q; the most likely casue of this error is different versions of VictoriaLogs cluster components; "+
+		return fmt.Errorf("unexpected protocol version=%q; want %q; the most likely cause of this error is different versions of VictoriaLogs cluster components; "+
 			"make sure VictoriaLogs compoments have the same release version", version, expectedProtocolVersion)
 	}
 	return nil


### PR DESCRIPTION
### Describe Your Changes

Fix a typo on `checkProtocolVersion()` function if the VictoriaLogs cluster component is different

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
