### PR TITLE
app/vlinsert/{internalinsert,nativeinsert}: warn about unsupported headers

### DIFF
--- a/app/vlinsert/internalinsert/internalinsert.go
+++ b/app/vlinsert/internalinsert/internalinsert.go
@@ -46,23 +46,23 @@ func RequestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if cp.TenantID.AccountID != 0 || cp.TenantID.ProjectID != 0 {
-		logger.Warnf("/internal/insert endpoint doesn't support setting tenantID; ignoring it; tenantID=%q", cp.TenantID)
+		logger.Warnf("/internal/insert endpoint doesn't support setting tenantID via AccountID and ProjectID request headers; ignoring it; tenantID=%q; see https://docs.victoriametrics.com/victorialogs/vlagent/#multitenancy", cp.TenantID)
 		cp.TenantID = logstorage.TenantID{}
 	}
 	if len(cp.TimeFields) > 0 {
-		logger.Warnf("/internal/insert endpoint doesn't support setting time fields; ignoring them; timeField=%q", cp.TimeFields)
+		logger.Warnf("/internal/insert endpoint doesn't support setting time fields via _time_field query arg and via VL-Time-Field request header; ignoring them; timeFields=%q", cp.TimeFields)
 		cp.TimeFields = nil
 	}
 	if len(cp.MsgFields) > 0 {
-		logger.Warnf("/internal/insert endpoint doesn't support setting msg fields; ignoring them; msgField=%q", cp.MsgFields)
+		logger.Warnf("/internal/insert endpoint doesn't support setting msg fields via _msg_field query arg and via VL-Msg-Field request header; ignoring them; msgFields=%q", cp.MsgFields)
 		cp.MsgFields = nil
 	}
 	if len(cp.StreamFields) > 0 {
-		logger.Warnf("/internal/insert endpoint doesn't support setting stream fields; ignoring them; streamField=%q", cp.StreamFields)
+		logger.Warnf("/internal/insert endpoint doesn't support setting stream fields via _stream_fields query arg and via VL-Stream-Fields request header; ignoring them; streamFields=%q", cp.StreamFields)
 		cp.StreamFields = nil
 	}
 	if len(cp.DecolorizeFields) > 0 {
-		logger.Warnf("/internal/insert endpoint doesn't support setting decolorize fields; ignoring them; decolorizeField=%q", cp.DecolorizeFields)
+		logger.Warnf("/internal/insert endpoint doesn't support setting decolorize_fields query arg and VL-Decolorize-Fields request header; ignoring them; decolorizeFields=%q", cp.DecolorizeFields)
 		cp.DecolorizeFields = nil
 	}
 

--- a/app/vlinsert/nativeinsert/nativeinsert.go
+++ b/app/vlinsert/nativeinsert/nativeinsert.go
@@ -50,19 +50,19 @@ func RequestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(cp.TimeFields) > 0 {
-		logger.Warnf("/insert/native endpoint doesn't support setting time fields; ignoring them; timeField=%q", cp.TimeFields)
+		logger.Warnf("/insert/native endpoint doesn't support setting time fields via _time_field query arg and via VL-Time-Field request header; ignoring them; timeFields=%q", cp.TimeFields)
 		cp.TimeFields = nil
 	}
 	if len(cp.MsgFields) > 0 {
-		logger.Warnf("/insert/native endpoint doesn't support setting msg fields; ignoring them; msgField=%q", cp.MsgFields)
+		logger.Warnf("/insert/native endpoint doesn't support setting msg fields via _msg_field query arg and via VL-Msg-Field request header; ignoring them; msgFields=%q", cp.MsgFields)
 		cp.MsgFields = nil
 	}
 	if len(cp.StreamFields) > 0 {
-		logger.Warnf("/insert/native endpoint doesn't support setting stream fields; ignoring them; streamField=%q", cp.StreamFields)
+		logger.Warnf("/insert/native endpoint doesn't support setting stream fields via _stream_fields query arg and via VL-Stream-Fields request header; ignoring them; streamFields=%q", cp.StreamFields)
 		cp.StreamFields = nil
 	}
 	if len(cp.DecolorizeFields) > 0 {
-		logger.Warnf("/insert/native endpoint doesn't support setting decolorize fields; ignoring them; decolorizeField=%q", cp.DecolorizeFields)
+		logger.Warnf("/insert/native endpoint doesn't support setting decolorize_fields query arg and VL-Decolorize-Fields request header; ignoring them; decolorizeFields=%q", cp.DecolorizeFields)
 		cp.DecolorizeFields = nil
 	}
 


### PR DESCRIPTION
### Describe Your Changes

Log a warning about unsupported headers for  `/internal/insert` and `/insert/native` endpoints to avoid confusing users.

The ProjectID, AccountID, VL-Msg-Fields, VL-Time-Fields, and VL-Stream-Fields headers were already unsupported; this PR simply adds explicit handling for them.

What has changed: The VL-Decolorize-Fields header is now ignored. Previously, the `/internal/insert` and `/insert/native` endpoints were able to perform decoloring on the specified fields.

Blocks on #918

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
