### PR TITLE
app/vlinsert/{loki,opentelemetry}: call clear() on the entire slice fields slice

### DIFF
--- a/app/vlinsert/loki/pb.go
+++ b/app/vlinsert/loki/pb.go
@@ -50,7 +50,11 @@ func decodeStream(src []byte, pushLogs pushLogsHandler) error {
 	// }
 
 	fs := logstorage.GetFields()
-	defer logstorage.PutFields(fs)
+	defer func() {
+		// Expand slice to capacity to clear all field references before returning to pool.
+		fs.Fields = fs.Fields[:cap(fs.Fields)]
+		logstorage.PutFields(fs)
+	}()
 
 	labels, ok, err := easyproto.GetString(src, 1)
 	if err != nil {

--- a/app/vlinsert/opentelemetry/pb.go
+++ b/app/vlinsert/opentelemetry/pb.go
@@ -54,7 +54,11 @@ func decodeResourceLogs(src []byte, pushLogs pushLogsHandler) (err error) {
 	defer putFmtBuffer(fb)
 
 	fs := logstorage.GetFields()
-	defer logstorage.PutFields(fs)
+	defer func() {
+		// Expand slice to capacity to clear all field references before returning to pool.
+		fs.Fields = fs.Fields[:cap(fs.Fields)]
+		logstorage.PutFields(fs)
+	}()
 
 	// Decode resource
 	resourceData, ok, err := easyproto.GetMessageData(src, 1)
@@ -88,9 +92,7 @@ func decodeResourceLogs(src []byte, pushLogs pushLogsHandler) (err error) {
 				return fmt.Errorf("cannot decode ScopeLogs: %w", err)
 			}
 
-			clear(fs.Fields[streamFieldsLen:])
 			fs.Fields = fs.Fields[:streamFieldsLen]
-
 			fb.buf = fb.buf[:fbLen]
 		}
 	}
@@ -175,13 +177,10 @@ func decodeScopeLogs(src []byte, fs *logstorage.Fields, fb *fmtBuffer, pushLogs 
 				pushLogs(timestamp, fs.Fields, streamFieldsLen+1)
 
 				// Return back common fields to their places before the next iteration
-				fieldsLen := len(fs.Fields)
 				fs.Fields = append(fs.Fields[:streamFieldsLen], fs.Fields[streamFieldsLen+1:commonFieldsLen+1]...)
-				clear(fs.Fields[commonFieldsLen:fieldsLen])
 			} else {
 				pushLogs(timestamp, fs.Fields, streamFieldsLen)
 
-				clear(fs.Fields[commonFieldsLen:])
 				fs.Fields = fs.Fields[:commonFieldsLen]
 			}
 


### PR DESCRIPTION
Call `clear()` on the entire slice before exiting the function to guarantee the release of all held references to the input byte slice.

Related: #869 