### PR TITLE
vlagent: add log message when checkpoint file is missing

### DIFF
--- a/app/vlagent/kubernetescollector/checkpoints_db.go
+++ b/app/vlagent/kubernetescollector/checkpoints_db.go
@@ -125,6 +125,7 @@ func readCheckpoints(path string) ([]checkpoint, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
+			logger.Infof("no checkpoints file found at %q; vlagent will read log files from the beginning", path)
 			return nil, nil
 		}
 		return nil, fmt.Errorf("cannot read file checkpoints: %w", err)


### PR DESCRIPTION
### Describe Your Changes

Adds an info log indicating the checkpoint file is not found. This is needed to simplify debugging.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
