### PR TITLE
app/vlagent/kubernetescollector: use resourceVersion to skip already processed events

### DIFF
--- a/app/vlagent/kubernetescollector/checkpoints_db.go
+++ b/app/vlagent/kubernetescollector/checkpoints_db.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
-
-	"github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage"
 )
 
 // checkpointsDB manages persistent log file reading state checkpoints.
@@ -67,10 +65,9 @@ func startCheckpointsDB(path string) (*checkpointsDB, error) {
 // checkpoint includes pod metadata (common and stream fields) to allow immediate log processing
 // without waiting for the Kubernetes API server to provide pod information.
 type checkpoint struct {
-	Path         string             `json:"path"`
-	Inode        uint64             `json:"inode"`
-	Offset       int64              `json:"offset"`
-	CommonFields []logstorage.Field `json:"commonFields"`
+	Path   string `json:"path"`
+	Inode  uint64 `json:"inode"`
+	Offset int64  `json:"offset"`
 }
 
 func (db *checkpointsDB) set(cp checkpoint) {

--- a/app/vlagent/kubernetescollector/client.go
+++ b/app/vlagent/kubernetescollector/client.go
@@ -76,9 +76,14 @@ type watchEvent struct {
 
 // watchNodePods starts watching Pod changes on the specified node.
 // It returns a stream of watchEvent values representing updates to those Pods.
-//
 // See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#watch-pod-v1-core
-func (c *kubeAPIClient) watchNodePods(ctx context.Context, nodeName string) (podWatchStream, error) {
+//
+// watchNodePods accepts the resourceVersion argument to skip already processed events.
+// It is recommended to skip already processed events to significantly reduce the load on the Kubernetes API server.
+// The resourceVersion value can be obtained from the podListMetadata.ResourceVersion field returned by getNodePods
+// or from the watchEvent.Object.metadata.resourceVersion field.
+// See https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes
+func (c *kubeAPIClient) watchNodePods(ctx context.Context, nodeName, resourceVersion string) (podWatchStream, error) {
 	args := url.Values{
 		"watch": []string{"true"},
 		"fieldSelector": []string{
@@ -88,10 +93,22 @@ func (c *kubeAPIClient) watchNodePods(ctx context.Context, nodeName string) (pod
 		},
 	}
 
+	// Set resourceVersion if it is non-empty to skip already processed events.
+	if resourceVersion != "" {
+		args["resourceVersion"] = []string{resourceVersion}
+	}
+
 	req := c.mustCreateRequest(ctx, http.MethodGet, "/api/v1/pods", args)
 	resp, err := c.c.Do(req)
 	if err != nil {
 		return podWatchStream{}, fmt.Errorf("cannot do %q GET request: %w", req.URL.String(), err)
+	}
+
+	if resp.StatusCode == http.StatusGone && resourceVersion != "" {
+		// Requested watch operation fail because the historical resourceVersion is too old.
+		// Fallback to watching from the beginning.
+		// See https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-watch
+		return c.watchNodePods(ctx, nodeName, "")
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -137,11 +154,12 @@ type pod struct {
 }
 
 type podMetadata struct {
-	Name        string            `json:"name"`
-	Labels      map[string]string `json:"labels"`
-	Annotations map[string]string `json:"annotations"`
-	Namespace   string            `json:"namespace"`
-	UID         string            `json:"uid"`
+	Name            string            `json:"name"`
+	Labels          map[string]string `json:"labels"`
+	Annotations     map[string]string `json:"annotations"`
+	Namespace       string            `json:"namespace"`
+	ResourceVersion string            `json:"resourceVersion"`
+	UID             string            `json:"uid"`
 }
 
 type podSpec struct {
@@ -185,6 +203,50 @@ func (ps *podStatus) findInitContainerStatus(containerName string) (containerSta
 		}
 	}
 	return containerStatus{}, false
+}
+
+type podList struct {
+	Metadata podListMetadata `json:"metadata"`
+	Items    []pod           `json:"items"`
+}
+
+type podListMetadata struct {
+	ResourceVersion string `json:"resourceVersion"`
+}
+
+// getNodePods returns a list of pods on the given node.
+//
+// See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#list-all-namespaces-pod-v1-core
+func (c *kubeAPIClient) getNodePods(ctx context.Context, nodeName string) (podList, error) {
+	args := url.Values{
+		"fieldSelector": []string{
+			// Watch pods only on the given node.
+			// See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
+			"spec.nodeName=" + nodeName,
+		},
+	}
+
+	req := c.mustCreateRequest(ctx, http.MethodGet, "/api/v1/pods", args)
+	resp, err := c.c.Do(req)
+	if err != nil {
+		return podList{}, fmt.Errorf("cannot do %q GET request: %w", req.URL.String(), err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		payload, err := io.ReadAll(resp.Body)
+		if err != nil {
+			payload = []byte(err.Error())
+		}
+		_ = resp.Body.Close()
+		return podList{}, fmt.Errorf("unexpected status code %d from %q; response: %q", resp.StatusCode, req.URL.String(), payload)
+	}
+
+	var pl podList
+	if err := json.NewDecoder(resp.Body).Decode(&pl); err != nil {
+		return podList{}, fmt.Errorf("cannot decode response body: %w", err)
+	}
+	return pl, nil
 }
 
 // getPod returns the pod with the given namespace and name.

--- a/app/vlagent/kubernetescollector/collector.go
+++ b/app/vlagent/kubernetescollector/collector.go
@@ -19,10 +19,15 @@ import (
 )
 
 type client interface {
-	// watchNodePods starts watching Pods scheduled on the given node.
-	// The returned stream includes initial events representing the current state
-	// of all Pods running on that node, followed by incremental updates.
-	watchNodePods(ctx context.Context, node string) (podWatchStream, error)
+	// watchNodePods starts watching Pod scheduled on the given node.
+	//
+	// It uses resourceVersion to resume from a specific state.
+	// If empty, the watch provides the current state of all active Pods on the node first,
+	// followed by incremental updates.
+	watchNodePods(ctx context.Context, node, resourceVersion string) (podWatchStream, error)
+
+	// getNodePods returns information about Pods scheduled on the given node.
+	getNodePods(ctx context.Context, node string) (podList, error)
 
 	// getNodeByName returns information about the node with the given name.
 	getNodeByName(ctx context.Context, nodeName string) (node, error)
@@ -78,14 +83,49 @@ func startKubernetesCollector(client client, currentNodeName, logsPath, checkpoi
 	fc := startFileCollector(checkpointsPath, excludeFilter, newProcessor)
 	kc.fileCollector = fc
 
-	kc.startWatchCluster(kc.ctx)
+	pl, err := client.getNodePods(ctx, currentNodeName)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("cannot get Pods on node %q: %w", currentNodeName, err)
+	}
+
+	// Start reading existing Pod logs.
+	for _, pod := range pl.Items {
+		kc.startReadPodLogs(pod)
+	}
+	// Cleanup checkpoints for deleted Pods.
+	fc.cleanupCheckpoints()
+
+	// Start watching for new Pods.
+	kc.startWatchCluster(kc.ctx, pl.Metadata.ResourceVersion)
 
 	return kc, nil
 }
 
 // startWatchCluster starts watching Pods scheduled on the given node.
 // It calls handleUpdateEvent for each received event.
-func (kc *kubernetesCollector) startWatchCluster(ctx context.Context) {
+func (kc *kubernetesCollector) startWatchCluster(ctx context.Context, resourceVersion string) {
+	handleEvent := func(event watchEvent) {
+		switch event.Type {
+		case "ADDED", "MODIFIED":
+			var pod pod
+			if err := json.Unmarshal(event.Object, &pod); err != nil {
+				logger.Panicf("FATAL: cannot unmarshal Kubernetes event object %q: %s", event.Object, err)
+			}
+
+			kc.startReadPodLogs(pod)
+
+			// Update resourceVersion to the latest seen.
+			resourceVersion = pod.Metadata.ResourceVersion
+		case "DELETED":
+			// Ignore deleted pods.
+		case "ERROR":
+			logger.Errorf("got an error event from Kubernetes API: %q", string(event.Object))
+		default:
+			logger.Errorf("unexpected Kubernetes event type %q: %s", event.Type, string(event.Object))
+		}
+	}
+
 	currentNodeName := kc.currentNode.Metadata.Name
 
 	kc.wg.Add(1)
@@ -101,7 +141,7 @@ func (kc *kubernetesCollector) startWatchCluster(ctx context.Context) {
 		lastEOF := time.Time{}
 
 		for {
-			r, err := kc.client.watchNodePods(ctx, currentNodeName)
+			r, err := kc.client.watchNodePods(ctx, currentNodeName, resourceVersion)
 			if err != nil {
 				if ctx.Err() != nil {
 					return
@@ -121,7 +161,7 @@ func (kc *kubernetesCollector) startWatchCluster(ctx context.Context) {
 
 			bt.reset()
 
-			err = r.readEvents(kc.handleEvent)
+			err = r.readEvents(handleEvent)
 			_ = r.close()
 			if err != nil {
 				if ctx.Err() != nil {
@@ -145,27 +185,7 @@ func (kc *kubernetesCollector) startWatchCluster(ctx context.Context) {
 	}()
 }
 
-func (kc *kubernetesCollector) handleEvent(event watchEvent) {
-	switch event.Type {
-	case "ADDED", "MODIFIED":
-		kc.handleUpdateEvent(event.Object)
-	case "DELETED":
-		// ignore deleted pods
-	case "ERROR":
-		logger.Errorf("got an error event from Kubernetes API: %q", string(event.Object))
-	default:
-		logger.Errorf("unexpected Kubernetes event type %q: %s", event.Type, string(event.Object))
-	}
-}
-
-// handleUpdateEvent prepares log file path and common fields for the given pod
-// and delegates log file processing to fileCollector.
-func (kc *kubernetesCollector) handleUpdateEvent(data json.RawMessage) {
-	var pod pod
-	if err := json.Unmarshal(data, &pod); err != nil {
-		logger.Panicf("FATAL: cannot unmarshal Kubernetes event object %q: %s", data, err)
-	}
-
+func (kc *kubernetesCollector) startReadPodLogs(pod pod) {
 	startRead := func(pc podContainer, cs containerStatus) {
 		commonFields := getCommonFields(kc.currentNode, pod, cs)
 

--- a/app/vlagent/kubernetescollector/logfile.go
+++ b/app/vlagent/kubernetescollector/logfile.go
@@ -34,8 +34,6 @@ type logFile struct {
 	// commitOffset tracks the offset of the last committed log entry.
 	commitOffset int64
 
-	commonFields []logstorage.Field
-
 	// tail contains the last incomplete line read from the file.
 	// Can be truncated if it exceeds maxLineSize.
 	tail *bytesutil.ByteBuffer
@@ -43,21 +41,20 @@ type logFile struct {
 	tailSize int
 }
 
-func newLogFile(symlink string, commonFields []logstorage.Field) *logFile {
+func newLogFile(symlink string) *logFile {
 	return &logFile{
-		path:         symlink,
-		commonFields: commonFields,
+		path: symlink,
 	}
 }
 
-func newLogFileFromFile(f *os.File, symlink string, commonFields []logstorage.Field) (*logFile, error) {
+func newLogFileFromFile(f *os.File, symlink string) (*logFile, error) {
 	fi, err := f.Stat()
 	if err != nil {
 		return nil, fmt.Errorf("cannot get file info of %q: %w", f.Name(), err)
 	}
 	inode := getInode(fi)
 
-	lf := newLogFile(symlink, commonFields)
+	lf := newLogFile(symlink)
 	lf.inode = inode
 	lf.commitInode = inode
 	lf.file = f
@@ -307,10 +304,9 @@ func (lf *logFile) close() {
 
 func (lf *logFile) checkpoint() checkpoint {
 	return checkpoint{
-		Path:         lf.path,
-		Inode:        lf.commitInode,
-		Offset:       lf.commitOffset,
-		CommonFields: lf.commonFields,
+		Path:   lf.path,
+		Inode:  lf.commitInode,
+		Offset: lf.commitOffset,
 	}
 }
 

--- a/app/vlagent/kubernetescollector/logfile_test.go
+++ b/app/vlagent/kubernetescollector/logfile_test.go
@@ -17,7 +17,7 @@ func TestReadLines(t *testing.T) {
 		filePath, _ := createTestLogFile(t)
 
 		writeLinesToFile(t, filePath, in...)
-		lf := newLogFile(filePath, nil)
+		lf := newLogFile(filePath)
 
 		proc := newTestLogFileProcessor()
 		lf.readLines(stopCh, proc)
@@ -166,7 +166,7 @@ func benchmarkReadLines(b *testing.B, lineLen, count int) {
 
 	stopCh := make(chan struct{})
 	b.RunParallel(func(pb *testing.PB) {
-		lf := newLogFile(logFilePath, nil)
+		lf := newLogFile(logFilePath)
 		defer lf.close()
 
 		for pb.Next() {

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -22,6 +22,7 @@ according to the following docs:
 ## tip
 
 * FEATURE: [Kubernetes Collector](https://docs.victoriametrics.com/victorialogs/vlagent/#collect-kubernetes-pod-logs): add an ability to include and exclude Pod/Node labels and annotation fields from logs. This metadata is also available for [filtering](https://docs.victoriametrics.com/victorialogs/vlagent/#filtering-kubernetes-logs). See [#923](https://github.com/VictoriaMetrics/VictoriaLogs/issues/923) and [these docs](https://docs.victoriametrics.com/victorialogs/vlagent/#kubernetes-metadata-configuration) for details.
+* FEATURE: [Kubernetes Collector](https://docs.victoriametrics.com/victorialogs/vlagent/#collect-kubernetes-pod-logs): reduce a load on the Kubernetes API by using [resource versions](https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions) to ignore already processed events when a TCP connection is dropped. In the previous version, vlagent would request the full state of the current node from the control plane every 5 minutes, which could lead to an increased load on the central API server in large clusters.
 
 ## [v1.42.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.42.0)
 


### PR DESCRIPTION
### Describe Your Changes

Use [`resourceVersion`](https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions) to skip already processed events from the Kubernetes API.

This commit also removes commonFields from the checkpoint struct. Previously, these fields were stored to avoid synchronization between the startWatchCluster and fileCollector components. This fixes the issue described in #934 and #927.

Blocks on #934 

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
