### PR TITLE
docs/extra-filters: clarify that extra_filters are propagated into all subqueries

### DIFF
--- a/docs/victorialogs/querying/README.md
+++ b/docs/victorialogs/querying/README.md
@@ -1044,6 +1044,9 @@ All the [HTTP querying APIs](https://docs.victoriametrics.com/victorialogs/query
   which must be applied to the `query` before returning results. Multiple `extra_stream_filters` args may be passed in a single request.
   All the stream filters across all the `extra_stream_filters` args are applied to the `query` then.
 
+Note that `extra_filters` and `extra_stream_filters` are global constraints. They are unconditionally propagated into all the subqueries
+inside the `query` (for example, queries inside `| join ... (...)`, `| union(...)`, `...:in(<query>)`, etc). This behavior is needed for reliable access control (e.g. restricting queries to a subset of logs) - otherwise it can be bypassed via subqueries.
+
 The `extra_filters` and `extra_stream_filters` values can have the following format:
 
 - JSON object with `"field":"value"` entries. For example, the following JSON applies `namespace:=my-app and env:=prod` filter to the `query`

--- a/docs/victorialogs/security-and-lb.md
+++ b/docs/victorialogs/security-and-lb.md
@@ -271,7 +271,11 @@ VictoriaLogs will assume that the corresponding header has a value of 0.
 
 `VictoriaLogs` can apply extra filters for each request to the select APIs according to [these docs](https://docs.victoriametrics.com/victorialogs/querying/#extra-filters).
 This is useful when you need to give access to a subset of data within a single tenant.
-If you want to hide a subset of data within a tenant, use the HTTP query parameter `extra_filters`:
+If you want to hide a subset of data within a tenant, use the HTTP query parameter `extra_filters`.
+
+`extra_filters` are enforced globally - they are propagated into all the subqueries inside the provided `query`. This makes it impossible to bypass the restrictions via `join`, `union`, `in(<query>)` and other subqueries.
+
+Consider the example below:
 
 ```yaml
 users:


### PR DESCRIPTION
Related to https://github.com/VictoriaMetrics/victorialogs-datasource/issues/510

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
