### PR TITLE
logstorage/ipv4: simplify IPv4 parsing logic

### DIFF
--- a/lib/logstorage/values_encoder.go
+++ b/lib/logstorage/values_encoder.go
@@ -680,8 +680,8 @@ func tryIPv4Encoding(dstBuf []byte, dstValues, srcValues []string) ([]byte, []st
 
 // tryParseIPv4 tries parsing ipv4 from s.
 func tryParseIPv4(s string) (uint32, bool) {
-	if strings.IndexByte(s, '.') < 0 {
-		// Fast path - the entry isn't IPv4.
+	if len(s) < len("1.1.1.1") || len(s) > len("255.255.255.255") || strings.Count(s, ".") != 3 {
+		// Fast path - the entry isn't IPv4
 		return 0, false
 	}
 	addr, err := netip.ParseAddr(s)


### PR DESCRIPTION
Simplify `tryParseIPv4`

```
BenchmarkTryParseIPv4-14    	151425498	         7.828 ns/op	 638.76 MB/s
BenchmarkTryParseIPv4-14    	153531536	         7.792 ns/op	 641.65 MB/s
BenchmarkTryParseIPv4-14    	153910430	         7.831 ns/op	 638.46 MB/s
BenchmarkTryParseIPv4-14    	154941453	         7.838 ns/op	 637.92 MB/s
BenchmarkTryParseIPv4-14    	154076271	         7.733 ns/op	 646.55 MB/s
BenchmarkTryParseIPv4-14    	152002987	         7.869 ns/op	 635.39 MB/s
BenchmarkTryParseIPv4-14    	154159215	         7.807 ns/op	 640.46 MB/s
BenchmarkTryParseIPv4-14    	153738799	         7.896 ns/op	 633.25 MB/s
BenchmarkTryParseIPv4-14    	152720760	         7.801 ns/op	 640.97 MB/s
BenchmarkTryParseIPv4-14    	153314458	         7.873 ns/op	 635.06 MB/s
BenchmarkOldTryParseIPv4-14    	121244202	         9.721 ns/op	 514.36 MB/s
BenchmarkOldTryParseIPv4-14    	129863997	         9.272 ns/op	 539.24 MB/s
BenchmarkOldTryParseIPv4-14    	127582876	         9.404 ns/op	 531.69 MB/s
BenchmarkOldTryParseIPv4-14    	125876193	         9.403 ns/op	 531.75 MB/s
BenchmarkOldTryParseIPv4-14    	126915073	         9.430 ns/op	 530.21 MB/s
BenchmarkOldTryParseIPv4-14    	125758122	         9.498 ns/op	 526.42 MB/s
BenchmarkOldTryParseIPv4-14    	125180359	         9.774 ns/op	 511.54 MB/s
BenchmarkOldTryParseIPv4-14    	124463218	         9.701 ns/op	 515.39 MB/s
BenchmarkOldTryParseIPv4-14    	124838733	         9.596 ns/op	 521.04 MB/s
BenchmarkOldTryParseIPv4-14    	124361400	         9.621 ns/op	 519.71 MB/s
```

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
