### PR TITLE
app/vlagent/kubernetescollector: ignore ErrUnexpectedEOF

### DIFF
--- a/app/vlagent/kubernetescollector/collector.go
+++ b/app/vlagent/kubernetescollector/collector.go
@@ -115,7 +115,8 @@ func (kc *kubernetesCollector) startWatchCluster(ctx context.Context) {
 					return
 				}
 
-				if errors.Is(err, io.EOF) && time.Since(lastEOF) > time.Minute {
+				isEOF := errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
+				if isEOF && time.Since(lastEOF) > time.Minute {
 					// Kubernetes API server closed the connection.
 					// This is expected to happen from time to time.
 					// Ignore EOF errors happening not more often than once per minute.


### PR DESCRIPTION
### Describe Your Changes

This PR fixes the `failed to read the Kubernetes Pod watch stream: cannot read event line: unexpected EOF` errors.
It is expected behavior for TCP connections to close occasionally, which causes the client to receive `EOF` or `UnexpectedEOF` errors. 

This commit adds logic to ignore UnexpectedEOF errors if they occur less frequently than once per minute.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
