### PR TITLE
deployment: fix dashboards export error

### DIFF
--- a/dashboards/Makefile
+++ b/dashboards/Makefile
@@ -11,5 +11,5 @@ dashboard-copy:
 # The command should be called before committing changes to dashboards/* files.
 dashboards-sync:
 	SRC=vlagent.json D_UID=Y5Z9GzMGz TITLE="VictoriaLogs - vlagent" $(MAKE) dashboard-copy
-	SRC=victorialogs.json D_UID=OqPIZTX4z TITLE="VictoriaLogs" $(MAKE) dashboard-copy
+	SRC=victorialogs.json D_UID=OqPIZTX4z TITLE="VictoriaLogs - single-node" $(MAKE) dashboard-copy
 	SRC=victorialogs-cluster.json D_UID=XqCOFEX4z TITLE="VictoriaLogs - cluster" $(MAKE) dashboard-copy

--- a/dashboards/victorialogs-cluster.json
+++ b/dashboards/victorialogs-cluster.json
@@ -15,7 +15,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "12.2.1"
+      "version": "12.3.0"
     },
     {
       "type": "datasource",
@@ -46,12 +46,6 @@
       "id": "timeseries",
       "name": "Time series",
       "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "victoriametrics-metrics-datasource",
-      "name": "VictoriaMetrics",
-      "version": "0.19.7"
     }
   ],
   "annotations": {
@@ -77,7 +71,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "$ds"
+          "uid": "$DS_PROMETHEUS"
         },
         "enable": true,
         "expr": "sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"}) by(short_version) unless (sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"} offset $__interval) by(short_version))",
@@ -90,7 +84,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "enable": true,
         "expr": "sum(changes(vm_app_start_timestamp{job=~\"$job\", instance=~\"$instance\"}[$__interval])) by(job)",
@@ -105,7 +99,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": null,
   "links": [
     {
       "icon": "doc",
@@ -161,7 +154,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Total amount of log entries in the storage.",
       "fieldConfig": {
@@ -209,12 +202,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -233,7 +226,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "The total number of log entries ingested over the past 24 hours.",
       "fieldConfig": {
@@ -281,12 +274,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -305,7 +298,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Average ingestion rate of log entries.",
       "fieldConfig": {
@@ -353,12 +346,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -377,7 +370,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Total amount of used disk space.\nAccounts for all compressed log entries and index size.\n\nSee how to [control disk usage](https://docs.victoriametrics.com/victorialogs/#retention-by-disk-space-usage).",
       "fieldConfig": {
@@ -425,12 +418,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -449,7 +442,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Integer number of CPU cores available to the application. This value is automatically rounded down from fractional CPU quotas. For optimal performance, fractional CPU units should be avoided. See the [best practices](https://docs.victoriametrics.com/victoriametrics/bestpractices/#kubernetes) documentation for more details.",
       "fieldConfig": {
@@ -497,12 +490,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -536,14 +529,14 @@
         "content": "<div style=\"text-align: center;\">$version</div>",
         "mode": "markdown"
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "title": "Version",
       "type": "text"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "The cumulative number of log entries ingested over the last 24h. \n\nThe size is calculated before compression.",
       "fieldConfig": {
@@ -591,12 +584,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -615,7 +608,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Rate of HTTP read requests.",
       "fieldConfig": {
@@ -663,12 +656,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -687,7 +680,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "The ratio between original data size and compressed data stored on disk. This metric excludes indexdb size. \n\nThe ratio can go up or down as the system performs automatic maintenance and applies retention policies. For examples:\n- Background merges: [Merges](https://docs.victoriametrics.com/victorialogs/#forced-merge) improve compression by combining data into larger, more efficiently compressed blocks\n- Retention policies: When old data is deleted due to retention settings, the ratio changes as different time periods have varying compression characteristics\n\n",
       "fieldConfig": {
@@ -735,12 +728,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -759,7 +752,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Total system memory available to the application. This represents the system or container's memory capacity or limit, not the currently free memory.",
       "fieldConfig": {
@@ -807,12 +800,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -831,7 +824,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "fieldConfig": {
         "defaults": {
@@ -908,12 +901,12 @@
           }
         ]
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -932,7 +925,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Uptime shows whether the services are working and what their roles are. A VictoriaLogs instance can serve all roles; if it is not yet serving requests from the network, it will show as unknown.",
       "fieldConfig": {
@@ -1020,12 +1013,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(min_over_time(up{job=~\"$job\", instance=~\"$instance_storage_all\"}[$__rate_interval]))",
@@ -1037,7 +1030,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum (\n  min_over_time(\n    up{job=~\"$job\", instance=~\"$instance_select_all\"}[$__rate_interval]\n  )\n  unless on(instance)\n  up{job=~\"$job\", instance=~\"$instance_insert_all\"}\n)",
@@ -1050,7 +1043,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum (\n  min_over_time(\n    up{job=~\"$job\", instance=~\"$instance_insert_all\"}[$__rate_interval]\n  )\n  unless on(instance)\n  up{job=~\"$job\", instance=~\"$instance_select_all\"}\n)",
@@ -1063,7 +1056,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(\n  min_over_time(\n    up{job=~\"$job\", instance=~\"$instance_select_all\"}[$__rate_interval]\n  )\n  and on(instance)\n  up{job=~\"$job\", instance=~\"$instance_insert_all\"}\n)",
@@ -1076,7 +1069,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum by (instance) (\n  min_over_time(up{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\nunless on (instance)\nsum by (instance) (\n  min_over_time(up{job=~\"$job\", instance=~\"$instance_storage_all\"}[$__rate_interval])\n  or\n  min_over_time(up{job=~\"$job\", instance=~\"$instance_insert_all\"}[$__rate_interval])\n  or\n  min_over_time(up{job=~\"$job\", instance=~\"$instance_select_all\"}[$__rate_interval])\n)",
@@ -1106,7 +1099,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Ingestion rate in number of log entries and bytes per second.",
       "fieldConfig": {
@@ -1210,12 +1203,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vl_rows_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) > 0",
@@ -1229,7 +1222,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vl_bytes_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) > 0",
@@ -1246,7 +1239,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "* `*` - unsupported query path\n* `/insert` - [inserts](https://docs.victoriametrics.com/victorialogs/data-ingestion/)\n* `/select` - [reads](https://docs.victoriametrics.com/victorialogs/querying/)\n* `/metrics` - scraping of system metrics",
       "fieldConfig": {
@@ -1334,12 +1327,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path) > 0",
@@ -1357,7 +1350,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "* `*` - unsupported query path\n* `/insert` - [inserts](https://docs.victoriametrics.com/victorialogs/data-ingestion/)\n* `/select` - [reads](https://docs.victoriametrics.com/victorialogs/querying/)\n* `/metrics` - scraping of system metrics",
       "fieldConfig": {
@@ -1442,12 +1435,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -1462,7 +1455,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -1482,7 +1475,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "99th percentile response time for VictoriaLogs HTTP endpoints, grouped by instance and path. This means 99% of requests are faster than this value. **Lower numbers are better**, as they indicate faster responses and fewer slow requests.",
       "fieldConfig": {
@@ -1571,12 +1564,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\"}) by (path) > 0",
@@ -1593,7 +1586,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "99th percentile response time for VictoriaLogs HTTP endpoints, grouped by instance and path. This means 99% of requests are faster than this value. **Lower numbers are better**, as they indicate faster responses and fewer slow requests.",
       "fieldConfig": {
@@ -1625,6 +1618,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1680,12 +1674,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(vl_data_size_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
@@ -1703,7 +1697,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Rate of VictoriaLogs' own application log messages (debug, warnings, errors) - NOT the logs that VictoriaLogs is collecting from external sources.",
       "fieldConfig": {
@@ -1735,6 +1729,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1787,12 +1782,12 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vm_log_messages_total{job=~\"$job\", instance=~\"$instance\", level!=\"info\"}[$__rate_interval])) by (job, level, location)",
@@ -1821,7 +1816,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Number of restarts per job. The chart can be useful to identify periodic process restarts and correlate them with potential issues or anomalies. \n\nNormally, processes shouldn't restart unless restart was inited by user. The reason of restarts should be figured out by checking the logs of each specific service. ",
       "fieldConfig": {
@@ -1913,7 +1908,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(changes(vm_app_start_timestamp{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job)",
@@ -1929,7 +1924,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "The number of new [log streams](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields) created over the last 24 hours. A lower rate is better. See [How to determine which fields must be associated with log streams?](https://docs.victoriametrics.com/victorialogs/keyconcepts/#how-to-determine-which-fields-must-be-associated-with-log-streams) for more details.\n",
       "fieldConfig": {
@@ -2021,7 +2016,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "increase(vl_streams_created_total{job=~\"$job\", instance=~\"$instance\"}[1d])",
@@ -2039,7 +2034,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Flags explicitly set to non-default values",
       "fieldConfig": {
@@ -2132,7 +2127,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -2150,7 +2145,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Number of log entries ignored or dropped on insertion due to the following reasons:\n* Timestamp out of the retention period or in the future\n* Number of fields per entry exceeded\n* Line too long\n\nIf this occurs, check the VictoriaLogs log for details.",
       "fieldConfig": {
@@ -2242,7 +2237,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -2256,7 +2251,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -2284,7 +2279,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Percentage of physical RAM used compared to the memory limit. If this percentage is high, check the `RSS` anonymous vs resident ratio panel for more details.",
           "fieldConfig": {
@@ -2345,7 +2340,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -2364,7 +2359,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "How much memory (RAM) the VictoriaLogs process is actually using, compared to its allowed container or system limit. See 'Memory Usage' panel for a detailed breakdown.\n\n- Good: Below 70% most of the time, maybe spiking a bit under load.\n- Bad: Above 90% for more than 5 minutes = risk of out-of-memory (`OOM`) kill.",
           "fieldConfig": {
@@ -2457,7 +2452,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -2474,7 +2469,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Portion of RAM that cannot be reclaimed without swapping. If both the `RSS`-to-limit percentage and this ratio are high, the process is at high risk of an `OOM` kill.",
           "fieldConfig": {
@@ -2527,7 +2522,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -2546,7 +2541,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "- Anonymous resident memory: Private memory allocated to the application that **cannot** be reclaimed by the kernel. Refer to the [Check/profile](https://docs.victoriametrics.com/victorialogs/#profiling) Go heap section for troubleshooting.\n- File-backed resident memory: Memory mapped from files, which can be safely reclaimed. Increases during querying. Correlate with `I/O` panels for further analysis.\n- Shared resident memory: Typically negligible. Large spikes may indicate unexpected shared memory consumers.",
           "fieldConfig": {
@@ -2638,7 +2633,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job\", instance=~\"$instance\"})",
@@ -2652,7 +2647,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(process_resident_memory_file_bytes{job=~\"$job\", instance=~\"$instance\"})",
@@ -2666,7 +2661,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(process_resident_memory_shared_bytes{job=~\"$job\", instance=~\"$instance\"})",
@@ -2684,7 +2679,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "fieldConfig": {
             "defaults": {
@@ -2777,7 +2772,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -2796,7 +2791,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Lower is better, e.g. 20% means the process was delayed by memory pressure 20% of the time. See [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html).\n\n- waiting: Time fraction where at least one thread was blocked on memory.\n- stalled: Time fraction where every thread was blocked on memory (severe pressure).\n\nIf queries slow down and both series spike, the host is likely limited by RAM or I/O throughput.",
           "fieldConfig": {
@@ -2891,7 +2886,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(rate(process_pressure_memory_waiting_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job)",
@@ -2906,7 +2901,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(rate(process_pressure_memory_stalled_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job)",
@@ -2925,7 +2920,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Helps troubleshoot high CPU usage or throttling:\n\n- waiting: The percentage of time at least one task in the VictoriaLogs process was ready to run (runnable) but couldn't get scheduled on the CPU.\n- stalled: The percentage of time all tasks in the process (except idle ones) were unable to get CPU time — a full CPU stall.\n\nIf there’s a CPU burst, it's normal to see waiting or stalled > 1%. It only becomes a concern if it consistently climbs above 5–10% and aligns with latency spikes or GC slowdowns.",
           "fieldConfig": {
@@ -3017,7 +3012,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_cpu_waiting_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job) > 0.005",
@@ -3031,7 +3026,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_cpu_stalled_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job) > 0.005",
@@ -3050,7 +3045,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of read/write calls application makes:\n\n- read call: Number of read*()-family system calls your process has issued since start. Each call can move 1 byte or megabytes, cached or uncached.\n- write call: Number of write*()-family system calls (including write, pwrite, writev, etc.) made by the process.",
           "fieldConfig": {
@@ -3154,7 +3149,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_io_read_syscalls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
@@ -3169,7 +3164,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_io_write_syscalls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
@@ -3188,7 +3183,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Percentage of open file descriptors (files, sockets, pipes, etc.,) compared to the limit set in the OS. Reaching the limit of open files can cause various issues and must be prevented.\n\nSee [how to change limits](https://medium.com/@muhammadtriwibowo/set-permanently-ulimit-n-open-files-in-ubuntu-4d61064429a).",
           "fieldConfig": {
@@ -3297,7 +3292,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(max_over_time(process_open_fds{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n/\nprocess_max_fds{job=~\"$job\", instance=~\"$instance\"}) by (job)",
@@ -3316,7 +3311,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Measure the actual bytes read from and written to disk by the process:\n\n- read: physical bytes the kernel actually pulled from the storage device on behalf of the process (after checking page-cache).\n- write: physical bytes the kernel ultimately wrote to the storage device for the process (after combining, caching, or delaying writes).",
           "fieldConfig": {
@@ -3420,7 +3415,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_io_storage_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
@@ -3435,7 +3430,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_io_storage_written_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
@@ -3454,7 +3449,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "IO pressure based on [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html). The lower the better.\n\n- waiting: at least one runnable thread blocked on block-`I/O` (disk, NVMe, network-storage) while others could still make progress.\n- stalled: all non-idle threads simultaneously waiting on `I/O`; no useful user code ran during these periods → true `I/O` thrashing.\n\nIf stalled > 0 while querying, it's recommended to increase queue depth on NVMe, raise blk-mq budgets, or relax cgroup I/O limits.",
           "fieldConfig": {
@@ -3544,7 +3539,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(rate(process_pressure_io_waiting_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job) > 0.005",
@@ -3558,7 +3553,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(rate(process_pressure_io_stalled_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job) > 0.005",
@@ -3577,7 +3572,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Current number of active TCP connections to VictoriaLogs. This metric helps monitor connection pool usage and identify potential connection leaks. High values may indicate clients not properly closing connections or connection pooling issues. Monitor for gradual increases that could lead to resource exhaustion.",
           "fieldConfig": {
@@ -3669,7 +3664,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(vm_tcplistener_conns{job=~\"$job\", instance=~\"$instance\"}) by (job)",
@@ -3687,7 +3682,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "fieldConfig": {
             "defaults": {
@@ -3779,7 +3774,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(go_goroutines{job=~\"$job\", instance=~\"$instance\"}) by (job)",
@@ -3796,7 +3791,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Rate of incoming TCP connections accepted by VictoriaLogs. This metric indicates network activity and client connection patterns. Sudden spikes may indicate increased load or potential DDoS attacks. Sustained high rates should be correlated with resource usage to ensure adequate capacity.",
           "fieldConfig": {
@@ -3888,7 +3883,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(rate(vm_tcplistener_accepts_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (job)",
@@ -3906,7 +3901,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "fieldConfig": {
             "defaults": {
@@ -3998,7 +3993,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(process_num_threads{job=~\"$job\", instance=~\"$instance\"}) by (job)",
@@ -4015,7 +4010,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Percent of CPU spent on garbage collection.\n\nIf % is high, then CPU usage can be decreased by changing `GOGC` to higher values. Increasing `GOGC` value will increase memory usage, and decrease CPU usage.\n\nTry searching for keyword `GOGC` at https://docs.victoriametrics.com/victoriametrics/troubleshooting/ ",
           "fieldConfig": {
@@ -4106,7 +4101,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(\n  rate(go_gc_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) \n / rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n ) by(job)",
@@ -4124,7 +4119,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Time goroutines have spent in runnable state before actually running. The lower is better.\n\nHigh values or values exceeding the threshold is usually a sign of            insufficient CPU resources or CPU throttling. \n\nVerify that service has enough CPU resources. Otherwise, the service could work unreliably with delays in processing.",
           "fieldConfig": {
@@ -4215,7 +4210,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(histogram_quantile(0.99, sum(rate(go_sched_latencies_seconds_bucket{job=~\"$job\"}[$__rate_interval])) by (job, le))) by (job)",
@@ -4233,7 +4228,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Rate of allocations in memory. Sudden increase in allocations would mean increased pressure on Go Garbage Collector and can saturate CPU resources of the application.",
           "fieldConfig": {
@@ -4320,7 +4315,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[$__rate_interval])) by (job)",
@@ -4352,7 +4347,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "CPU utilization per instance as a fraction of available cores. Sustained values above 80% indicate CPU saturation; correlate with CPU PSI and query latency.",
           "fieldConfig": {
@@ -4664,15 +4659,15 @@
               "218": "}",
               "219": "\n",
               "220": ")",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
               "editorMode": "code",
               "expr": "max(\n  rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])\n  /\n  process_cpu_cores_available{job=~\"$job\", instance=~\"$instance_storage\"}\n)",
               "legendFormat": "max",
               "range": true,
-              "refId": "A",
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$ds"
-              }
+              "refId": "A"
             },
             {
               "0": "m",
@@ -4898,7 +4893,7 @@
               "220": ")",
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "min(\n  rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])\n  /\n  process_cpu_cores_available{job=~\"$job\", instance=~\"$instance_storage\"}\n)",
@@ -5131,7 +5126,7 @@
               "220": ")",
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "quantile(0.5,\n    rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance_storage\", instance=~\"$instance\"}[$__rate_interval])\n    /\n    process_cpu_cores_available{job=~\"$job\", instance=~\"$instance_storage\", instance=~\"$instance\"}\n)",
@@ -5147,7 +5142,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "How much memory (RAM) the VictoriaLogs process is actually using, compared to its allowed container or system limit. See 'Memory Usage' panel for a detailed breakdown.\n\n- Good: Below 70% most of the time, maybe spiking a bit under load.\n- Bad: Above 90% for more than 5 minutes = risk of out-of-memory (`OOM`) kill.",
           "fieldConfig": {
@@ -5240,7 +5235,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -5253,7 +5248,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -5267,7 +5262,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -5285,7 +5280,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Disk space usage and limits for VictoriaLogs storage. Tracks current data usage against the configured retention limit and total disk space.\n\nThe orange line indicates the space retention limit. When usage approaches this limit, older data will be automatically deleted. If the space retention limit (`-retention.maxDiskSpaceUsageBytes`) is not specified, it won't show.",
           "fieldConfig": {
@@ -5396,7 +5391,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${ds}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -5410,7 +5405,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -5428,7 +5423,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Rate of incoming query requests by endpoint path. This metric tracks the query load on VictoriaLogs, including different query interfaces and internal operations. \n\nHigher rates indicate increased query activity from users or applications. Monitor for sudden spikes that might indicate new dashboards, automated queries, or potential performance issues. Sustained high rates may require scaling query processing capacity.",
           "fieldConfig": {
@@ -5521,7 +5516,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])) by (path) > 0",
@@ -5539,7 +5534,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "99th percentile of HTTP request duration. This represents the time it takes for 99% of HTTP operations to complete. High values indicate slow ingestion/querying performance that could affect overall system throughput. Spikes may suggest storage bottlenecks, resource contention, or inefficient data processing.",
           "fieldConfig": {
@@ -5632,7 +5627,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance_storage\", quantile=\"0.99\"}) by (path) > 0",
@@ -5649,7 +5644,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "99th percentile response time for VictoriaLogs HTTP endpoints, grouped by instance and path. This means 99% of requests are faster than this value. **Lower numbers are better**, as they indicate faster responses and fewer slow requests.",
           "fieldConfig": {
@@ -5757,7 +5752,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_rows_ingested_total{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])) by (type) > 0",
@@ -5771,7 +5766,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_bytes_ingested_total{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])) by (type) > 0",
@@ -5788,7 +5783,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of concurrent insert operations has reached the configured limit: `-maxConcurrentInserts` (default: 2x CPU cores)",
           "fieldConfig": {
@@ -5896,7 +5891,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(increase(vm_concurrent_insert_limit_reached_total{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])) by (job)",
@@ -5914,7 +5909,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of insert requests that timed out while waiting for available concurrency slots. This indicates sustained ingestion overload beyond configured limits.\n\nHigh values suggest:\n- Insert queue is consistently full\n- Insert requests waiting too long for execution slots\n- System under sustained heavy ingestion load\n- Need for horizontal scaling or ingestion optimization\n\nCombined with `Insert concurrency limit reached`, provides complete picture of ingestion rejection patterns.",
           "fieldConfig": {
@@ -5999,7 +5994,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(rate(vm_concurrent_insert_limit_timeout_total{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])) by (job)",
@@ -6015,7 +6010,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of active message processors handling log ingestion. These processors parse and process incoming log messages before storage. The count typically correlates with the ingestion load.\n\nIf this number is unusually high or inflated (which is rare), check memory usage. It may indicate a heavy, concurrently ingestion load or processing bottlenecks that could benefit from performance tuning.",
           "fieldConfig": {
@@ -6109,7 +6104,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(max_over_time(vl_insert_processors_count{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])) by (job)",
@@ -6123,7 +6118,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(max_over_time(vm_concurrent_insert_capacity{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval]))",
@@ -6140,7 +6135,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of log rows waiting to be written to storage, categorized by type. Pending rows indicate temporary queuing during ingestion. Consistently high values may suggest storage write bottlenecks or insufficient write capacity.\n\nPending rows are flushed in two ways:\n\n- After a specific time period (typically 1 second)\n- When the pending row size exceeds a threshold (typically 1.75 MB)",
           "fieldConfig": {
@@ -6232,7 +6227,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(vl_pending_rows{job=~\"$job\", instance=~\"$instance_storage\"}) by (type)",
@@ -6250,7 +6245,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "99th percentile duration of background flush operations by type (max across instances). High values may indicate disk pressure or heavy ingestion. Correlate with `I/O` panels.",
           "fieldConfig": {
@@ -6342,7 +6337,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(vl_insert_flush_duration_seconds{job=~\"$job\", instance=~\"$instance_storage\", quantile=\"0.99\"}) by (type) > 0",
@@ -6359,7 +6354,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "The number of new [log streams](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields) created over the last 24 hours. Lower is better. See [How to determine which fields must be associated with log streams?](https://docs.victoriametrics.com/victorialogs/keyconcepts/#how-to-determine-which-fields-must-be-associated-with-log-streams)",
           "fieldConfig": {
@@ -6454,7 +6449,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(increase(vl_streams_created_total{job=~\"$job\", instance=~\"$instance_storage\"}[1d])) by (job)",
@@ -6472,7 +6467,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Rate of incoming query requests by endpoint path. This metric tracks the query load on VictoriaLogs, including different query interfaces and internal operations. \n\nHigher rates indicate increased query activity from users or applications. Monitor for sudden spikes that might indicate new dashboards, automated queries, or potential performance issues. Sustained high rates may require scaling query processing capacity.",
           "fieldConfig": {
@@ -6565,7 +6560,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance_storage\",path=~\"^/(internal/)?select.*\"}[$__rate_interval])) by (path) > 0",
@@ -6583,7 +6578,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "The number of concurrent select operations has reached the configured limit: `-search.maxConcurrentRequests`. To check the default capacity, refer to the `-vl_concurrent_select_capacity` metric.",
           "fieldConfig": {
@@ -6691,7 +6686,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(increase(vl_concurrent_select_limit_reached_total{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])) by (job)",
@@ -6709,7 +6704,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of queries that timed out while waiting for available concurrency slots. This indicates sustained query overload beyond configured limits.\n\nHigh values suggest:\n- Query queue is consistently full\n- Queries waiting too long for execution slots\n- System under sustained heavy load\n- Need for horizontal scaling or query optimization\n\nCombined with `Select concurrency limit reached`, provides complete picture of query rejection patterns.",
           "fieldConfig": {
@@ -6794,7 +6789,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_concurrent_select_limit_timeout_total{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])) by (job) > 0",
@@ -6810,7 +6805,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Total number of time-based (daily) partitions in storage. The number typically grows over time as new data arrives and is partitioned by time periods. \n\nExcessive partition counts may indicate retention policy issues or very high data ingestion rates that could impact query performance.",
           "fieldConfig": {
@@ -6863,7 +6858,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -6882,7 +6877,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of storage parts (data files) in each tier. More parts mean fragmentation; fewer parts suggest successful merging. High part counts may slow queries and trigger background merge operations.",
           "fieldConfig": {
@@ -6972,7 +6967,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -6990,7 +6985,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of storage merge operations by type (sum across instances). Merges compact smaller parts into larger ones; bursts are normal after activity spikes.",
           "fieldConfig": {
@@ -7082,7 +7077,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -7100,7 +7095,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "99th percentile duration of merge operations by storage type. Merge operations combine smaller storage parts into larger ones for optimization. \n\nNormal merge durations vary by storage type and data volume. Consistently high durations may indicate storage performance issues, high write load, or insufficient resources for background operations. Monitor for trends that could impact overall system performance.",
           "fieldConfig": {
@@ -7191,7 +7186,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -7209,7 +7204,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "99th percentile of data volume processed during merge operations by storage type. \n\nThis metric indicates the scale of background storage optimization activities. Larger merge sizes generally improve storage efficiency but require more resources. Consistently high values may indicate heavy write loads or large storage parts that need optimization. Monitor correlation with merge duration for performance insights.",
           "fieldConfig": {
@@ -7301,7 +7296,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -7333,7 +7328,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "CPU utilization per instance as a fraction of available cores. Sustained values above 80% indicate CPU saturation; correlate with CPU PSI and query latency.",
           "fieldConfig": {
@@ -7645,15 +7640,15 @@
               "218": "}",
               "219": "\n",
               "220": ")",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$DS_PROMETHEUS"
+              },
               "editorMode": "code",
               "expr": "max(\n  rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval])\n  /\n  process_cpu_cores_available{job=~\"$job\", instance=~\"$instance_insert\"}\n)",
               "legendFormat": "max",
               "range": true,
-              "refId": "A",
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$ds"
-              }
+              "refId": "A"
             },
             {
               "0": "m",
@@ -7879,7 +7874,7 @@
               "220": ")",
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "min(\n  rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval])\n  /\n  process_cpu_cores_available{job=~\"$job\", instance=~\"$instance_insert\"}\n)",
@@ -8112,7 +8107,7 @@
               "220": ")",
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "quantile(0.5,\n    rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval])\n    /\n    process_cpu_cores_available{job=~\"$job\", instance=~\"$instance_insert\"}\n)",
@@ -8128,7 +8123,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "99th percentile of insert operation duration. This represents the time it takes for 99% of insert operations to complete. High values indicate slow ingestion performance that could affect overall system throughput. Spikes may suggest storage bottlenecks, resource contention, or inefficient data processing.",
           "fieldConfig": {
@@ -8220,7 +8215,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance_insert_all\", instance=~\"$instance\", quantile=\"0.99\"}) by (path) > 0",
@@ -8237,7 +8232,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Rate of incoming query requests by endpoint path. This metric tracks the query load on VictoriaLogs, including different query interfaces and internal operations. \n\nHigher rates indicate increased query activity from users or applications. Monitor for sudden spikes that might indicate new dashboards, automated queries, or potential performance issues. Sustained high rates may require scaling query processing capacity.",
           "fieldConfig": {
@@ -8329,7 +8324,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval])) by (path) > 0",
@@ -8347,7 +8342,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "99th percentile response time for VictoriaLogs HTTP endpoints, grouped by instance and path. This means 99% of requests are faster than this value. **Lower numbers are better**, as they indicate faster responses and fewer slow requests.",
           "fieldConfig": {
@@ -8455,7 +8450,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_rows_ingested_total{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval])) by (type) > 0",
@@ -8469,7 +8464,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_bytes_ingested_total{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval])) by (type) > 0",
@@ -8486,7 +8481,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of concurrent insert operations has reached the configured limit: `-maxConcurrentInserts` (default: 2x CPU cores)",
           "fieldConfig": {
@@ -8594,7 +8589,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(increase(vm_concurrent_insert_limit_reached_total{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval])) by (job)",
@@ -8612,7 +8607,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of insert requests that timed out while waiting for available concurrency slots. This indicates sustained ingestion overload beyond configured limits.\n\nHigh values suggest:\n- Insert queue is consistently full\n- Insert requests waiting too long for execution slots\n- System under sustained heavy ingestion load\n- Need for horizontal scaling or ingestion optimization\n\nCombined with `Insert concurrency limit reached`, provides complete picture of ingestion rejection patterns.",
           "fieldConfig": {
@@ -8697,7 +8692,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vm_concurrent_insert_limit_timeout_total{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval])) by (job) > 0",
@@ -8713,7 +8708,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of active message processors handling log ingestion. These processors parse and process incoming log messages before storage. The count typically correlates with the ingestion load.\n\nIf this number is unusually high or inflated (which is rare), check memory usage. It may indicate a heavy ingestion load or processing bottlenecks that could benefit from performance tuning.",
           "fieldConfig": {
@@ -8806,7 +8801,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(max_over_time(vl_insert_processors_count{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval])) by (job)",
@@ -8820,7 +8815,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(max_over_time(vm_concurrent_insert_capacity{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval]))",
@@ -8837,7 +8832,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "99th percentile duration of flush operations in vlinsert by type (max across instances). Spikes imply slow disks or backpressure from remote storage.",
           "fieldConfig": {
@@ -8929,7 +8924,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(vl_insert_flush_duration_seconds{job=~\"$job\", instance=~\"$instance_insert\", quantile=\"0.99\"}) by (type) > 0",
@@ -8946,7 +8941,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of active log streams tracked by vlinsert per instance. Steady growth indicates increasing stream cardinality; review stream field design.",
           "fieldConfig": {
@@ -9038,7 +9033,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(vl_insert_active_streams{job=~\"$job\", instance=~\"$instance_insert\"}) by (job)",
@@ -9055,7 +9050,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of remote write send errors over the last 24 hours per vlinsert instance. Non‑zero values typically indicate connectivity issues, timeouts, or 4xx/5xx responses.",
           "fieldConfig": {
@@ -9148,7 +9143,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(increase(vl_insert_remote_send_errors_total{job=~\"$job\", instance=~\"$instance_insert\"}[24h])) by (job)",
@@ -9179,7 +9174,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "CPU utilization per vlselect instance as a fraction of available cores. Sustained values above 80% suggest CPU bottlenecks; correlate with query duration.",
           "fieldConfig": {
@@ -9287,7 +9282,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -9303,7 +9298,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance_select\"}[$__rate_interval])) by (job)",
@@ -9321,7 +9316,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "How much memory (RAM) the VictoriaLogs process is actually using, compared to its allowed container or system limit. See 'Memory Usage' panel for a detailed breakdown.\n\n- Good: Below 70% most of the time, maybe spiking a bit under load.\n- Bad: Above 90% for more than 5 minutes = risk of out-of-memory (`OOM`) kill.",
           "fieldConfig": {
@@ -9429,7 +9424,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -9442,7 +9437,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -9460,7 +9455,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Rate of incoming query requests by endpoint path. This metric tracks the query load on VictoriaLogs, including different query interfaces and internal operations. \n\nHigher rates indicate increased query activity from users or applications. Monitor for sudden spikes that might indicate new dashboards, automated queries, or potential performance issues. Sustained high rates may require scaling query processing capacity.",
           "fieldConfig": {
@@ -9552,7 +9547,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance_select\"}[$__rate_interval])) by (path) > 0",
@@ -9570,7 +9565,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "99th percentile of query execution duration. This represents the time it takes for 99% of queries to complete:\n\n- High values indicate slow query performance that affects user experience. \n- Spikes may suggest complex queries, resource contention, or inefficient indexes. Monitor for trends that could indicate degrading performance.",
           "fieldConfig": {
@@ -9662,7 +9657,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance_select\", quantile=\"0.99\"}) by (path) > 0",
@@ -9679,7 +9674,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "The number of concurrent select operations has reached the configured limit: `-search.maxConcurrentRequests`. To check the default capacity, refer to the `-vl_concurrent_select_capacity` metric.",
           "fieldConfig": {
@@ -9787,7 +9782,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(increase(vl_concurrent_select_limit_reached_total{job=~\"$job\", instance=~\"$instance_select\"}[$__rate_interval])) by (job)",
@@ -9805,7 +9800,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of queries that timed out while waiting for available concurrency slots. This indicates sustained query overload beyond configured limits.\n\nHigh values suggest:\n- Query queue is consistently full\n- Queries waiting too long for execution slots\n- System under sustained heavy load\n- Need for horizontal scaling or query optimization\n\nCombined with `Select concurrency limit reached`, provides complete picture of query rejection patterns.",
           "fieldConfig": {
@@ -9890,7 +9885,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(increase(vl_concurrent_select_limit_timeout_total{job=~\"$job\", instance=~\"$instance_select\"}[$__rate_interval])) by (job)",
@@ -9906,7 +9901,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of remote send errors reported by vlselect. Check the logs when sending fails to see the details.",
           "fieldConfig": {
@@ -9999,7 +9994,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(increase(vl_select_remote_send_errors_total{job=~\"$job\", instance=~\"$instance_select\"}[$__rate_interval])) by (job) > 0",
@@ -10030,7 +10025,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of storage blocks scanned per query (99th percentile). Each block contains logs for a specific time period and field combination. High values indicate queries scanning too many blocks, often caused by:\n\n- Wide time ranges without specific filters\n- Queries missing indexed fields (like `_stream`, `kubernetes.*`)\n- Non-selective filters that don't utilize `bloom filters`\n\nCorrelate with `Bytes/query p99` - if blocks are high but bytes are low, blocks contain little data (good). If both are high, query is reading large amounts of data.",
           "fieldConfig": {
@@ -10122,7 +10117,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${ds}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -10140,7 +10135,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Total bytes read from disk per query (99th percentile). This represents the complete `I/O` overhead for query execution, including:\n\n- Block headers and metadata\n- Bloom filter data for candidate selection\n- Column headers and indexes\n- Actual log values and timestamps\n\nHigh values indicate expensive queries. Compare with specific breakdown panels below to identify bottlenecks. Monitor trends over time and correlate with query complexity.",
           "fieldConfig": {
@@ -10232,7 +10227,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${ds}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -10250,7 +10245,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Bytes read from block headers per query (99th percentile). Block headers contain metadata about each storage block including `time ranges`, `field names`, and data location pointers.\n\nHigh values indicate:\n- Query `time range` spans many blocks (reduce time range or add time-based filters)\n- Missing stream-level filters (`_stream` field) causing full block header scans\n- High cardinality fields creating excessive blocks\n\nMonitor relative changes over time - sudden increases suggest inefficient query patterns or changes in data structure.",
           "fieldConfig": {
@@ -10342,7 +10337,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${ds}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -10360,7 +10355,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Bytes read from Bloom filters per query (99th percentile). `Bloom filters` are probabilistic data structures that quickly eliminate blocks that definitely don't contain search terms.\n\nHigh values indicate:\n- Queries with low-selectivity text filters (common words like `error`, `info`)\n- Missing or ineffective field-based filters\n- Queries that force scanning many candidate blocks\n\nOptimize by adding specific field filters (`kubernetes.container_name`, `_stream`) before text searches. Monitor for sudden increases that indicate poor filter selectivity.",
           "fieldConfig": {
@@ -10452,7 +10447,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${ds}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -10470,7 +10465,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Bytes read from actual log values per query (99th percentile). This represents the uncompressed log content being retrieved and processed for the query result.\n\nHigh values indicate:\n- Queries returning large result sets (add `LIMIT` clause)\n- Retrieving logs with large payloads (`JSON` objects, stack traces)\n- Missing filters that would reduce matching log volume\n- Functions like `uniq` or `stats` processing many log entries\n\nReduce by: adding selective filters, using field extractors instead of full log retrieval, limiting result count.",
           "fieldConfig": {
@@ -10562,7 +10557,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${ds}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -10580,7 +10575,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Bytes read from timestamp column (`_time`) per query (99th percentile). The `_time` column is automatically indexed and used for time-range filtering during query execution.\n\nHigh values indicate:\n- Queries with very wide time ranges requiring timestamp scanning\n- Time-based aggregations over large datasets\n- Missing time-range restrictions in query filters\n\nThis is usually the smallest component of query `I/O`. Spikes correlate with time range width and data density in the queried period.",
           "fieldConfig": {
@@ -10672,7 +10667,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${ds}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -10690,7 +10685,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Bytes read from column header indexes per query (99th percentile). `Column header indexes` contain metadata about which fields exist in each block and their data types.\n\nHigh values suggest:\n- Queries scanning many blocks due to missing field filters\n- High field cardinality creating large index structures\n- Queries accessing many different field names across blocks\n- Schema evolution causing index fragmentation\n\nOptimize by using consistent `field names` and adding field-specific filters early in query pipeline.",
           "fieldConfig": {
@@ -10782,7 +10777,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${ds}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -10800,7 +10795,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Bytes read from column headers per query (99th percentile). `Column headers` store the actual field schema and compression metadata for each block's columns.\n\nThis metric helps identify:\n- Schema complexity overhead (many fields per log entry)\n- Inefficient field access patterns\n- Blocks with heterogeneous schemas requiring header reads\n\nCompare with other `I/O` breakdown panels to understand query cost distribution. High column header reads suggest schema optimization opportunities or need for more selective field access patterns.",
           "fieldConfig": {
@@ -10892,7 +10887,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${ds}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -10912,6 +10907,7 @@
       "type": "row"
     }
   ],
+  "preload": false,
   "refresh": "",
   "schemaVersion": 42,
   "tags": [
@@ -10921,9 +10917,14 @@
   "templating": {
     "list": [
       {
-        "current": {},
+        "current": {
+          "text": "",
+          "value": "${DS_PROMETHEUS}",
+          "selected": true
+        },
         "includeAll": false,
-        "name": "ds",
+        "label": "Datasource",
+        "name": "DS_PROMETHEUS",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
@@ -10934,7 +10935,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vm_app_version{version=~\"victoria-logs-.*\"}, job)",
         "includeAll": true,
@@ -10953,7 +10954,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "$ds"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vm_app_version{job=~\"$job\"}, instance)",
         "includeAll": true,
@@ -10972,7 +10973,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vm_app_version{job=~\"$job\", instance=~\"$instance\"},short_version)",
         "hide": 2,
@@ -10991,7 +10992,7 @@
         "baseFilters": [],
         "datasource": {
           "type": "prometheus",
-          "uid": "$ds"
+          "uid": "$DS_PROMETHEUS"
         },
         "filters": [],
         "name": "adhoc",
@@ -11002,7 +11003,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vl_merges_total,instance)",
         "hide": 2,
@@ -11024,7 +11025,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${ds}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vl_merges_total{instance=~\"$instance\"},instance)",
         "hide": 2,
@@ -11046,7 +11047,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vlinsert_backend_conn_bytes_read_total,instance)",
         "hide": 2,
@@ -11068,7 +11069,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${ds}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vlinsert_backend_conn_bytes_read_total{instance=~\"$instance\"},instance)",
         "hide": 2,
@@ -11090,7 +11091,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vlselect_backend_conn_reads_total,instance)",
         "description": "Instances of vlselect discovered from metrics; used to scope vlselect panels.",
@@ -11113,7 +11114,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${ds}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vlselect_backend_conn_reads_total{instance=~\"$instance\"},instance)",
         "description": "Instances of vlselect discovered from metrics; used to scope vlselect panels.",
@@ -11141,6 +11142,7 @@
   "timezone": "",
   "title": "VictoriaLogs - cluster",
   "uid": "XqCOFEX4z",
-  "version": 1,
-  "weekStart": ""
+  "version": 3,
+  "weekStart": "",
+  "id": null
 }

--- a/dashboards/victorialogs.json
+++ b/dashboards/victorialogs.json
@@ -15,7 +15,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "12.2.1"
+      "version": "12.3.0"
     },
     {
       "type": "datasource",
@@ -46,12 +46,6 @@
       "id": "timeseries",
       "name": "Time series",
       "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "victoriametrics-metrics-datasource",
-      "name": "VictoriaMetrics",
-      "version": "0.19.7"
     }
   ],
   "annotations": {
@@ -77,7 +71,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "$ds"
+          "uid": "${DS_PROMETHEUS}"
         },
         "enable": true,
         "expr": "sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"}) by(short_version) unless (sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"} offset $__interval) by(short_version))",
@@ -102,7 +96,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "${ds}"
+          "uid": "${DS_PROMETHEUS}"
         },
         "enable": false,
         "filter": {
@@ -128,7 +122,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": null,
   "links": [
     {
       "icon": "doc",
@@ -232,12 +225,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -304,12 +297,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -376,12 +369,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -448,12 +441,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -520,12 +513,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -559,7 +552,7 @@
         "content": "<div style=\"text-align: center;\">$version</div>",
         "mode": "markdown"
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "title": "Version",
       "type": "text"
     },
@@ -614,12 +607,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -686,12 +679,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -758,12 +751,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -830,11 +823,11 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -970,12 +963,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(rate(vl_rows_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) > 0",
@@ -1006,7 +999,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "* `*` - unsupported query path\n* `/insert` - [inserts](https://docs.victoriametrics.com/victorialogs/data-ingestion/)\n* `/select` - [reads](https://docs.victoriametrics.com/victorialogs/querying/)\n* `/metrics` - scraping of system metrics",
       "fieldConfig": {
@@ -1095,7 +1088,7 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
@@ -1118,7 +1111,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "* `*` - unsupported query path\n* `/insert` - [inserts](https://docs.victoriametrics.com/victorialogs/data-ingestion/)\n* `/select` - [reads](https://docs.victoriametrics.com/victorialogs/querying/)\n* `/metrics` - scraping of system metrics",
       "fieldConfig": {
@@ -1203,7 +1196,7 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
@@ -1223,7 +1216,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -1332,12 +1325,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\"}) by (path) > 0",
@@ -1388,6 +1381,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1443,12 +1437,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "max(vl_total_disk_space_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
@@ -1499,6 +1493,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1582,12 +1577,12 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(rate(vm_log_messages_total{job=~\"$job\", instance=~\"$instance\", level!=\"info\"}[$__rate_interval])) by (instance, level, location)",
@@ -1708,7 +1703,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(changes(vm_app_start_timestamp{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
@@ -1820,7 +1815,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(increase(vl_streams_created_total{job=~\"$job\", instance=~\"$instance\"}[1d])) by (instance)",
@@ -1931,7 +1926,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -2040,7 +2035,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -2081,7 +2076,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Percentage of physical RAM used compared to the memory limit. If this percentage is high, check the `RSS` anonymous vs resident ratio panel for more details.",
           "fieldConfig": {
@@ -2161,7 +2156,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "How much memory (RAM) the VictoriaLogs process is actually using, compared to its allowed container or system limit. See 'Memory Usage' panel for a detailed breakdown.\n\n- Good: Below 70% most of the time, maybe spiking a bit under load.\n- Bad: Above 90% for more than 5 minutes = risk of out-of-memory (OOM) kill.",
           "fieldConfig": {
@@ -2271,7 +2266,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Portion of RAM that CANNOT be reclaimed without swapping. If both the `RSS`-to-limit percentage and this ratio are high, the process is at high risk of an `OOM` kill.",
           "fieldConfig": {
@@ -2343,7 +2338,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "- Anonymous resident memory: Private memory allocated to the application that **cannot** be reclaimed by the kernel. Refer to the [Check/profile](https://docs.victoriametrics.com/victorialogs/#profiling) Go heap section for troubleshooting.\n- File-backed resident memory: Memory mapped from files, which can be safely reclaimed. Increases during querying. Correlate with `I/O` panels for further analysis.\n- Shared resident memory: Typically negligible. Large spikes may indicate unexpected shared memory consumers.",
           "fieldConfig": {
@@ -2449,7 +2444,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(process_resident_memory_file_bytes{job=~\"$job\", instance=~\"$instance\"})",
@@ -2481,7 +2476,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2592,7 +2587,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Lower is better, e.g. 20% means the process was delayed by memory pressure 20% of the time. See [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html).\n\n- waiting: Time fraction where at least one thread was blocked on memory.\n- stalled: Time fraction where every thread was blocked on memory (severe pressure).\n\nIf queries slow down and both series spike, the host is likely limited by RAM or I/O throughput.",
           "fieldConfig": {
@@ -2702,7 +2697,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_memory_stalled_seconds_total{job=~\"$job\"}[$__rate_interval])) by (instance)",
@@ -2813,7 +2808,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_cpu_waiting_seconds_total{job=~\"$job\"}[$__rate_interval])) by (instance)",
@@ -2846,7 +2841,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of read/write calls application makes:\n\n- read call: Number of read*()-family system calls your process has issued since start. Each call can move 1 byte or megabytes, cached or uncached.\n- write call: Number of write*()-family system calls (including write, pwrite, writev, etc.) made by the process.",
           "fieldConfig": {
@@ -2965,7 +2960,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(rate(process_io_write_syscalls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
@@ -3093,7 +3088,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max_over_time(process_open_fds{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n/\nprocess_max_fds{job=~\"$job\", instance=~\"$instance\"}",
@@ -3216,7 +3211,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(rate(process_io_storage_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
@@ -3250,7 +3245,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "IO pressure based on [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html). The lower the better.\n\n- waiting: at least one runnable thread blocked on block-`I/O` (disk, NVMe, network-storage) while others could still make progress.\n- stalled: all non-idle threads simultaneously waiting on `I/O`; no useful user code ran during these periods → true `I/O` thrashing.\n\nIf stalled > 0 while querying, it's recommended to increase queue depth on NVMe, raise blk-mq budgets, or relax cgroup I/O limits.",
           "fieldConfig": {
@@ -3354,7 +3349,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_io_stalled_seconds_total{job=~\"$job\"}[$__rate_interval])) by (instance)",
@@ -3465,7 +3460,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(vm_tcplistener_conns{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
@@ -3575,7 +3570,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(go_goroutines{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
@@ -3684,7 +3679,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(rate(vm_tcplistener_accepts_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
@@ -3794,7 +3789,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(process_num_threads{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
@@ -3902,7 +3897,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(\n  rate(go_gc_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) \n / rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n ) by(instance)",
@@ -4011,7 +4006,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(histogram_quantile(0.99, sum(rate(go_sched_latencies_seconds_bucket{job=~\"$job\"}[$__rate_interval])) by (instance, le))) by (instance)",
@@ -4096,7 +4091,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -4205,7 +4200,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -4335,7 +4330,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -4367,7 +4362,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of storage merge operations by type (sum across instances). Merges compact smaller parts into larger ones; bursts are normal after activity spikes.",
           "fieldConfig": {
@@ -4477,7 +4472,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "99th percentile duration of merge operations by storage type. Merge operations combine smaller storage parts into larger ones for optimization. \n\nNormal merge durations vary by storage type and data volume. Consistently high durations may indicate storage performance issues, high write load, or insufficient resources for background operations. Monitor for trends that could impact overall system performance.",
           "fieldConfig": {
@@ -4586,7 +4581,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "99th percentile of data volume processed during merge operations by storage type. \n\nThis metric indicates the scale of background storage optimization activities. Larger merge sizes generally improve storage efficiency but require more resources. Consistently high values may indicate heavy write loads or large storage parts that need optimization. Monitor correlation with merge duration for performance insights.",
           "fieldConfig": {
@@ -4710,7 +4705,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of incoming log insertion requests by endpoint path. This metric tracks the ingestion load on VictoriaLogs, including different insertion methods and protocols.\n\nHigher rates indicate increased log ingestion activity. Monitor for sudden spikes that might indicate new log sources, application deployments, or potential issues requiring capacity planning. Sustained high rates may require scaling ingestion capacity.",
           "fieldConfig": {
@@ -4832,7 +4827,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_bytes_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) > 0",
@@ -4942,7 +4937,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance\",path=~\"^/(internal/)?insert.*\"}[$__rate_interval])) by (path) > 0",
@@ -5052,7 +5047,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\", path=~\"^/(internal/)?insert.*\"}) by (path) > 0",
@@ -5162,7 +5157,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\", path=~\"^/(internal/)?insert.*\"}) by (path) > 0",
@@ -5273,7 +5268,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(max_over_time(vl_insert_processors_count{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
@@ -5304,7 +5299,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of log rows waiting to be written to storage, categorized by type. Pending rows indicate temporary queuing during ingestion. Consistently high values may suggest storage write bottlenecks or insufficient write capacity.\n\nPending rows are flushed in two ways:\n\n- After a specific time period (typically 1 second)\n- When the pending row size exceeds a threshold (typically 1.75 MB)",
           "fieldConfig": {
@@ -5414,7 +5409,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of concurrent insert operations has reached the configured limit: -maxConcurrentInserts (default: 2x CPU cores\n",
           "fieldConfig": {
@@ -5540,7 +5535,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of insert requests that timed out while waiting for available concurrency slots. This indicates sustained ingestion overload beyond configured limits.\n\nHigh values suggest:\n- Insert queue is consistently full\n- Insert requests waiting too long for execution slots\n- System under sustained heavy ingestion load\n- Need for horizontal scaling or ingestion optimization\n\nCombined with `Insert concurrency limit reached`, provides complete picture of ingestion rejection patterns.",
           "fieldConfig": {
@@ -5645,7 +5640,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "99th percentile duration of background flush operations by type. High values may indicate disk pressure or heavy ingestion. Correlate with `I/O` panels.",
           "fieldConfig": {
@@ -5768,7 +5763,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of incoming query requests by endpoint path. This metric tracks the query load on VictoriaLogs, including different query interfaces and internal operations. \n\nHigher rates indicate increased query activity from users or applications. Monitor for sudden spikes that might indicate new dashboards, automated queries, or potential performance issues. Sustained high rates may require scaling query processing capacity.",
           "fieldConfig": {
@@ -5879,7 +5874,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "99th percentile of query execution duration. This represents the time it takes for 99% of queries to complete:\n\n- High values indicate slow query performance that affects user experience. \n- Spikes may suggest complex queries, resource contention, or inefficient indexes. Monitor for trends that could indicate degrading performance.",
           "fieldConfig": {
@@ -5989,7 +5984,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of concurrent select (query) operations compared to the configured limit.\n\nHigh utilization near the limit may indicate query bottlenecks or insufficient query processing capacity.\n\nIf it's consistently high while CPU usage remains low, consider increasing the concurrency limit (`-search.maxConcurrentRequests`) or optimizing query performance to support more concurrent users.",
           "fieldConfig": {
@@ -6111,7 +6106,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(max_over_time(vl_concurrent_select_capacity{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
@@ -6215,7 +6210,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_concurrent_select_limit_timeout_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance) > 0",
@@ -6337,7 +6332,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -6447,7 +6442,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -6557,7 +6552,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -6665,7 +6660,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -6775,7 +6770,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -6885,7 +6880,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -6995,7 +6990,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -7105,7 +7100,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -7125,6 +7120,7 @@
       "type": "row"
     }
   ],
+  "preload": false,
   "refresh": "",
   "schemaVersion": 42,
   "tags": [
@@ -7134,9 +7130,14 @@
   "templating": {
     "list": [
       {
-        "current": {},
+        "current": {
+          "text": "",
+          "value": "${DS_PROMETHEUS}",
+          "selected": true
+        },
         "includeAll": false,
-        "name": "ds",
+        "label": "Datasource",
+        "name": "DS_PROMETHEUS",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
@@ -7165,7 +7166,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "$ds"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values(vm_app_version{job=~\"$job\"}, instance)",
         "includeAll": true,
@@ -7203,7 +7204,7 @@
         "baseFilters": [],
         "datasource": {
           "type": "prometheus",
-          "uid": "$ds"
+          "uid": "${DS_PROMETHEUS}"
         },
         "filters": [],
         "name": "adhoc",
@@ -7219,6 +7220,7 @@
   "timezone": "",
   "title": "VictoriaLogs - single-node",
   "uid": "OqPIZTX4z",
-  "version": 1,
-  "weekStart": ""
+  "version": 7,
+  "weekStart": "",
+  "id": null
 }

--- a/dashboards/vlagent.json
+++ b/dashboards/vlagent.json
@@ -15,7 +15,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "12.2.1"
+      "version": "12.3.0"
     },
     {
       "type": "datasource",
@@ -46,12 +46,6 @@
       "id": "timeseries",
       "name": "Time series",
       "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "victoriametrics-metrics-datasource",
-      "name": "VictoriaMetrics",
-      "version": "0.19.7"
     }
   ],
   "annotations": {
@@ -77,7 +71,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "$ds"
+          "uid": "$DS_PROMETHEUS"
         },
         "enable": true,
         "expr": "sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"}) by(short_version) unless (sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"} offset $__interval) by(short_version))",
@@ -90,7 +84,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "enable": true,
         "expr": "sum(changes(vm_app_start_timestamp{job=~\"$job\", instance=~\"$instance\"}[$__interval])) by(job, instance)",
@@ -105,7 +99,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": null,
   "links": [
     {
       "icon": "doc",
@@ -188,14 +181,14 @@
         "content": "<div style=\"text-align: center;\">$version</div>",
         "mode": "markdown"
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "title": "Version",
       "type": "text"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Shows number of generated  error messages in  logs over last 30m. Non-zero value may be a sign of connectivity or misconfiguration errors.",
       "fieldConfig": {
@@ -251,12 +244,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "expr": "sum(increase(vm_log_messages_total{job=~\"$job\", instance=~\"$instance\", level!=\"info\"}[30m]))",
           "interval": "",
@@ -270,7 +263,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Persistent queue size shows size of pending logs in bytes which hasn't been flushed to remote storage yet. \nIncreasing of value might be a sign of connectivity issues. In such cases, vlagent starts to flush pending data on disk with attempt to send it later once connection is restored.",
       "fieldConfig": {
@@ -319,12 +312,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "expr": "sum(vlagent_remotewrite_pending_data_bytes{job=~\"$job\", instance=~\"$instance\"})",
           "interval": "",
@@ -338,7 +331,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Shows the cumulative number of log entries ingested. \n\nThe size is calculated before compression.",
       "fieldConfig": {
@@ -382,12 +375,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vl_bytes_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
@@ -403,7 +396,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Total number of available CPUs for selected vlagents. ",
       "fieldConfig": {
@@ -451,12 +444,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -474,11 +467,12 @@
     },
     {
       "datasource": {
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "align": "auto",
             "cellOptions": {
               "type": "auto"
             },
@@ -587,12 +581,12 @@
         "cellHeight": "sm",
         "showHeader": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "expr": "sort((time() - vm_app_start_timestamp{job=~\"$job\", instance=~\"$instance\"}) or (up{job=~\"$job\", instance=~\"$instance\"}))",
           "format": "table",
@@ -616,7 +610,7 @@
     },
     {
       "datasource": {
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "fieldConfig": {
         "defaults": {
@@ -701,12 +695,12 @@
           "sort": "asc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "expr": "sort(sum(up{job=~\"$job\", instance=~\"$instance\"}) by (job, instance))",
           "format": "time_series",
@@ -722,7 +716,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Total size of available memory for selected vlagents.",
       "fieldConfig": {
@@ -770,12 +764,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -807,7 +801,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Shows ingestion rate in number of log entries and bytes per second.",
       "fieldConfig": {
@@ -911,12 +905,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vl_rows_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) > 0",
@@ -930,7 +924,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vl_bytes_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) > 0",
@@ -947,7 +941,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Shows the persistent queue size of pending logs in bytes >2MB which hasn't been flushed to remote storage yet. \n\nIncreasing of value might be a sign of connectivity issues. In such cases, vlagent starts to flush pending data on disk with attempt to send it later once connection is restored.\n\nRemote write URLs are hidden by default but might be unveiled once `-remoteWrite.showURL` is set to true.\n\nClick on the line and choose Drilldown to show the persistent queue size per instance.\n",
       "fieldConfig": {
@@ -1047,12 +1041,12 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1069,7 +1063,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "* `*` - unsupported query path\n* `/insert` - [inserts](https://docs.victoriametrics.com/victorialogs/data-ingestion/)\n* `/select` - [reads](https://docs.victoriametrics.com/victorialogs/querying/)\n* `/metrics` - scraping of system metrics",
       "fieldConfig": {
@@ -1157,12 +1151,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path) > 0",
@@ -1180,7 +1174,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Shows rate of dropped logs from persistent queue. vlagent drops log lines from queue if in-memory and on-disk queues are full and it is unable to flush them to remote storage.\nThe max size of on-disk queue is configured by `-remoteWrite.maxDiskUsagePerURL` flag.",
       "fieldConfig": {
@@ -1273,12 +1267,12 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vm_persistentqueue_bytes_dropped_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path) > 0",
@@ -1294,7 +1288,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Shows the rate of logging the messages by their level. Unexpected spike in rate is a good reason to check logs.",
       "fieldConfig": {
@@ -1303,11 +1297,13 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "bars",
             "fillOpacity": 100,
             "gradientMode": "none",
@@ -1316,6 +1312,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1323,6 +1320,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1339,7 +1337,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1377,12 +1376,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1402,7 +1401,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Errors rate shows rate for multiple metrics that track possible errors in vlagent, such as network or parsing errors.",
       "fieldConfig": {
@@ -1411,11 +1410,13 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -1424,6 +1425,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1431,6 +1433,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1447,7 +1450,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1490,12 +1494,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vm_http_request_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, protocol) > 0",
@@ -1507,7 +1511,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vm_protoparser_read_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, type) > 0",
@@ -1519,7 +1523,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vm_ingestserver_request_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, type) > 0",
@@ -1531,7 +1535,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vm_protoparser_unmarshal_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, type) > 0",
@@ -1543,7 +1547,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vm_promscrape_dial_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job) > 0",
@@ -1569,7 +1573,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Percentage of used RSS memory (resident).\nThe RSS memory shows the amount of memory recently accessed by the application. It includes anonymous memory and data from recently accessed files (aka page cache).\nThe application's performance will significantly degrade when memory usage is close to 100%.\n\nClick on the line and choose Drilldown to show memory usage per instance",
           "fieldConfig": {
@@ -1663,7 +1667,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -1680,7 +1684,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "fieldConfig": {
             "defaults": {
@@ -1773,7 +1777,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -1792,7 +1796,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Share for memory allocated by the process itself. When memory usage reaches 100% it will be likely OOM-killed.\nSafe memory usage % considered to be below 80%\n\nClick on the line and choose Drilldown to show memory usage per instance",
           "fieldConfig": {
@@ -1880,7 +1884,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -1897,7 +1901,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows CPU pressure based on [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html).\n\nThe lower the better.",
           "fieldConfig": {
@@ -1982,7 +1986,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_cpu_waiting_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job, instance)",
@@ -1996,7 +2000,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_cpu_stalled_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job, instance)",
@@ -2015,7 +2019,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows memory pressure based on [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html).\n\nThe lower the better.",
           "fieldConfig": {
@@ -2100,7 +2104,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_memory_waiting_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job, instance)",
@@ -2114,7 +2118,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_memory_stalled_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job, instance)",
@@ -2133,7 +2137,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the number of bytes read/write from the storage layer when vlagent has to buffer data on disk or read already buffered data.\n\nClick on the line and choose Drilldown to show CPU usage per instance",
           "fieldConfig": {
@@ -2239,7 +2243,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_io_storage_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job) ",
@@ -2254,7 +2258,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_io_storage_written_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job)",
@@ -2273,7 +2277,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "fieldConfig": {
             "defaults": {
@@ -2359,7 +2363,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(max_over_time(go_goroutines{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job)",
@@ -2377,7 +2381,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows IO pressure based on [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html).\n\nThe lower the better.",
           "fieldConfig": {
@@ -2462,7 +2466,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_io_waiting_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job, instance)",
@@ -2476,7 +2480,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_io_stalled_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job, instance)",
@@ -2495,7 +2499,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "fieldConfig": {
             "defaults": {
@@ -2581,7 +2585,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(max_over_time(process_num_threads{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job)",
@@ -2598,7 +2602,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Network usage shows the bytes rate for data accepted by vlagent and pushed via remotewrite protocol.\nDiscrepancies are possible because of different protocols used for ingesting, scraping and writing data.",
           "fieldConfig": {
@@ -2698,7 +2702,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vm_tcplistener_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job) * 8 \n+ sum(rate(vm_promscrape_conn_bytes_read_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job) * 8",
@@ -2710,7 +2714,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vlagent_remotewrite_conn_bytes_written_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job) * 8",
@@ -2726,7 +2730,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the percent of CPU spent on garbage collection.\n\nIf % is high, then CPU usage can be decreased by changing GOGC to higher values. Increasing GOGC value will increase memory usage, and decrease CPU usage.\n\nTry searching for keyword `GOGC` at https://docs.victoriametrics.com/victoriametrics/troubleshooting/ ",
           "fieldConfig": {
@@ -2813,7 +2817,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(\n  rate(go_gc_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) \n / rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n ) by(job)",
@@ -2831,7 +2835,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the time goroutines have spent in runnable state before actually running. The lower is better.\n\nHigh values or values exceeding the threshold is usually a sign of            insufficient CPU resources or CPU throttling. \n\nVerify that service has enough CPU resources. Otherwise, the service could work unreliably with delays in processing.",
           "fieldConfig": {
@@ -2918,7 +2922,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(histogram_quantile(0.99, sum(rate(go_sched_latencies_seconds_bucket{job=~\"$job\"}[$__rate_interval])) by (job, instance, le))) by(job)",
@@ -2936,7 +2940,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the rate of allocations in memory. Sudden increase in allocations would mean increased pressure on Go Garbage Collector and can saturate CPU resources of the application.",
           "fieldConfig": {
@@ -3019,7 +3023,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[$__rate_interval])) by (job, instance)",
@@ -3037,7 +3041,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Panel shows the percentage of open file descriptors in the OS per instance.\nReaching the limit of open files (100%) can cause various issues and must be prevented.\n\nSee how to change limits here https://medium.com/@muhammadtriwibowo/set-permanently-ulimit-n-open-files-in-ubuntu-4d61064429a",
           "fieldConfig": {
@@ -3124,7 +3128,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(\n    max_over_time(process_open_fds{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n    /\n    process_max_fds{job=~\"$job\", instance=~\"$instance\"}\n) by(job)",
@@ -3156,7 +3160,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows write saturation of the persistent queue. If the threshold of 0.9sec is reached, then the persistent queue is saturated by more than 90% and vlagent won't be able to keep up with flushing data on disk. In this case, consider to decrease load on the vlagent or improve the disk throughput.",
           "fieldConfig": {
@@ -3245,7 +3249,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -3262,7 +3266,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows read saturation of the persistent queue. If the threshold of 0.9sec is reached, then the persistent queue is saturated by more than 90% and vlagent won't be able to keep up with reading data from the disk. In this case, consider to decrease load on the vlagent or improve the disk throughput.",
           "fieldConfig": {
@@ -3351,7 +3355,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -3368,7 +3372,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the rate of dropped data blocks in cases when remote storage replies with `400 Bad Request` and `409 Conflict` HTTP responses.",
           "fieldConfig": {
@@ -3456,7 +3460,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -3473,7 +3477,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the rate of dropped log lines in cases when -remoteWrite.dropSamplesOnOverload or multiple -remoteWrite.disableOnDiskQueue options are set",
           "fieldConfig": {
@@ -3561,7 +3565,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -3578,7 +3582,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "fieldConfig": {
             "defaults": {
@@ -3663,7 +3667,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -3705,7 +3709,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the number of restarts per job. The chart can be useful to identify periodic process restarts and correlate them with potential issues or anomalies. Normally, processes shouldn't restart unless restart was inited by user. The reason of restarts should be figured out by checking the logs of each specific service. ",
           "fieldConfig": {
@@ -3792,7 +3796,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(changes(vm_app_start_timestamp{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) > 0) by(job)",
@@ -3822,7 +3826,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows how many concurrent inserts are taking place.\n\nIf the number of concurrent inserts hitting the `limit` or is close to the `limit` constantly - it might be a sign of a resource shortage.\n\n If vlagent's CPU usage and remote write connection saturation are at normal level, it might be that `-maxConcurrentInserts` cmd-line flag need to be increased.",
           "fieldConfig": {
@@ -3907,7 +3911,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -3920,7 +3924,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -3937,7 +3941,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the rate of write errors in ingestserver (UDP, TCP connections) and HTTP server.",
           "fieldConfig": {
@@ -4022,7 +4026,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "exemplar": true,
               "expr": "sum(rate(vm_ingestserver_request_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(type, net) > 0",
@@ -4033,7 +4037,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "exemplar": true,
               "expr": "sum(rate(vlagent_http_request_errors_total{job=~\"$job\", instance=~\"$instance\", protocol!=\"\"}[$__rate_interval])) by(protocol) > 0",
@@ -4062,7 +4066,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the rate of requests to configured remote write endpoints by url and status code.\n\nRemote write URLs are hidden by default but might be unveiled once `-remoteWrite.showURL` is set to true.\n\n",
           "fieldConfig": {
@@ -4149,7 +4153,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -4166,7 +4170,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the global rate for number of written bytes via remote write connections.",
           "fieldConfig": {
@@ -4252,7 +4256,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -4269,7 +4273,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows requests retry rate by url. Number of retries is unlimited but protected with delays up to 1m between attempts.\n\nRemote write URLs are hidden by default but might be unveiled once `-remoteWrite.showURL` is set to true.\n\n",
           "fieldConfig": {
@@ -4355,7 +4359,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -4372,7 +4376,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows current number of established connections to remote write endpoints.\n\n",
           "fieldConfig": {
@@ -4458,7 +4462,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -4475,7 +4479,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows saturation of every connection to remote storage. If the threshold of 90% is reached, then the connection is saturated (busy or slow) by more than 90%, so vlagent won't be able to keep up and can start buffering data. \n\nThis usually means that `-remoteWrite.queues` command-line flag must be increased in order to increase the number of connections per each remote storage.\n",
           "fieldConfig": {
@@ -4561,7 +4565,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -4618,7 +4622,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "",
           "fieldConfig": {
@@ -4702,7 +4706,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -4721,7 +4725,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the used memory (resident).\nThe application's performance will significantly degrade when memory usage is close to 100%.",
           "fieldConfig": {
@@ -4805,7 +4809,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -4822,7 +4826,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the persistent queue size of pending samples in bytes which hasn't been flushed to remote storage yet. \n\nIncreasing of value might be a sign of connectivity issues. In such cases, vlagent starts to flush pending data on disk with attempt to send it later once connection is restored.\n\nRemote write URLs are hidden by default but might be unveiled once `-remoteWrite.showURL` is set to true.",
           "fieldConfig": {
@@ -4914,7 +4918,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -4931,7 +4935,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the number of bytes read/write from the storage layer when vlagent has to buffer data on disk or read already buffered data.",
           "fieldConfig": {
@@ -5031,7 +5035,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_io_storage_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, instance)",
@@ -5046,7 +5050,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_io_storage_written_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job,instance)",
@@ -5067,6 +5071,7 @@
       "type": "row"
     }
   ],
+  "preload": false,
   "refresh": "",
   "schemaVersion": 42,
   "tags": [
@@ -5076,9 +5081,14 @@
   "templating": {
     "list": [
       {
-        "current": {},
+        "current": {
+          "text": "",
+          "value": "${DS_PROMETHEUS}",
+          "selected": true
+        },
         "includeAll": false,
-        "name": "ds",
+        "label": "Datasource",
+        "name": "DS_PROMETHEUS",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
@@ -5089,7 +5099,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vm_app_version{version=~\"^vlagent.*\"}, job)",
         "includeAll": true,
@@ -5109,7 +5119,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "$ds"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vm_app_version{job=~\"$job\"}, instance)",
         "includeAll": true,
@@ -5129,7 +5139,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vlagent_remotewrite_requests_total{job=~\"$job\", instance=~\"$instance\"}, url)",
         "description": "The remote write URLs",
@@ -5149,7 +5159,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${ds}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vm_app_version{job=~\"$job\", instance=~\"$instance\"},short_version)",
         "hide": 2,
@@ -5168,7 +5178,7 @@
         "baseFilters": [],
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "filters": [],
         "name": "adhoc",
@@ -5177,7 +5187,7 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-3h",
     "to": "now"
   },
   "timepicker": {
@@ -5196,6 +5206,7 @@
   "timezone": "",
   "title": "VictoriaLogs - vlagent",
   "uid": "Y5Z9GzMGz",
-  "version": 3,
-  "weekStart": ""
+  "version": 2,
+  "weekStart": "",
+  "id": null
 }

--- a/dashboards/vm/victorialogs-cluster.json
+++ b/dashboards/vm/victorialogs-cluster.json
@@ -16,7 +16,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "12.2.1"
+      "version": "12.3.0"
     },
     {
       "type": "datasource",
@@ -47,12 +47,6 @@
       "id": "timeseries",
       "name": "Time series",
       "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "victoriametrics-metrics-datasource",
-      "name": "VictoriaMetrics",
-      "version": "0.19.7"
     }
   ],
   "annotations": {
@@ -78,7 +72,7 @@
       {
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "$ds"
+          "uid": "$DS_PROMETHEUS"
         },
         "enable": true,
         "expr": "sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"}) by(short_version) unless (sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"} offset $__interval) by(short_version))",
@@ -91,7 +85,7 @@
       {
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "enable": true,
         "expr": "sum(changes(vm_app_start_timestamp{job=~\"$job\", instance=~\"$instance\"}[$__interval])) by(job)",
@@ -106,7 +100,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": null,
   "links": [
     {
       "icon": "doc",
@@ -162,7 +155,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Total amount of log entries in the storage.",
       "fieldConfig": {
@@ -210,12 +203,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -234,7 +227,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "The total number of log entries ingested over the past 24 hours.",
       "fieldConfig": {
@@ -282,12 +275,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -306,7 +299,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Average ingestion rate of log entries.",
       "fieldConfig": {
@@ -354,12 +347,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -378,7 +371,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Total amount of used disk space.\nAccounts for all compressed log entries and index size.\n\nSee how to [control disk usage](https://docs.victoriametrics.com/victorialogs/#retention-by-disk-space-usage).",
       "fieldConfig": {
@@ -426,12 +419,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -450,7 +443,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Integer number of CPU cores available to the application. This value is automatically rounded down from fractional CPU quotas. For optimal performance, fractional CPU units should be avoided. See the [best practices](https://docs.victoriametrics.com/victoriametrics/bestpractices/#kubernetes) documentation for more details.",
       "fieldConfig": {
@@ -498,12 +491,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -537,14 +530,14 @@
         "content": "<div style=\"text-align: center;\">$version</div>",
         "mode": "markdown"
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "title": "Version",
       "type": "text"
     },
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "The cumulative number of log entries ingested over the last 24h. \n\nThe size is calculated before compression.",
       "fieldConfig": {
@@ -592,12 +585,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -616,7 +609,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Rate of HTTP read requests.",
       "fieldConfig": {
@@ -664,12 +657,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -688,7 +681,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "The ratio between original data size and compressed data stored on disk. This metric excludes indexdb size. \n\nThe ratio can go up or down as the system performs automatic maintenance and applies retention policies. For examples:\n- Background merges: [Merges](https://docs.victoriametrics.com/victorialogs/#forced-merge) improve compression by combining data into larger, more efficiently compressed blocks\n- Retention policies: When old data is deleted due to retention settings, the ratio changes as different time periods have varying compression characteristics\n\n",
       "fieldConfig": {
@@ -736,12 +729,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -760,7 +753,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Total system memory available to the application. This represents the system or container's memory capacity or limit, not the currently free memory.",
       "fieldConfig": {
@@ -808,12 +801,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -832,7 +825,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "fieldConfig": {
         "defaults": {
@@ -909,12 +902,12 @@
           }
         ]
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -933,7 +926,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Uptime shows whether the services are working and what their roles are. A VictoriaLogs instance can serve all roles; if it is not yet serving requests from the network, it will show as unknown.",
       "fieldConfig": {
@@ -1021,12 +1014,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(min_over_time(up{job=~\"$job\", instance=~\"$instance_storage_all\"}[$__rate_interval]))",
@@ -1038,7 +1031,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum (\n  min_over_time(\n    up{job=~\"$job\", instance=~\"$instance_select_all\"}[$__rate_interval]\n  )\n  unless on(instance)\n  up{job=~\"$job\", instance=~\"$instance_insert_all\"}\n)",
@@ -1051,7 +1044,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum (\n  min_over_time(\n    up{job=~\"$job\", instance=~\"$instance_insert_all\"}[$__rate_interval]\n  )\n  unless on(instance)\n  up{job=~\"$job\", instance=~\"$instance_select_all\"}\n)",
@@ -1064,7 +1057,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(\n  min_over_time(\n    up{job=~\"$job\", instance=~\"$instance_select_all\"}[$__rate_interval]\n  )\n  and on(instance)\n  up{job=~\"$job\", instance=~\"$instance_insert_all\"}\n)",
@@ -1077,7 +1070,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum by (instance) (\n  min_over_time(up{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\nunless on (instance)\nsum by (instance) (\n  min_over_time(up{job=~\"$job\", instance=~\"$instance_storage_all\"}[$__rate_interval])\n  or\n  min_over_time(up{job=~\"$job\", instance=~\"$instance_insert_all\"}[$__rate_interval])\n  or\n  min_over_time(up{job=~\"$job\", instance=~\"$instance_select_all\"}[$__rate_interval])\n)",
@@ -1107,7 +1100,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Ingestion rate in number of log entries and bytes per second.",
       "fieldConfig": {
@@ -1211,12 +1204,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vl_rows_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) > 0",
@@ -1230,7 +1223,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vl_bytes_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) > 0",
@@ -1247,7 +1240,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "* `*` - unsupported query path\n* `/insert` - [inserts](https://docs.victoriametrics.com/victorialogs/data-ingestion/)\n* `/select` - [reads](https://docs.victoriametrics.com/victorialogs/querying/)\n* `/metrics` - scraping of system metrics",
       "fieldConfig": {
@@ -1335,12 +1328,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path) > 0",
@@ -1358,7 +1351,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "* `*` - unsupported query path\n* `/insert` - [inserts](https://docs.victoriametrics.com/victorialogs/data-ingestion/)\n* `/select` - [reads](https://docs.victoriametrics.com/victorialogs/querying/)\n* `/metrics` - scraping of system metrics",
       "fieldConfig": {
@@ -1443,12 +1436,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -1463,7 +1456,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -1483,7 +1476,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "99th percentile response time for VictoriaLogs HTTP endpoints, grouped by instance and path. This means 99% of requests are faster than this value. **Lower numbers are better**, as they indicate faster responses and fewer slow requests.",
       "fieldConfig": {
@@ -1572,12 +1565,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\"}) by (path) > 0",
@@ -1594,7 +1587,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "99th percentile response time for VictoriaLogs HTTP endpoints, grouped by instance and path. This means 99% of requests are faster than this value. **Lower numbers are better**, as they indicate faster responses and fewer slow requests.",
       "fieldConfig": {
@@ -1626,6 +1619,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1681,12 +1675,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(vl_data_size_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
@@ -1704,7 +1698,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Rate of VictoriaLogs' own application log messages (debug, warnings, errors) - NOT the logs that VictoriaLogs is collecting from external sources.",
       "fieldConfig": {
@@ -1736,6 +1730,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1788,12 +1783,12 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vm_log_messages_total{job=~\"$job\", instance=~\"$instance\", level!=\"info\"}[$__rate_interval])) by (job, level, location)",
@@ -1822,7 +1817,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Number of restarts per job. The chart can be useful to identify periodic process restarts and correlate them with potential issues or anomalies. \n\nNormally, processes shouldn't restart unless restart was inited by user. The reason of restarts should be figured out by checking the logs of each specific service. ",
       "fieldConfig": {
@@ -1914,7 +1909,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(changes(vm_app_start_timestamp{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job)",
@@ -1930,7 +1925,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "The number of new [log streams](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields) created over the last 24 hours. A lower rate is better. See [How to determine which fields must be associated with log streams?](https://docs.victoriametrics.com/victorialogs/keyconcepts/#how-to-determine-which-fields-must-be-associated-with-log-streams) for more details.\n",
       "fieldConfig": {
@@ -2022,7 +2017,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "increase(vl_streams_created_total{job=~\"$job\", instance=~\"$instance\"}[1d])",
@@ -2040,7 +2035,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Flags explicitly set to non-default values",
       "fieldConfig": {
@@ -2133,7 +2128,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -2151,7 +2146,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Number of log entries ignored or dropped on insertion due to the following reasons:\n* Timestamp out of the retention period or in the future\n* Number of fields per entry exceeded\n* Line too long\n\nIf this occurs, check the VictoriaLogs log for details.",
       "fieldConfig": {
@@ -2243,7 +2238,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -2257,7 +2252,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -2285,7 +2280,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Percentage of physical RAM used compared to the memory limit. If this percentage is high, check the `RSS` anonymous vs resident ratio panel for more details.",
           "fieldConfig": {
@@ -2346,7 +2341,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -2365,7 +2360,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "How much memory (RAM) the VictoriaLogs process is actually using, compared to its allowed container or system limit. See 'Memory Usage' panel for a detailed breakdown.\n\n- Good: Below 70% most of the time, maybe spiking a bit under load.\n- Bad: Above 90% for more than 5 minutes = risk of out-of-memory (`OOM`) kill.",
           "fieldConfig": {
@@ -2458,7 +2453,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -2475,7 +2470,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Portion of RAM that cannot be reclaimed without swapping. If both the `RSS`-to-limit percentage and this ratio are high, the process is at high risk of an `OOM` kill.",
           "fieldConfig": {
@@ -2528,7 +2523,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -2547,7 +2542,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "- Anonymous resident memory: Private memory allocated to the application that **cannot** be reclaimed by the kernel. Refer to the [Check/profile](https://docs.victoriametrics.com/victorialogs/#profiling) Go heap section for troubleshooting.\n- File-backed resident memory: Memory mapped from files, which can be safely reclaimed. Increases during querying. Correlate with `I/O` panels for further analysis.\n- Shared resident memory: Typically negligible. Large spikes may indicate unexpected shared memory consumers.",
           "fieldConfig": {
@@ -2639,7 +2634,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(process_resident_memory_anon_bytes{job=~\"$job\", instance=~\"$instance\"})",
@@ -2653,7 +2648,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(process_resident_memory_file_bytes{job=~\"$job\", instance=~\"$instance\"})",
@@ -2667,7 +2662,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(process_resident_memory_shared_bytes{job=~\"$job\", instance=~\"$instance\"})",
@@ -2685,7 +2680,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "fieldConfig": {
             "defaults": {
@@ -2778,7 +2773,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -2797,7 +2792,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Lower is better, e.g. 20% means the process was delayed by memory pressure 20% of the time. See [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html).\n\n- waiting: Time fraction where at least one thread was blocked on memory.\n- stalled: Time fraction where every thread was blocked on memory (severe pressure).\n\nIf queries slow down and both series spike, the host is likely limited by RAM or I/O throughput.",
           "fieldConfig": {
@@ -2892,7 +2887,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(rate(process_pressure_memory_waiting_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job)",
@@ -2907,7 +2902,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(rate(process_pressure_memory_stalled_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job)",
@@ -2926,7 +2921,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Helps troubleshoot high CPU usage or throttling:\n\n- waiting: The percentage of time at least one task in the VictoriaLogs process was ready to run (runnable) but couldn't get scheduled on the CPU.\n- stalled: The percentage of time all tasks in the process (except idle ones) were unable to get CPU time — a full CPU stall.\n\nIf there’s a CPU burst, it's normal to see waiting or stalled > 1%. It only becomes a concern if it consistently climbs above 5–10% and aligns with latency spikes or GC slowdowns.",
           "fieldConfig": {
@@ -3018,7 +3013,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_cpu_waiting_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job) > 0.005",
@@ -3032,7 +3027,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_cpu_stalled_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job) > 0.005",
@@ -3051,7 +3046,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of read/write calls application makes:\n\n- read call: Number of read*()-family system calls your process has issued since start. Each call can move 1 byte or megabytes, cached or uncached.\n- write call: Number of write*()-family system calls (including write, pwrite, writev, etc.) made by the process.",
           "fieldConfig": {
@@ -3155,7 +3150,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_io_read_syscalls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
@@ -3170,7 +3165,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_io_write_syscalls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
@@ -3189,7 +3184,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Percentage of open file descriptors (files, sockets, pipes, etc.,) compared to the limit set in the OS. Reaching the limit of open files can cause various issues and must be prevented.\n\nSee [how to change limits](https://medium.com/@muhammadtriwibowo/set-permanently-ulimit-n-open-files-in-ubuntu-4d61064429a).",
           "fieldConfig": {
@@ -3298,7 +3293,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(max_over_time(process_open_fds{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n/\nprocess_max_fds{job=~\"$job\", instance=~\"$instance\"}) by (job)",
@@ -3317,7 +3312,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Measure the actual bytes read from and written to disk by the process:\n\n- read: physical bytes the kernel actually pulled from the storage device on behalf of the process (after checking page-cache).\n- write: physical bytes the kernel ultimately wrote to the storage device for the process (after combining, caching, or delaying writes).",
           "fieldConfig": {
@@ -3421,7 +3416,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_io_storage_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
@@ -3436,7 +3431,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_io_storage_written_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
@@ -3455,7 +3450,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "IO pressure based on [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html). The lower the better.\n\n- waiting: at least one runnable thread blocked on block-`I/O` (disk, NVMe, network-storage) while others could still make progress.\n- stalled: all non-idle threads simultaneously waiting on `I/O`; no useful user code ran during these periods → true `I/O` thrashing.\n\nIf stalled > 0 while querying, it's recommended to increase queue depth on NVMe, raise blk-mq budgets, or relax cgroup I/O limits.",
           "fieldConfig": {
@@ -3545,7 +3540,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(rate(process_pressure_io_waiting_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job) > 0.005",
@@ -3559,7 +3554,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(rate(process_pressure_io_stalled_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job) > 0.005",
@@ -3578,7 +3573,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Current number of active TCP connections to VictoriaLogs. This metric helps monitor connection pool usage and identify potential connection leaks. High values may indicate clients not properly closing connections or connection pooling issues. Monitor for gradual increases that could lead to resource exhaustion.",
           "fieldConfig": {
@@ -3670,7 +3665,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(vm_tcplistener_conns{job=~\"$job\", instance=~\"$instance\"}) by (job)",
@@ -3688,7 +3683,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "fieldConfig": {
             "defaults": {
@@ -3780,7 +3775,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(go_goroutines{job=~\"$job\", instance=~\"$instance\"}) by (job)",
@@ -3797,7 +3792,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Rate of incoming TCP connections accepted by VictoriaLogs. This metric indicates network activity and client connection patterns. Sudden spikes may indicate increased load or potential DDoS attacks. Sustained high rates should be correlated with resource usage to ensure adequate capacity.",
           "fieldConfig": {
@@ -3889,7 +3884,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(rate(vm_tcplistener_accepts_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (job)",
@@ -3907,7 +3902,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "fieldConfig": {
             "defaults": {
@@ -3999,7 +3994,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(process_num_threads{job=~\"$job\", instance=~\"$instance\"}) by (job)",
@@ -4016,7 +4011,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Percent of CPU spent on garbage collection.\n\nIf % is high, then CPU usage can be decreased by changing `GOGC` to higher values. Increasing `GOGC` value will increase memory usage, and decrease CPU usage.\n\nTry searching for keyword `GOGC` at https://docs.victoriametrics.com/victoriametrics/troubleshooting/ ",
           "fieldConfig": {
@@ -4107,7 +4102,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(\n  rate(go_gc_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) \n / rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n ) by(job)",
@@ -4125,7 +4120,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Time goroutines have spent in runnable state before actually running. The lower is better.\n\nHigh values or values exceeding the threshold is usually a sign of            insufficient CPU resources or CPU throttling. \n\nVerify that service has enough CPU resources. Otherwise, the service could work unreliably with delays in processing.",
           "fieldConfig": {
@@ -4216,7 +4211,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(histogram_quantile(0.99, sum(rate(go_sched_latencies_seconds_bucket{job=~\"$job\"}[$__rate_interval])) by (job, le))) by (job)",
@@ -4234,7 +4229,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Rate of allocations in memory. Sudden increase in allocations would mean increased pressure on Go Garbage Collector and can saturate CPU resources of the application.",
           "fieldConfig": {
@@ -4321,7 +4316,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[$__rate_interval])) by (job)",
@@ -4353,7 +4348,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "CPU utilization per instance as a fraction of available cores. Sustained values above 80% indicate CPU saturation; correlate with CPU PSI and query latency.",
           "fieldConfig": {
@@ -4665,15 +4660,15 @@
               "218": "}",
               "219": "\n",
               "220": ")",
+              "datasource": {
+                "type": "victoriametrics-metrics-datasource",
+                "uid": "$DS_PROMETHEUS"
+              },
               "editorMode": "code",
               "expr": "max(\n  rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])\n  /\n  process_cpu_cores_available{job=~\"$job\", instance=~\"$instance_storage\"}\n)",
               "legendFormat": "max",
               "range": true,
-              "refId": "A",
-              "datasource": {
-                "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
-              }
+              "refId": "A"
             },
             {
               "0": "m",
@@ -4899,7 +4894,7 @@
               "220": ")",
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "min(\n  rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])\n  /\n  process_cpu_cores_available{job=~\"$job\", instance=~\"$instance_storage\"}\n)",
@@ -5132,7 +5127,7 @@
               "220": ")",
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "quantile(0.5,\n    rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance_storage\", instance=~\"$instance\"}[$__rate_interval])\n    /\n    process_cpu_cores_available{job=~\"$job\", instance=~\"$instance_storage\", instance=~\"$instance\"}\n)",
@@ -5148,7 +5143,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "How much memory (RAM) the VictoriaLogs process is actually using, compared to its allowed container or system limit. See 'Memory Usage' panel for a detailed breakdown.\n\n- Good: Below 70% most of the time, maybe spiking a bit under load.\n- Bad: Above 90% for more than 5 minutes = risk of out-of-memory (`OOM`) kill.",
           "fieldConfig": {
@@ -5241,7 +5236,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -5254,7 +5249,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -5268,7 +5263,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -5286,7 +5281,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Disk space usage and limits for VictoriaLogs storage. Tracks current data usage against the configured retention limit and total disk space.\n\nThe orange line indicates the space retention limit. When usage approaches this limit, older data will be automatically deleted. If the space retention limit (`-retention.maxDiskSpaceUsageBytes`) is not specified, it won't show.",
           "fieldConfig": {
@@ -5397,7 +5392,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${ds}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -5411,7 +5406,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -5429,7 +5424,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Rate of incoming query requests by endpoint path. This metric tracks the query load on VictoriaLogs, including different query interfaces and internal operations. \n\nHigher rates indicate increased query activity from users or applications. Monitor for sudden spikes that might indicate new dashboards, automated queries, or potential performance issues. Sustained high rates may require scaling query processing capacity.",
           "fieldConfig": {
@@ -5522,7 +5517,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])) by (path) > 0",
@@ -5540,7 +5535,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "99th percentile of HTTP request duration. This represents the time it takes for 99% of HTTP operations to complete. High values indicate slow ingestion/querying performance that could affect overall system throughput. Spikes may suggest storage bottlenecks, resource contention, or inefficient data processing.",
           "fieldConfig": {
@@ -5633,7 +5628,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance_storage\", quantile=\"0.99\"}) by (path) > 0",
@@ -5650,7 +5645,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "99th percentile response time for VictoriaLogs HTTP endpoints, grouped by instance and path. This means 99% of requests are faster than this value. **Lower numbers are better**, as they indicate faster responses and fewer slow requests.",
           "fieldConfig": {
@@ -5758,7 +5753,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_rows_ingested_total{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])) by (type) > 0",
@@ -5772,7 +5767,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_bytes_ingested_total{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])) by (type) > 0",
@@ -5789,7 +5784,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of concurrent insert operations has reached the configured limit: `-maxConcurrentInserts` (default: 2x CPU cores)",
           "fieldConfig": {
@@ -5897,7 +5892,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(increase(vm_concurrent_insert_limit_reached_total{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])) by (job)",
@@ -5915,7 +5910,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of insert requests that timed out while waiting for available concurrency slots. This indicates sustained ingestion overload beyond configured limits.\n\nHigh values suggest:\n- Insert queue is consistently full\n- Insert requests waiting too long for execution slots\n- System under sustained heavy ingestion load\n- Need for horizontal scaling or ingestion optimization\n\nCombined with `Insert concurrency limit reached`, provides complete picture of ingestion rejection patterns.",
           "fieldConfig": {
@@ -6000,7 +5995,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(rate(vm_concurrent_insert_limit_timeout_total{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])) by (job)",
@@ -6016,7 +6011,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of active message processors handling log ingestion. These processors parse and process incoming log messages before storage. The count typically correlates with the ingestion load.\n\nIf this number is unusually high or inflated (which is rare), check memory usage. It may indicate a heavy, concurrently ingestion load or processing bottlenecks that could benefit from performance tuning.",
           "fieldConfig": {
@@ -6110,7 +6105,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(max_over_time(vl_insert_processors_count{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])) by (job)",
@@ -6124,7 +6119,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(max_over_time(vm_concurrent_insert_capacity{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval]))",
@@ -6141,7 +6136,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of log rows waiting to be written to storage, categorized by type. Pending rows indicate temporary queuing during ingestion. Consistently high values may suggest storage write bottlenecks or insufficient write capacity.\n\nPending rows are flushed in two ways:\n\n- After a specific time period (typically 1 second)\n- When the pending row size exceeds a threshold (typically 1.75 MB)",
           "fieldConfig": {
@@ -6233,7 +6228,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(vl_pending_rows{job=~\"$job\", instance=~\"$instance_storage\"}) by (type)",
@@ -6251,7 +6246,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "99th percentile duration of background flush operations by type (max across instances). High values may indicate disk pressure or heavy ingestion. Correlate with `I/O` panels.",
           "fieldConfig": {
@@ -6343,7 +6338,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(vl_insert_flush_duration_seconds{job=~\"$job\", instance=~\"$instance_storage\", quantile=\"0.99\"}) by (type) > 0",
@@ -6360,7 +6355,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "The number of new [log streams](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields) created over the last 24 hours. Lower is better. See [How to determine which fields must be associated with log streams?](https://docs.victoriametrics.com/victorialogs/keyconcepts/#how-to-determine-which-fields-must-be-associated-with-log-streams)",
           "fieldConfig": {
@@ -6455,7 +6450,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(increase(vl_streams_created_total{job=~\"$job\", instance=~\"$instance_storage\"}[1d])) by (job)",
@@ -6473,7 +6468,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Rate of incoming query requests by endpoint path. This metric tracks the query load on VictoriaLogs, including different query interfaces and internal operations. \n\nHigher rates indicate increased query activity from users or applications. Monitor for sudden spikes that might indicate new dashboards, automated queries, or potential performance issues. Sustained high rates may require scaling query processing capacity.",
           "fieldConfig": {
@@ -6566,7 +6561,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance_storage\",path=~\"^/(internal/)?select.*\"}[$__rate_interval])) by (path) > 0",
@@ -6584,7 +6579,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "The number of concurrent select operations has reached the configured limit: `-search.maxConcurrentRequests`. To check the default capacity, refer to the `-vl_concurrent_select_capacity` metric.",
           "fieldConfig": {
@@ -6692,7 +6687,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(increase(vl_concurrent_select_limit_reached_total{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])) by (job)",
@@ -6710,7 +6705,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of queries that timed out while waiting for available concurrency slots. This indicates sustained query overload beyond configured limits.\n\nHigh values suggest:\n- Query queue is consistently full\n- Queries waiting too long for execution slots\n- System under sustained heavy load\n- Need for horizontal scaling or query optimization\n\nCombined with `Select concurrency limit reached`, provides complete picture of query rejection patterns.",
           "fieldConfig": {
@@ -6795,7 +6790,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_concurrent_select_limit_timeout_total{job=~\"$job\", instance=~\"$instance_storage\"}[$__rate_interval])) by (job) > 0",
@@ -6811,7 +6806,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Total number of time-based (daily) partitions in storage. The number typically grows over time as new data arrives and is partitioned by time periods. \n\nExcessive partition counts may indicate retention policy issues or very high data ingestion rates that could impact query performance.",
           "fieldConfig": {
@@ -6864,7 +6859,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -6883,7 +6878,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${ds}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of storage parts (data files) in each tier. More parts mean fragmentation; fewer parts suggest successful merging. High part counts may slow queries and trigger background merge operations.",
           "fieldConfig": {
@@ -6973,7 +6968,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -6991,7 +6986,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${ds}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of storage merge operations by type (sum across instances). Merges compact smaller parts into larger ones; bursts are normal after activity spikes.",
           "fieldConfig": {
@@ -7083,7 +7078,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -7101,7 +7096,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${ds}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "99th percentile duration of merge operations by storage type. Merge operations combine smaller storage parts into larger ones for optimization. \n\nNormal merge durations vary by storage type and data volume. Consistently high durations may indicate storage performance issues, high write load, or insufficient resources for background operations. Monitor for trends that could impact overall system performance.",
           "fieldConfig": {
@@ -7192,7 +7187,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -7210,7 +7205,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${ds}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "99th percentile of data volume processed during merge operations by storage type. \n\nThis metric indicates the scale of background storage optimization activities. Larger merge sizes generally improve storage efficiency but require more resources. Consistently high values may indicate heavy write loads or large storage parts that need optimization. Monitor correlation with merge duration for performance insights.",
           "fieldConfig": {
@@ -7302,7 +7297,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -7334,7 +7329,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "CPU utilization per instance as a fraction of available cores. Sustained values above 80% indicate CPU saturation; correlate with CPU PSI and query latency.",
           "fieldConfig": {
@@ -7646,15 +7641,15 @@
               "218": "}",
               "219": "\n",
               "220": ")",
+              "datasource": {
+                "type": "victoriametrics-metrics-datasource",
+                "uid": "$DS_PROMETHEUS"
+              },
               "editorMode": "code",
               "expr": "max(\n  rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval])\n  /\n  process_cpu_cores_available{job=~\"$job\", instance=~\"$instance_insert\"}\n)",
               "legendFormat": "max",
               "range": true,
-              "refId": "A",
-              "datasource": {
-                "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
-              }
+              "refId": "A"
             },
             {
               "0": "m",
@@ -7880,7 +7875,7 @@
               "220": ")",
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "min(\n  rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval])\n  /\n  process_cpu_cores_available{job=~\"$job\", instance=~\"$instance_insert\"}\n)",
@@ -8113,7 +8108,7 @@
               "220": ")",
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "quantile(0.5,\n    rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval])\n    /\n    process_cpu_cores_available{job=~\"$job\", instance=~\"$instance_insert\"}\n)",
@@ -8129,7 +8124,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "99th percentile of insert operation duration. This represents the time it takes for 99% of insert operations to complete. High values indicate slow ingestion performance that could affect overall system throughput. Spikes may suggest storage bottlenecks, resource contention, or inefficient data processing.",
           "fieldConfig": {
@@ -8221,7 +8216,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance_insert_all\", instance=~\"$instance\", quantile=\"0.99\"}) by (path) > 0",
@@ -8238,7 +8233,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Rate of incoming query requests by endpoint path. This metric tracks the query load on VictoriaLogs, including different query interfaces and internal operations. \n\nHigher rates indicate increased query activity from users or applications. Monitor for sudden spikes that might indicate new dashboards, automated queries, or potential performance issues. Sustained high rates may require scaling query processing capacity.",
           "fieldConfig": {
@@ -8330,7 +8325,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval])) by (path) > 0",
@@ -8348,7 +8343,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "99th percentile response time for VictoriaLogs HTTP endpoints, grouped by instance and path. This means 99% of requests are faster than this value. **Lower numbers are better**, as they indicate faster responses and fewer slow requests.",
           "fieldConfig": {
@@ -8456,7 +8451,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_rows_ingested_total{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval])) by (type) > 0",
@@ -8470,7 +8465,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_bytes_ingested_total{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval])) by (type) > 0",
@@ -8487,7 +8482,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of concurrent insert operations has reached the configured limit: `-maxConcurrentInserts` (default: 2x CPU cores)",
           "fieldConfig": {
@@ -8595,7 +8590,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(increase(vm_concurrent_insert_limit_reached_total{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval])) by (job)",
@@ -8613,7 +8608,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of insert requests that timed out while waiting for available concurrency slots. This indicates sustained ingestion overload beyond configured limits.\n\nHigh values suggest:\n- Insert queue is consistently full\n- Insert requests waiting too long for execution slots\n- System under sustained heavy ingestion load\n- Need for horizontal scaling or ingestion optimization\n\nCombined with `Insert concurrency limit reached`, provides complete picture of ingestion rejection patterns.",
           "fieldConfig": {
@@ -8698,7 +8693,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vm_concurrent_insert_limit_timeout_total{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval])) by (job) > 0",
@@ -8714,7 +8709,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of active message processors handling log ingestion. These processors parse and process incoming log messages before storage. The count typically correlates with the ingestion load.\n\nIf this number is unusually high or inflated (which is rare), check memory usage. It may indicate a heavy ingestion load or processing bottlenecks that could benefit from performance tuning.",
           "fieldConfig": {
@@ -8807,7 +8802,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(max_over_time(vl_insert_processors_count{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval])) by (job)",
@@ -8821,7 +8816,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(max_over_time(vm_concurrent_insert_capacity{job=~\"$job\", instance=~\"$instance_insert\"}[$__rate_interval]))",
@@ -8838,7 +8833,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "99th percentile duration of flush operations in vlinsert by type (max across instances). Spikes imply slow disks or backpressure from remote storage.",
           "fieldConfig": {
@@ -8930,7 +8925,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(vl_insert_flush_duration_seconds{job=~\"$job\", instance=~\"$instance_insert\", quantile=\"0.99\"}) by (type) > 0",
@@ -8947,7 +8942,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of active log streams tracked by vlinsert per instance. Steady growth indicates increasing stream cardinality; review stream field design.",
           "fieldConfig": {
@@ -9039,7 +9034,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(vl_insert_active_streams{job=~\"$job\", instance=~\"$instance_insert\"}) by (job)",
@@ -9056,7 +9051,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of remote write send errors over the last 24 hours per vlinsert instance. Non‑zero values typically indicate connectivity issues, timeouts, or 4xx/5xx responses.",
           "fieldConfig": {
@@ -9149,7 +9144,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(increase(vl_insert_remote_send_errors_total{job=~\"$job\", instance=~\"$instance_insert\"}[24h])) by (job)",
@@ -9180,7 +9175,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "CPU utilization per vlselect instance as a fraction of available cores. Sustained values above 80% suggest CPU bottlenecks; correlate with query duration.",
           "fieldConfig": {
@@ -9288,7 +9283,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -9304,7 +9299,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance_select\"}[$__rate_interval])) by (job)",
@@ -9322,7 +9317,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "How much memory (RAM) the VictoriaLogs process is actually using, compared to its allowed container or system limit. See 'Memory Usage' panel for a detailed breakdown.\n\n- Good: Below 70% most of the time, maybe spiking a bit under load.\n- Bad: Above 90% for more than 5 minutes = risk of out-of-memory (`OOM`) kill.",
           "fieldConfig": {
@@ -9430,7 +9425,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -9443,7 +9438,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -9461,7 +9456,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Rate of incoming query requests by endpoint path. This metric tracks the query load on VictoriaLogs, including different query interfaces and internal operations. \n\nHigher rates indicate increased query activity from users or applications. Monitor for sudden spikes that might indicate new dashboards, automated queries, or potential performance issues. Sustained high rates may require scaling query processing capacity.",
           "fieldConfig": {
@@ -9553,7 +9548,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance_select\"}[$__rate_interval])) by (path) > 0",
@@ -9571,7 +9566,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "99th percentile of query execution duration. This represents the time it takes for 99% of queries to complete:\n\n- High values indicate slow query performance that affects user experience. \n- Spikes may suggest complex queries, resource contention, or inefficient indexes. Monitor for trends that could indicate degrading performance.",
           "fieldConfig": {
@@ -9663,7 +9658,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance_select\", quantile=\"0.99\"}) by (path) > 0",
@@ -9680,7 +9675,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "The number of concurrent select operations has reached the configured limit: `-search.maxConcurrentRequests`. To check the default capacity, refer to the `-vl_concurrent_select_capacity` metric.",
           "fieldConfig": {
@@ -9788,7 +9783,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(increase(vl_concurrent_select_limit_reached_total{job=~\"$job\", instance=~\"$instance_select\"}[$__rate_interval])) by (job)",
@@ -9806,7 +9801,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of queries that timed out while waiting for available concurrency slots. This indicates sustained query overload beyond configured limits.\n\nHigh values suggest:\n- Query queue is consistently full\n- Queries waiting too long for execution slots\n- System under sustained heavy load\n- Need for horizontal scaling or query optimization\n\nCombined with `Select concurrency limit reached`, provides complete picture of query rejection patterns.",
           "fieldConfig": {
@@ -9891,7 +9886,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(increase(vl_concurrent_select_limit_timeout_total{job=~\"$job\", instance=~\"$instance_select\"}[$__rate_interval])) by (job)",
@@ -9907,7 +9902,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of remote send errors reported by vlselect. Check the logs when sending fails to see the details.",
           "fieldConfig": {
@@ -10000,7 +9995,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(increase(vl_select_remote_send_errors_total{job=~\"$job\", instance=~\"$instance_select\"}[$__rate_interval])) by (job) > 0",
@@ -10031,7 +10026,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Number of storage blocks scanned per query (99th percentile). Each block contains logs for a specific time period and field combination. High values indicate queries scanning too many blocks, often caused by:\n\n- Wide time ranges without specific filters\n- Queries missing indexed fields (like `_stream`, `kubernetes.*`)\n- Non-selective filters that don't utilize `bloom filters`\n\nCorrelate with `Bytes/query p99` - if blocks are high but bytes are low, blocks contain little data (good). If both are high, query is reading large amounts of data.",
           "fieldConfig": {
@@ -10123,7 +10118,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${ds}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -10141,7 +10136,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Total bytes read from disk per query (99th percentile). This represents the complete `I/O` overhead for query execution, including:\n\n- Block headers and metadata\n- Bloom filter data for candidate selection\n- Column headers and indexes\n- Actual log values and timestamps\n\nHigh values indicate expensive queries. Compare with specific breakdown panels below to identify bottlenecks. Monitor trends over time and correlate with query complexity.",
           "fieldConfig": {
@@ -10233,7 +10228,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${ds}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -10251,7 +10246,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Bytes read from block headers per query (99th percentile). Block headers contain metadata about each storage block including `time ranges`, `field names`, and data location pointers.\n\nHigh values indicate:\n- Query `time range` spans many blocks (reduce time range or add time-based filters)\n- Missing stream-level filters (`_stream` field) causing full block header scans\n- High cardinality fields creating excessive blocks\n\nMonitor relative changes over time - sudden increases suggest inefficient query patterns or changes in data structure.",
           "fieldConfig": {
@@ -10343,7 +10338,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${ds}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -10361,7 +10356,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Bytes read from Bloom filters per query (99th percentile). `Bloom filters` are probabilistic data structures that quickly eliminate blocks that definitely don't contain search terms.\n\nHigh values indicate:\n- Queries with low-selectivity text filters (common words like `error`, `info`)\n- Missing or ineffective field-based filters\n- Queries that force scanning many candidate blocks\n\nOptimize by adding specific field filters (`kubernetes.container_name`, `_stream`) before text searches. Monitor for sudden increases that indicate poor filter selectivity.",
           "fieldConfig": {
@@ -10453,7 +10448,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${ds}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -10471,7 +10466,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Bytes read from actual log values per query (99th percentile). This represents the uncompressed log content being retrieved and processed for the query result.\n\nHigh values indicate:\n- Queries returning large result sets (add `LIMIT` clause)\n- Retrieving logs with large payloads (`JSON` objects, stack traces)\n- Missing filters that would reduce matching log volume\n- Functions like `uniq` or `stats` processing many log entries\n\nReduce by: adding selective filters, using field extractors instead of full log retrieval, limiting result count.",
           "fieldConfig": {
@@ -10563,7 +10558,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${ds}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -10581,7 +10576,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Bytes read from timestamp column (`_time`) per query (99th percentile). The `_time` column is automatically indexed and used for time-range filtering during query execution.\n\nHigh values indicate:\n- Queries with very wide time ranges requiring timestamp scanning\n- Time-based aggregations over large datasets\n- Missing time-range restrictions in query filters\n\nThis is usually the smallest component of query `I/O`. Spikes correlate with time range width and data density in the queried period.",
           "fieldConfig": {
@@ -10673,7 +10668,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${ds}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -10691,7 +10686,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Bytes read from column header indexes per query (99th percentile). `Column header indexes` contain metadata about which fields exist in each block and their data types.\n\nHigh values suggest:\n- Queries scanning many blocks due to missing field filters\n- High field cardinality creating large index structures\n- Queries accessing many different field names across blocks\n- Schema evolution causing index fragmentation\n\nOptimize by using consistent `field names` and adding field-specific filters early in query pipeline.",
           "fieldConfig": {
@@ -10783,7 +10778,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${ds}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -10801,7 +10796,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Bytes read from column headers per query (99th percentile). `Column headers` store the actual field schema and compression metadata for each block's columns.\n\nThis metric helps identify:\n- Schema complexity overhead (many fields per log entry)\n- Inefficient field access patterns\n- Blocks with heterogeneous schemas requiring header reads\n\nCompare with other `I/O` breakdown panels to understand query cost distribution. High column header reads suggest schema optimization opportunities or need for more selective field access patterns.",
           "fieldConfig": {
@@ -10893,7 +10888,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${ds}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -10913,6 +10908,7 @@
       "type": "row"
     }
   ],
+  "preload": false,
   "refresh": "",
   "schemaVersion": 42,
   "tags": [
@@ -10922,9 +10918,14 @@
   "templating": {
     "list": [
       {
-        "current": {},
+        "current": {
+          "text": "",
+          "value": "${DS_PROMETHEUS}",
+          "selected": true
+        },
         "includeAll": false,
-        "name": "ds",
+        "label": "Datasource",
+        "name": "DS_PROMETHEUS",
         "options": [],
         "query": "victoriametrics-metrics-datasource",
         "refresh": 1,
@@ -10935,7 +10936,7 @@
         "current": {},
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vm_app_version{version=~\"victoria-logs-.*\"}, job)",
         "includeAll": true,
@@ -10954,7 +10955,7 @@
         "current": {},
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "$ds"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vm_app_version{job=~\"$job\"}, instance)",
         "includeAll": true,
@@ -10973,7 +10974,7 @@
         "current": {},
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vm_app_version{job=~\"$job\", instance=~\"$instance\"},short_version)",
         "hide": 2,
@@ -10992,7 +10993,7 @@
         "baseFilters": [],
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "$ds"
+          "uid": "$DS_PROMETHEUS"
         },
         "filters": [],
         "name": "adhoc",
@@ -11003,7 +11004,7 @@
         "current": {},
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vl_merges_total,instance)",
         "hide": 2,
@@ -11025,7 +11026,7 @@
         "current": {},
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "${ds}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vl_merges_total{instance=~\"$instance\"},instance)",
         "hide": 2,
@@ -11047,7 +11048,7 @@
         "current": {},
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vlinsert_backend_conn_bytes_read_total,instance)",
         "hide": 2,
@@ -11069,7 +11070,7 @@
         "current": {},
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "${ds}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vlinsert_backend_conn_bytes_read_total{instance=~\"$instance\"},instance)",
         "hide": 2,
@@ -11091,7 +11092,7 @@
         "current": {},
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vlselect_backend_conn_reads_total,instance)",
         "description": "Instances of vlselect discovered from metrics; used to scope vlselect panels.",
@@ -11114,7 +11115,7 @@
         "current": {},
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "${ds}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vlselect_backend_conn_reads_total{instance=~\"$instance\"},instance)",
         "description": "Instances of vlselect discovered from metrics; used to scope vlselect panels.",
@@ -11142,6 +11143,7 @@
   "timezone": "",
   "title": "VictoriaLogs - cluster (VM)",
   "uid": "XqCOFEX4z_vm",
-  "version": 1,
-  "weekStart": ""
+  "version": 3,
+  "weekStart": "",
+  "id": null
 }

--- a/dashboards/vm/victorialogs.json
+++ b/dashboards/vm/victorialogs.json
@@ -16,7 +16,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "12.2.1"
+      "version": "12.3.0"
     },
     {
       "type": "datasource",
@@ -47,12 +47,6 @@
       "id": "timeseries",
       "name": "Time series",
       "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "victoriametrics-metrics-datasource",
-      "name": "VictoriaMetrics",
-      "version": "0.19.7"
     }
   ],
   "annotations": {
@@ -78,7 +72,7 @@
       {
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "$ds"
+          "uid": "${DS_PROMETHEUS}"
         },
         "enable": true,
         "expr": "sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"}) by(short_version) unless (sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"} offset $__interval) by(short_version))",
@@ -103,7 +97,7 @@
       {
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "${ds}"
+          "uid": "${DS_PROMETHEUS}"
         },
         "enable": false,
         "filter": {
@@ -129,7 +123,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": null,
   "links": [
     {
       "icon": "doc",
@@ -233,12 +226,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -305,12 +298,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -377,12 +370,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -449,12 +442,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -521,12 +514,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -560,7 +553,7 @@
         "content": "<div style=\"text-align: center;\">$version</div>",
         "mode": "markdown"
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "title": "Version",
       "type": "text"
     },
@@ -615,12 +608,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -687,12 +680,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -759,12 +752,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -831,11 +824,11 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -971,12 +964,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(rate(vl_rows_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) > 0",
@@ -1007,7 +1000,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "* `*` - unsupported query path\n* `/insert` - [inserts](https://docs.victoriametrics.com/victorialogs/data-ingestion/)\n* `/select` - [reads](https://docs.victoriametrics.com/victorialogs/querying/)\n* `/metrics` - scraping of system metrics",
       "fieldConfig": {
@@ -1096,7 +1089,7 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
@@ -1119,7 +1112,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "* `*` - unsupported query path\n* `/insert` - [inserts](https://docs.victoriametrics.com/victorialogs/data-ingestion/)\n* `/select` - [reads](https://docs.victoriametrics.com/victorialogs/querying/)\n* `/metrics` - scraping of system metrics",
       "fieldConfig": {
@@ -1204,7 +1197,7 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
@@ -1224,7 +1217,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -1333,12 +1326,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\"}) by (path) > 0",
@@ -1389,6 +1382,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1444,12 +1438,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "max(vl_total_disk_space_bytes{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
@@ -1500,6 +1494,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1583,12 +1578,12 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(rate(vm_log_messages_total{job=~\"$job\", instance=~\"$instance\", level!=\"info\"}[$__rate_interval])) by (instance, level, location)",
@@ -1709,7 +1704,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(changes(vm_app_start_timestamp{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
@@ -1821,7 +1816,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(increase(vl_streams_created_total{job=~\"$job\", instance=~\"$instance\"}[1d])) by (instance)",
@@ -1932,7 +1927,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -2041,7 +2036,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -2082,7 +2077,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Percentage of physical RAM used compared to the memory limit. If this percentage is high, check the `RSS` anonymous vs resident ratio panel for more details.",
           "fieldConfig": {
@@ -2162,7 +2157,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "How much memory (RAM) the VictoriaLogs process is actually using, compared to its allowed container or system limit. See 'Memory Usage' panel for a detailed breakdown.\n\n- Good: Below 70% most of the time, maybe spiking a bit under load.\n- Bad: Above 90% for more than 5 minutes = risk of out-of-memory (OOM) kill.",
           "fieldConfig": {
@@ -2272,7 +2267,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Portion of RAM that CANNOT be reclaimed without swapping. If both the `RSS`-to-limit percentage and this ratio are high, the process is at high risk of an `OOM` kill.",
           "fieldConfig": {
@@ -2344,7 +2339,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "- Anonymous resident memory: Private memory allocated to the application that **cannot** be reclaimed by the kernel. Refer to the [Check/profile](https://docs.victoriametrics.com/victorialogs/#profiling) Go heap section for troubleshooting.\n- File-backed resident memory: Memory mapped from files, which can be safely reclaimed. Increases during querying. Correlate with `I/O` panels for further analysis.\n- Shared resident memory: Typically negligible. Large spikes may indicate unexpected shared memory consumers.",
           "fieldConfig": {
@@ -2450,7 +2445,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(process_resident_memory_file_bytes{job=~\"$job\", instance=~\"$instance\"})",
@@ -2482,7 +2477,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2593,7 +2588,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Lower is better, e.g. 20% means the process was delayed by memory pressure 20% of the time. See [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html).\n\n- waiting: Time fraction where at least one thread was blocked on memory.\n- stalled: Time fraction where every thread was blocked on memory (severe pressure).\n\nIf queries slow down and both series spike, the host is likely limited by RAM or I/O throughput.",
           "fieldConfig": {
@@ -2703,7 +2698,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_memory_stalled_seconds_total{job=~\"$job\"}[$__rate_interval])) by (instance)",
@@ -2814,7 +2809,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_cpu_waiting_seconds_total{job=~\"$job\"}[$__rate_interval])) by (instance)",
@@ -2847,7 +2842,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of read/write calls application makes:\n\n- read call: Number of read*()-family system calls your process has issued since start. Each call can move 1 byte or megabytes, cached or uncached.\n- write call: Number of write*()-family system calls (including write, pwrite, writev, etc.) made by the process.",
           "fieldConfig": {
@@ -2966,7 +2961,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(rate(process_io_write_syscalls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
@@ -3094,7 +3089,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max_over_time(process_open_fds{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n/\nprocess_max_fds{job=~\"$job\", instance=~\"$instance\"}",
@@ -3217,7 +3212,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(rate(process_io_storage_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
@@ -3251,7 +3246,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "IO pressure based on [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html). The lower the better.\n\n- waiting: at least one runnable thread blocked on block-`I/O` (disk, NVMe, network-storage) while others could still make progress.\n- stalled: all non-idle threads simultaneously waiting on `I/O`; no useful user code ran during these periods → true `I/O` thrashing.\n\nIf stalled > 0 while querying, it's recommended to increase queue depth on NVMe, raise blk-mq budgets, or relax cgroup I/O limits.",
           "fieldConfig": {
@@ -3355,7 +3350,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_io_stalled_seconds_total{job=~\"$job\"}[$__rate_interval])) by (instance)",
@@ -3466,7 +3461,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(vm_tcplistener_conns{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
@@ -3576,7 +3571,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(go_goroutines{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
@@ -3685,7 +3680,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(rate(vm_tcplistener_accepts_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
@@ -3795,7 +3790,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(process_num_threads{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
@@ -3903,7 +3898,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(\n  rate(go_gc_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) \n / rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n ) by(instance)",
@@ -4012,7 +4007,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(histogram_quantile(0.99, sum(rate(go_sched_latencies_seconds_bucket{job=~\"$job\"}[$__rate_interval])) by (instance, le))) by (instance)",
@@ -4097,7 +4092,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -4206,7 +4201,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -4336,7 +4331,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -4368,7 +4363,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${ds}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of storage merge operations by type (sum across instances). Merges compact smaller parts into larger ones; bursts are normal after activity spikes.",
           "fieldConfig": {
@@ -4478,7 +4473,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${ds}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "99th percentile duration of merge operations by storage type. Merge operations combine smaller storage parts into larger ones for optimization. \n\nNormal merge durations vary by storage type and data volume. Consistently high durations may indicate storage performance issues, high write load, or insufficient resources for background operations. Monitor for trends that could impact overall system performance.",
           "fieldConfig": {
@@ -4587,7 +4582,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${ds}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "99th percentile of data volume processed during merge operations by storage type. \n\nThis metric indicates the scale of background storage optimization activities. Larger merge sizes generally improve storage efficiency but require more resources. Consistently high values may indicate heavy write loads or large storage parts that need optimization. Monitor correlation with merge duration for performance insights.",
           "fieldConfig": {
@@ -4711,7 +4706,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of incoming log insertion requests by endpoint path. This metric tracks the ingestion load on VictoriaLogs, including different insertion methods and protocols.\n\nHigher rates indicate increased log ingestion activity. Monitor for sudden spikes that might indicate new log sources, application deployments, or potential issues requiring capacity planning. Sustained high rates may require scaling ingestion capacity.",
           "fieldConfig": {
@@ -4833,7 +4828,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_bytes_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) > 0",
@@ -4943,7 +4938,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance\",path=~\"^/(internal/)?insert.*\"}[$__rate_interval])) by (path) > 0",
@@ -5053,7 +5048,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\", path=~\"^/(internal/)?insert.*\"}) by (path) > 0",
@@ -5163,7 +5158,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(vl_http_request_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\", path=~\"^/(internal/)?insert.*\"}) by (path) > 0",
@@ -5274,7 +5269,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(max_over_time(vl_insert_processors_count{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance)",
@@ -5305,7 +5300,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of log rows waiting to be written to storage, categorized by type. Pending rows indicate temporary queuing during ingestion. Consistently high values may suggest storage write bottlenecks or insufficient write capacity.\n\nPending rows are flushed in two ways:\n\n- After a specific time period (typically 1 second)\n- When the pending row size exceeds a threshold (typically 1.75 MB)",
           "fieldConfig": {
@@ -5415,7 +5410,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of concurrent insert operations has reached the configured limit: -maxConcurrentInserts (default: 2x CPU cores\n",
           "fieldConfig": {
@@ -5541,7 +5536,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of insert requests that timed out while waiting for available concurrency slots. This indicates sustained ingestion overload beyond configured limits.\n\nHigh values suggest:\n- Insert queue is consistently full\n- Insert requests waiting too long for execution slots\n- System under sustained heavy ingestion load\n- Need for horizontal scaling or ingestion optimization\n\nCombined with `Insert concurrency limit reached`, provides complete picture of ingestion rejection patterns.",
           "fieldConfig": {
@@ -5646,7 +5641,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "99th percentile duration of background flush operations by type. High values may indicate disk pressure or heavy ingestion. Correlate with `I/O` panels.",
           "fieldConfig": {
@@ -5769,7 +5764,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of incoming query requests by endpoint path. This metric tracks the query load on VictoriaLogs, including different query interfaces and internal operations. \n\nHigher rates indicate increased query activity from users or applications. Monitor for sudden spikes that might indicate new dashboards, automated queries, or potential performance issues. Sustained high rates may require scaling query processing capacity.",
           "fieldConfig": {
@@ -5880,7 +5875,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "99th percentile of query execution duration. This represents the time it takes for 99% of queries to complete:\n\n- High values indicate slow query performance that affects user experience. \n- Spikes may suggest complex queries, resource contention, or inefficient indexes. Monitor for trends that could indicate degrading performance.",
           "fieldConfig": {
@@ -5990,7 +5985,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of concurrent select (query) operations compared to the configured limit.\n\nHigh utilization near the limit may indicate query bottlenecks or insufficient query processing capacity.\n\nIf it's consistently high while CPU usage remains low, consider increasing the concurrency limit (`-search.maxConcurrentRequests`) or optimizing query performance to support more concurrent users.",
           "fieldConfig": {
@@ -6112,7 +6107,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "max(max_over_time(vl_concurrent_select_capacity{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
@@ -6216,7 +6211,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(vl_concurrent_select_limit_timeout_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (instance) > 0",
@@ -6338,7 +6333,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -6448,7 +6443,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -6558,7 +6553,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -6666,7 +6661,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -6776,7 +6771,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -6886,7 +6881,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -6996,7 +6991,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -7106,7 +7101,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${ds}"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -7126,6 +7121,7 @@
       "type": "row"
     }
   ],
+  "preload": false,
   "refresh": "",
   "schemaVersion": 42,
   "tags": [
@@ -7135,9 +7131,14 @@
   "templating": {
     "list": [
       {
-        "current": {},
+        "current": {
+          "text": "",
+          "value": "${DS_PROMETHEUS}",
+          "selected": true
+        },
         "includeAll": false,
-        "name": "ds",
+        "label": "Datasource",
+        "name": "DS_PROMETHEUS",
         "options": [],
         "query": "victoriametrics-metrics-datasource",
         "refresh": 1,
@@ -7166,7 +7167,7 @@
         "current": {},
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "$ds"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values(vm_app_version{job=~\"$job\"}, instance)",
         "includeAll": true,
@@ -7204,7 +7205,7 @@
         "baseFilters": [],
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "$ds"
+          "uid": "${DS_PROMETHEUS}"
         },
         "filters": [],
         "name": "adhoc",
@@ -7218,8 +7219,9 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "VictoriaLogs - single-node",
+  "title": "VictoriaLogs - single-node (VM)",
   "uid": "OqPIZTX4z_vm",
-  "version": 1,
-  "weekStart": ""
+  "version": 7,
+  "weekStart": "",
+  "id": null
 }

--- a/dashboards/vm/vlagent.json
+++ b/dashboards/vm/vlagent.json
@@ -16,7 +16,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "12.2.1"
+      "version": "12.3.0"
     },
     {
       "type": "datasource",
@@ -47,12 +47,6 @@
       "id": "timeseries",
       "name": "Time series",
       "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "victoriametrics-metrics-datasource",
-      "name": "VictoriaMetrics",
-      "version": "0.19.7"
     }
   ],
   "annotations": {
@@ -78,7 +72,7 @@
       {
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "$ds"
+          "uid": "$DS_PROMETHEUS"
         },
         "enable": true,
         "expr": "sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"}) by(short_version) unless (sum(vm_app_version{job=~\"$job\", instance=~\"$instance\"} offset $__interval) by(short_version))",
@@ -91,7 +85,7 @@
       {
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "enable": true,
         "expr": "sum(changes(vm_app_start_timestamp{job=~\"$job\", instance=~\"$instance\"}[$__interval])) by(job, instance)",
@@ -106,7 +100,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": null,
   "links": [
     {
       "icon": "doc",
@@ -189,14 +182,14 @@
         "content": "<div style=\"text-align: center;\">$version</div>",
         "mode": "markdown"
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "title": "Version",
       "type": "text"
     },
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Shows number of generated  error messages in  logs over last 30m. Non-zero value may be a sign of connectivity or misconfiguration errors.",
       "fieldConfig": {
@@ -252,12 +245,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "expr": "sum(increase(vm_log_messages_total{job=~\"$job\", instance=~\"$instance\", level!=\"info\"}[30m]))",
           "interval": "",
@@ -271,7 +264,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Persistent queue size shows size of pending logs in bytes which hasn't been flushed to remote storage yet. \nIncreasing of value might be a sign of connectivity issues. In such cases, vlagent starts to flush pending data on disk with attempt to send it later once connection is restored.",
       "fieldConfig": {
@@ -320,12 +313,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "expr": "sum(vlagent_remotewrite_pending_data_bytes{job=~\"$job\", instance=~\"$instance\"})",
           "interval": "",
@@ -339,7 +332,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Shows the cumulative number of log entries ingested. \n\nThe size is calculated before compression.",
       "fieldConfig": {
@@ -383,12 +376,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vl_bytes_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
@@ -404,7 +397,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Total number of available CPUs for selected vlagents. ",
       "fieldConfig": {
@@ -452,12 +445,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -475,11 +468,12 @@
     },
     {
       "datasource": {
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "align": "auto",
             "cellOptions": {
               "type": "auto"
             },
@@ -588,12 +582,12 @@
         "cellHeight": "sm",
         "showHeader": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "expr": "sort((time() - vm_app_start_timestamp{job=~\"$job\", instance=~\"$instance\"}) or (up{job=~\"$job\", instance=~\"$instance\"}))",
           "format": "table",
@@ -617,7 +611,7 @@
     },
     {
       "datasource": {
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "fieldConfig": {
         "defaults": {
@@ -702,12 +696,12 @@
           "sort": "asc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "expr": "sort(sum(up{job=~\"$job\", instance=~\"$instance\"}) by (job, instance))",
           "format": "time_series",
@@ -723,7 +717,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Total size of available memory for selected vlagents.",
       "fieldConfig": {
@@ -771,12 +765,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -808,7 +802,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "$ds"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Shows ingestion rate in number of log entries and bytes per second.",
       "fieldConfig": {
@@ -912,12 +906,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vl_rows_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) > 0",
@@ -931,7 +925,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vl_bytes_ingested_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (type) > 0",
@@ -948,7 +942,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Shows the persistent queue size of pending logs in bytes >2MB which hasn't been flushed to remote storage yet. \n\nIncreasing of value might be a sign of connectivity issues. In such cases, vlagent starts to flush pending data on disk with attempt to send it later once connection is restored.\n\nRemote write URLs are hidden by default but might be unveiled once `-remoteWrite.showURL` is set to true.\n\nClick on the line and choose Drilldown to show the persistent queue size per instance.\n",
       "fieldConfig": {
@@ -1048,12 +1042,12 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1070,7 +1064,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "* `*` - unsupported query path\n* `/insert` - [inserts](https://docs.victoriametrics.com/victorialogs/data-ingestion/)\n* `/select` - [reads](https://docs.victoriametrics.com/victorialogs/querying/)\n* `/metrics` - scraping of system metrics",
       "fieldConfig": {
@@ -1158,12 +1152,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vl_http_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path) > 0",
@@ -1181,7 +1175,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Shows rate of dropped logs from persistent queue. vlagent drops log lines from queue if in-memory and on-disk queues are full and it is unable to flush them to remote storage.\nThe max size of on-disk queue is configured by `-remoteWrite.maxDiskUsagePerURL` flag.",
       "fieldConfig": {
@@ -1274,12 +1268,12 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vm_persistentqueue_bytes_dropped_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (path) > 0",
@@ -1295,7 +1289,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Shows the rate of logging the messages by their level. Unexpected spike in rate is a good reason to check logs.",
       "fieldConfig": {
@@ -1304,11 +1298,13 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "bars",
             "fillOpacity": 100,
             "gradientMode": "none",
@@ -1317,6 +1313,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1324,6 +1321,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1340,7 +1338,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1378,12 +1377,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1403,7 +1402,7 @@
     {
       "datasource": {
         "type": "victoriametrics-metrics-datasource",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$DS_PROMETHEUS"
       },
       "description": "Errors rate shows rate for multiple metrics that track possible errors in vlagent, such as network or parsing errors.",
       "fieldConfig": {
@@ -1412,11 +1411,13 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -1425,6 +1426,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1432,6 +1434,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1448,7 +1451,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1491,12 +1495,12 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.5.0",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vm_http_request_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, protocol) > 0",
@@ -1508,7 +1512,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vm_protoparser_read_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, type) > 0",
@@ -1520,7 +1524,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vm_ingestserver_request_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, type) > 0",
@@ -1532,7 +1536,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vm_protoparser_unmarshal_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, type) > 0",
@@ -1544,7 +1548,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
           "expr": "sum(rate(vm_promscrape_dial_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job) > 0",
@@ -1570,7 +1574,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Percentage of used RSS memory (resident).\nThe RSS memory shows the amount of memory recently accessed by the application. It includes anonymous memory and data from recently accessed files (aka page cache).\nThe application's performance will significantly degrade when memory usage is close to 100%.\n\nClick on the line and choose Drilldown to show memory usage per instance",
           "fieldConfig": {
@@ -1664,7 +1668,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -1681,7 +1685,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "fieldConfig": {
             "defaults": {
@@ -1774,7 +1778,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -1793,7 +1797,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Share for memory allocated by the process itself. When memory usage reaches 100% it will be likely OOM-killed.\nSafe memory usage % considered to be below 80%\n\nClick on the line and choose Drilldown to show memory usage per instance",
           "fieldConfig": {
@@ -1881,7 +1885,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -1898,7 +1902,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows CPU pressure based on [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html).\n\nThe lower the better.",
           "fieldConfig": {
@@ -1983,7 +1987,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_cpu_waiting_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job, instance)",
@@ -1997,7 +2001,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_cpu_stalled_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job, instance)",
@@ -2016,7 +2020,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows memory pressure based on [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html).\n\nThe lower the better.",
           "fieldConfig": {
@@ -2101,7 +2105,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_memory_waiting_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job, instance)",
@@ -2115,7 +2119,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_memory_stalled_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job, instance)",
@@ -2134,7 +2138,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the number of bytes read/write from the storage layer when vlagent has to buffer data on disk or read already buffered data.\n\nClick on the line and choose Drilldown to show CPU usage per instance",
           "fieldConfig": {
@@ -2240,7 +2244,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_io_storage_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job) ",
@@ -2255,7 +2259,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_io_storage_written_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job)",
@@ -2274,7 +2278,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "fieldConfig": {
             "defaults": {
@@ -2360,7 +2364,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(max_over_time(go_goroutines{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job)",
@@ -2378,7 +2382,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows IO pressure based on [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html).\n\nThe lower the better.",
           "fieldConfig": {
@@ -2463,7 +2467,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_io_waiting_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job, instance)",
@@ -2477,7 +2481,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_pressure_io_stalled_seconds_total{job=~\"$job\"}[$__rate_interval])) by (job, instance)",
@@ -2496,7 +2500,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "fieldConfig": {
             "defaults": {
@@ -2582,7 +2586,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(max_over_time(process_num_threads{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job)",
@@ -2599,7 +2603,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Network usage shows the bytes rate for data accepted by vlagent and pushed via remotewrite protocol.\nDiscrepancies are possible because of different protocols used for ingesting, scraping and writing data.",
           "fieldConfig": {
@@ -2699,7 +2703,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vm_tcplistener_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job) * 8 \n+ sum(rate(vm_promscrape_conn_bytes_read_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job) * 8",
@@ -2711,7 +2715,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(vlagent_remotewrite_conn_bytes_written_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job) * 8",
@@ -2727,7 +2731,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the percent of CPU spent on garbage collection.\n\nIf % is high, then CPU usage can be decreased by changing GOGC to higher values. Increasing GOGC value will increase memory usage, and decrease CPU usage.\n\nTry searching for keyword `GOGC` at https://docs.victoriametrics.com/victoriametrics/troubleshooting/ ",
           "fieldConfig": {
@@ -2814,7 +2818,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(\n  rate(go_gc_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) \n / rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n ) by(job)",
@@ -2832,7 +2836,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the time goroutines have spent in runnable state before actually running. The lower is better.\n\nHigh values or values exceeding the threshold is usually a sign of            insufficient CPU resources or CPU throttling. \n\nVerify that service has enough CPU resources. Otherwise, the service could work unreliably with delays in processing.",
           "fieldConfig": {
@@ -2919,7 +2923,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(histogram_quantile(0.99, sum(rate(go_sched_latencies_seconds_bucket{job=~\"$job\"}[$__rate_interval])) by (job, instance, le))) by(job)",
@@ -2937,7 +2941,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the rate of allocations in memory. Sudden increase in allocations would mean increased pressure on Go Garbage Collector and can saturate CPU resources of the application.",
           "fieldConfig": {
@@ -3020,7 +3024,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[$__rate_interval])) by (job, instance)",
@@ -3038,7 +3042,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Panel shows the percentage of open file descriptors in the OS per instance.\nReaching the limit of open files (100%) can cause various issues and must be prevented.\n\nSee how to change limits here https://medium.com/@muhammadtriwibowo/set-permanently-ulimit-n-open-files-in-ubuntu-4d61064429a",
           "fieldConfig": {
@@ -3125,7 +3129,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "max(\n    max_over_time(process_open_fds{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n    /\n    process_max_fds{job=~\"$job\", instance=~\"$instance\"}\n) by(job)",
@@ -3157,7 +3161,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows write saturation of the persistent queue. If the threshold of 0.9sec is reached, then the persistent queue is saturated by more than 90% and vlagent won't be able to keep up with flushing data on disk. In this case, consider to decrease load on the vlagent or improve the disk throughput.",
           "fieldConfig": {
@@ -3246,7 +3250,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -3263,7 +3267,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows read saturation of the persistent queue. If the threshold of 0.9sec is reached, then the persistent queue is saturated by more than 90% and vlagent won't be able to keep up with reading data from the disk. In this case, consider to decrease load on the vlagent or improve the disk throughput.",
           "fieldConfig": {
@@ -3352,7 +3356,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -3369,7 +3373,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the rate of dropped data blocks in cases when remote storage replies with `400 Bad Request` and `409 Conflict` HTTP responses.",
           "fieldConfig": {
@@ -3457,7 +3461,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -3474,7 +3478,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the rate of dropped log lines in cases when -remoteWrite.dropSamplesOnOverload or multiple -remoteWrite.disableOnDiskQueue options are set",
           "fieldConfig": {
@@ -3562,7 +3566,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -3579,7 +3583,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "fieldConfig": {
             "defaults": {
@@ -3664,7 +3668,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -3706,7 +3710,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the number of restarts per job. The chart can be useful to identify periodic process restarts and correlate them with potential issues or anomalies. Normally, processes shouldn't restart unless restart was inited by user. The reason of restarts should be figured out by checking the logs of each specific service. ",
           "fieldConfig": {
@@ -3793,7 +3797,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(changes(vm_app_start_timestamp{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) > 0) by(job)",
@@ -3823,7 +3827,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows how many concurrent inserts are taking place.\n\nIf the number of concurrent inserts hitting the `limit` or is close to the `limit` constantly - it might be a sign of a resource shortage.\n\n If vlagent's CPU usage and remote write connection saturation are at normal level, it might be that `-maxConcurrentInserts` cmd-line flag need to be increased.",
           "fieldConfig": {
@@ -3908,7 +3912,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -3921,7 +3925,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -3938,7 +3942,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the rate of write errors in ingestserver (UDP, TCP connections) and HTTP server.",
           "fieldConfig": {
@@ -4023,7 +4027,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "exemplar": true,
               "expr": "sum(rate(vm_ingestserver_request_errors_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(type, net) > 0",
@@ -4034,7 +4038,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "exemplar": true,
               "expr": "sum(rate(vlagent_http_request_errors_total{job=~\"$job\", instance=~\"$instance\", protocol!=\"\"}[$__rate_interval])) by(protocol) > 0",
@@ -4063,7 +4067,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the rate of requests to configured remote write endpoints by url and status code.\n\nRemote write URLs are hidden by default but might be unveiled once `-remoteWrite.showURL` is set to true.\n\n",
           "fieldConfig": {
@@ -4150,7 +4154,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -4167,7 +4171,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the global rate for number of written bytes via remote write connections.",
           "fieldConfig": {
@@ -4253,7 +4257,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -4270,7 +4274,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows requests retry rate by url. Number of retries is unlimited but protected with delays up to 1m between attempts.\n\nRemote write URLs are hidden by default but might be unveiled once `-remoteWrite.showURL` is set to true.\n\n",
           "fieldConfig": {
@@ -4356,7 +4360,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -4373,7 +4377,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows current number of established connections to remote write endpoints.\n\n",
           "fieldConfig": {
@@ -4459,7 +4463,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -4476,7 +4480,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows saturation of every connection to remote storage. If the threshold of 90% is reached, then the connection is saturated (busy or slow) by more than 90%, so vlagent won't be able to keep up and can start buffering data. \n\nThis usually means that `-remoteWrite.queues` command-line flag must be increased in order to increase the number of connections per each remote storage.\n",
           "fieldConfig": {
@@ -4562,7 +4566,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -4619,7 +4623,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "",
           "fieldConfig": {
@@ -4703,7 +4707,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -4722,7 +4726,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the used memory (resident).\nThe application's performance will significantly degrade when memory usage is close to 100%.",
           "fieldConfig": {
@@ -4806,7 +4810,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -4823,7 +4827,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the persistent queue size of pending samples in bytes which hasn't been flushed to remote storage yet. \n\nIncreasing of value might be a sign of connectivity issues. In such cases, vlagent starts to flush pending data on disk with attempt to send it later once connection is restored.\n\nRemote write URLs are hidden by default but might be unveiled once `-remoteWrite.showURL` is set to true.",
           "fieldConfig": {
@@ -4915,7 +4919,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "exemplar": true,
@@ -4932,7 +4936,7 @@
         {
           "datasource": {
             "type": "victoriametrics-metrics-datasource",
-            "uid": "$ds"
+            "uid": "$DS_PROMETHEUS"
           },
           "description": "Shows the number of bytes read/write from the storage layer when vlagent has to buffer data on disk or read already buffered data.",
           "fieldConfig": {
@@ -5032,7 +5036,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_io_storage_read_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job, instance)",
@@ -5047,7 +5051,7 @@
             {
               "datasource": {
                 "type": "victoriametrics-metrics-datasource",
-                "uid": "$ds"
+                "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
               "expr": "sum(rate(process_io_storage_written_bytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by(job,instance)",
@@ -5068,6 +5072,7 @@
       "type": "row"
     }
   ],
+  "preload": false,
   "refresh": "",
   "schemaVersion": 42,
   "tags": [
@@ -5077,9 +5082,14 @@
   "templating": {
     "list": [
       {
-        "current": {},
+        "current": {
+          "text": "",
+          "value": "${DS_PROMETHEUS}",
+          "selected": true
+        },
         "includeAll": false,
-        "name": "ds",
+        "label": "Datasource",
+        "name": "DS_PROMETHEUS",
         "options": [],
         "query": "victoriametrics-metrics-datasource",
         "refresh": 1,
@@ -5090,7 +5100,7 @@
         "current": {},
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vm_app_version{version=~\"^vlagent.*\"}, job)",
         "includeAll": true,
@@ -5110,7 +5120,7 @@
         "current": {},
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "$ds"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vm_app_version{job=~\"$job\"}, instance)",
         "includeAll": true,
@@ -5130,7 +5140,7 @@
         "current": {},
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vlagent_remotewrite_requests_total{job=~\"$job\", instance=~\"$instance\"}, url)",
         "description": "The remote write URLs",
@@ -5150,7 +5160,7 @@
         "current": {},
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "${ds}"
+          "uid": "$DS_PROMETHEUS"
         },
         "definition": "label_values(vm_app_version{job=~\"$job\", instance=~\"$instance\"},short_version)",
         "hide": 2,
@@ -5169,7 +5179,7 @@
         "baseFilters": [],
         "datasource": {
           "type": "victoriametrics-metrics-datasource",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$DS_PROMETHEUS"
         },
         "filters": [],
         "name": "adhoc",
@@ -5178,7 +5188,7 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-3h",
     "to": "now"
   },
   "timepicker": {
@@ -5197,6 +5207,7 @@
   "timezone": "",
   "title": "VictoriaLogs - vlagent (VM)",
   "uid": "Y5Z9GzMGz_vm",
-  "version": 3,
-  "weekStart": ""
+  "version": 2,
+  "weekStart": "",
+  "id": null
 }


### PR DESCRIPTION
### Describe Your Changes

Currently, if a user tries to export any of our dashboards for external use, the error 'Datasource ${DS_PROMETHEUS} was not found' occurs. There is only one way to fix this: use the 'DS_PROMETHEUS' variable instead of 'ds'.

Also, this PR removes references to multiple datasources at once - now only one datasource is used.

Also, updated the VictoriaLogs single-single dashboard title in the Makefile, because it was outdated.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
