### PR TITLE
lib/logstorage: add lateral join support with dynamic field references

### DIFF
--- a/docs/victorialogs/logsql.md
+++ b/docs/victorialogs/logsql.md
@@ -2429,6 +2429,46 @@ See also:
 - [conditional `stats`](https://docs.victoriametrics.com/victorialogs/logsql/#stats-with-additional-filters)
 - [`filter` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#filter-pipe)
 
+#### Lateral join
+
+The `lateral` variant allows `<q2>` to be evaluated dynamically per row (or per join key) during `<q1>` execution, and reference fields from the current row:
+
+```logsql
+<q1> | join lateral by (k1, k2) (<q2_with_placeholders>) [options(...)] [inner] [prefix ...]
+```
+
+`inner`, `prefix` and `options(...)` can be supplied in any order after `<q2>`; they are canonicalized in the printed form.
+
+Differences from regular `join`:
+
+- `<q2>` is not pre-executed; it runs on demand for each unique `by (k1, k2)` key.
+- `<q2>` can use placeholders like `${field}`, which are replaced with values from the current row's unpacked fields (not limited to `by` fields; missing values are replaced with empty strings).
+- Results for each "placeholder-instantiated `<q2>`" are cached locally, keyed by the rendered query string; identical rendered queries hit the cache.
+- `<q2>` must include a `_time` filter; otherwise the subquery is skipped for that row to avoid unbounded scans.
+- `prefix` is applied to fields returned from `<q2>` the same way as in regular `join`.
+
+Optional `options(...)` parameters (comma-separated), with defaults: `max_subqueries=1000`, `max_per_key=100`, `concurrency=4`, `timeout=5s`:
+
+- `max_subqueries`: maximum total number of subqueries allowed for the entire query.
+- `max_per_key`: maximum number of result rows per join key.
+- `concurrency`: maximum number of subqueries executed in parallel.
+- `timeout`: timeout for each individual subquery.
+
+Example: for each pod, fetch recent error logs from the same pod over the last 10 minutes:
+
+```logsql
+_time:10m | join lateral by (kubernetes.pod_name) (
+  level:error | filter pod:"${kubernetes.pod_name}" _time:10m
+) prefix "err." options(max_subqueries=200,max_per_key=10,concurrency=3)
+```
+
+**Performance and safety tips**:
+
+- Always specify a time window in `<q2>` (e.g., `_time:5m`) to avoid full-table scans.
+- Tune `max_subqueries` and `concurrency` to prevent overload from high-cardinality keys.
+- Subquery errors or timeouts return empty results and do not interrupt the main query; each subquery is cancelled when its timeout elapses.
+- Best suited for correlated subquery scenarios (trace/user-based lookups); not suitable for large static broadcasts.
+
 ### json_array_len pipe
 
 `<q> | json_array_len(field) as result_field` calculates the length of JSON array at the given [`field`](https://docs.victoriametrics.com/victorialogs/keyconcepts/#data-model)

--- a/lib/logstorage/pipe_join.go
+++ b/lib/logstorage/pipe_join.go
@@ -1,8 +1,13 @@
 package logstorage
 
 import (
+	"context"
 	"fmt"
 	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/atomicutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/slicesutil"
@@ -24,6 +29,27 @@ type pipeJoin struct {
 	// Otherwise the join is performed as LEFT JOIN.
 	isInner bool
 
+	// isLateral means the join query must be evaluated per row (or per key)
+	// using values from the outer query. When enabled, pj.q isn't pre-executed,
+	// but evaluated during processing. This is a checkpoint for the lateral join
+	// implementation (see issue #635).
+	isLateral bool
+	// baseCtx is used as parent context for lateral subqueries.
+	baseCtx context.Context
+
+	// runSubQuery is set for lateral joins and allows executing the inner query
+	// on demand during processing.
+	runSubQuery func(ctx context.Context, q *Query, writeBlock writeBlockResultFunc) error
+
+	// hasTimeFilter is true if q contains a time filter. Used to guard lateral subqueries.
+	hasTimeFilter bool
+
+	// limits for lateral execution
+	maxSubqueries   int
+	maxPerKey       int
+	concurrency     int
+	subQueryTimeout time.Duration
+
 	// prefix is the prefix to add to log fields from q query
 	prefix string
 
@@ -32,14 +58,43 @@ type pipeJoin struct {
 }
 
 func (pj *pipeJoin) String() string {
-	s := fmt.Sprintf("join by (%s) (%s)", fieldNamesString(pj.byFields), pj.q.String())
+	s := "join"
+	if pj.isLateral {
+		s += " lateral"
+	}
+	s = fmt.Sprintf("%s by (%s) (%s)", s, fieldNamesString(pj.byFields), pj.q.String())
 	if pj.isInner {
 		s += " inner"
 	}
 	if pj.prefix != "" {
 		s += " prefix " + quoteTokenIfNeeded(pj.prefix)
 	}
+	if pj.isLateral {
+		if opts := pj.lateralOptionsString(); opts != "" {
+			s += " " + opts
+		}
+	}
 	return s
+}
+
+func (pj *pipeJoin) lateralOptionsString() string {
+	var parts []string
+	if pj.maxSubqueries > 0 {
+		parts = append(parts, fmt.Sprintf("max_subqueries=%d", pj.maxSubqueries))
+	}
+	if pj.maxPerKey > 0 {
+		parts = append(parts, fmt.Sprintf("max_per_key=%d", pj.maxPerKey))
+	}
+	if pj.concurrency > 0 {
+		parts = append(parts, fmt.Sprintf("concurrency=%d", pj.concurrency))
+	}
+	if pj.subQueryTimeout > 0 {
+		parts = append(parts, fmt.Sprintf("timeout=%s", pj.subQueryTimeout))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "options(" + strings.Join(parts, ",") + ")"
 }
 
 func (pj *pipeJoin) splitToRemoteAndLocal(_ int64) (pipe, []pipe) {
@@ -69,6 +124,12 @@ func (pj *pipeJoin) visitSubqueries(visitFunc func(q *Query)) {
 }
 
 func (pj *pipeJoin) initJoinMap(getJoinMapFunc getJoinMapFunc) (pipe, error) {
+	if pj.isLateral {
+		// Lateral join is evaluated during processing; skip precomputed map.
+		pj.hasTimeFilter = hasTimeFilter(pj.q.f)
+		return pj, nil
+	}
+
 	m, err := getJoinMapFunc(pj.q, pj.byFields, pj.prefix)
 	if err != nil {
 		return nil, fmt.Errorf("cannot execute query at pipe [%s]: %w", pj, err)
@@ -96,6 +157,12 @@ type pipeJoinProcessor struct {
 	ppNext pipeProcessor
 
 	shards atomicutil.Slice[pipeJoinProcessorShard]
+
+	// lateral cache & limits
+	cacheMu   sync.Mutex
+	cache     map[string][][]Field
+	subqSem   chan struct{}
+	subqCount int
 }
 
 type pipeJoinProcessorShard struct {
@@ -104,10 +171,17 @@ type pipeJoinProcessorShard struct {
 	byValues     []string
 	byValuesIdxs []int
 	tmpBuf       []byte
+
+	rowFieldMap map[string]string
 }
 
 func (pjp *pipeJoinProcessor) writeBlock(workerID uint, br *blockResult) {
 	if br.rowsLen == 0 {
+		return
+	}
+
+	if pjp.pj.isLateral {
+		pjp.writeBlockLateral(workerID, br)
 		return
 	}
 
@@ -160,11 +234,349 @@ func (pjp *pipeJoinProcessor) flush() error {
 	return nil
 }
 
+// writeBlockLateral executes the join per key by running subqueries on demand.
+func (pjp *pipeJoinProcessor) writeBlockLateral(workerID uint, br *blockResult) {
+	pj := pjp.pj
+
+	// init cache and semaphore once
+	pjp.cacheMu.Lock()
+	if pjp.cache == nil {
+		pjp.cache = make(map[string][][]Field)
+	}
+	if pjp.subqSem == nil {
+		conc := pj.concurrency
+		if conc <= 0 {
+			conc = 4
+		}
+		pjp.subqSem = make(chan struct{}, conc)
+	}
+	pjp.cacheMu.Unlock()
+
+	shard := pjp.shards.Get(workerID)
+	shard.wctx.init(workerID, pjp.ppNext, true, true, br)
+
+	shard.byValues = slicesutil.SetLength(shard.byValues, len(pj.byFields))
+	byValues := shard.byValues
+
+	cs := br.getColumns()
+	shard.byValuesIdxs = slicesutil.SetLength(shard.byValuesIdxs, len(cs))
+	byValuesIdxs := shard.byValuesIdxs
+	for i := range cs {
+		name := cs[i].name
+		byValuesIdxs[i] = slices.Index(pj.byFields, name)
+	}
+
+	for rowIdx := 0; rowIdx < br.rowsLen; rowIdx++ {
+		clear(byValues)
+		if shard.rowFieldMap == nil {
+			shard.rowFieldMap = make(map[string]string)
+		}
+		for k := range shard.rowFieldMap {
+			delete(shard.rowFieldMap, k)
+		}
+		for j := range cs {
+			if cIdx := byValuesIdxs[j]; cIdx >= 0 {
+				byValues[cIdx] = cs[j].getValueAtRow(br, rowIdx)
+			}
+			v := cs[j].getValueAtRow(br, rowIdx)
+			if v != "" {
+				shard.rowFieldMap[cs[j].name] = v
+			}
+		}
+
+		matchingRows := pjp.getOrRunSubquery(byValues, shard.rowFieldMap)
+
+		if len(matchingRows) == 0 {
+			if !pj.isInner {
+				shard.wctx.writeRow(rowIdx, nil)
+			}
+			continue
+		}
+		for _, extraFields := range matchingRows {
+			if needStop(pjp.stopCh) {
+				return
+			}
+			shard.wctx.writeRow(rowIdx, extraFields)
+		}
+	}
+
+	shard.wctx.flush()
+	shard.wctx.reset()
+}
+
+func (pjp *pipeJoinProcessor) getOrRunSubquery(byValues []string, outer map[string]string) [][]Field {
+	pj := pjp.pj
+	if pj.runSubQuery == nil {
+		return nil
+	}
+
+	// lazy init for tests or direct calls
+	pjp.cacheMu.Lock()
+	if pjp.cache == nil {
+		pjp.cache = make(map[string][][]Field)
+	}
+	if pjp.subqSem == nil {
+		conc := pj.concurrency
+		if conc <= 0 {
+			conc = 4
+		}
+		pjp.subqSem = make(chan struct{}, conc)
+	}
+	pjp.cacheMu.Unlock()
+
+	q, rendered, err := instantiateLateralQuery(pj.q, pj.byFields, byValues, outer)
+	if err != nil || q == nil {
+		return nil
+	}
+	if !hasTimeFilter(q.f) {
+		// Guard: avoid unbounded scans for lateral subqueries without time filter.
+		return nil
+	}
+	cacheKey := buildLateralCacheKey(rendered, byValues)
+
+	// cache check by rendered query
+	pjp.cacheMu.Lock()
+	if rows, ok := pjp.cache[cacheKey]; ok {
+		pjp.cacheMu.Unlock()
+		return rows
+	}
+	pjp.cacheMu.Unlock()
+
+	// limit total subqueries
+	pjp.cacheMu.Lock()
+	if pjp.pj.maxSubqueries > 0 && pjp.subqCount >= pjp.pj.maxSubqueries {
+		pjp.cacheMu.Unlock()
+		return nil
+	}
+	pjp.subqCount++
+	pjp.cacheMu.Unlock()
+
+	// concurrency gate
+	pjp.subqSem <- struct{}{}
+	defer func() { <-pjp.subqSem }()
+
+	rows := pjp.runSubqueryForQuery(q, byValues)
+
+	pjp.cacheMu.Lock()
+	pjp.cache[cacheKey] = rows
+	pjp.cacheMu.Unlock()
+
+	return rows
+}
+
+func (pjp *pipeJoinProcessor) runSubqueryForQuery(q *Query, byValues []string) [][]Field {
+	pj := pjp.pj
+	if pj.runSubQuery == nil {
+		return nil
+	}
+
+	// inject equality filters for byFields
+	q.f = addAndFiltersJoin(q.f, pj.byFields, byValues)
+
+	// limit rows per key
+	limit := pj.maxPerKey
+	if limit <= 0 {
+		limit = 100
+	}
+
+	var results [][]Field
+	var rowsSeen int
+	writeBlock := func(_ uint, br *blockResult) {
+		if br.rowsLen == 0 {
+			return
+		}
+		cs := br.getColumns()
+		for rowIdx := 0; rowIdx < br.rowsLen; rowIdx++ {
+			if rowsSeen >= limit {
+				return
+			}
+			rowsSeen++
+			fields := make([]Field, 0, len(cs))
+			for j := range cs {
+				name := cs[j].name
+				if pj.prefix != "" {
+					name = pj.prefix + name
+				} else {
+					name = strings.Clone(name)
+				}
+				v := cs[j].getValueAtRow(br, rowIdx)
+				if v == "" {
+					continue
+				}
+				fields = append(fields, Field{
+					Name:  name,
+					Value: strings.Clone(v),
+				})
+			}
+			results = append(results, fields)
+		}
+	}
+
+	ctx := pj.baseCtx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if pj.subQueryTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, pj.subQueryTimeout)
+		defer cancel()
+	}
+
+	_ = pj.runSubQuery(ctx, q, writeBlock)
+
+	return results
+}
+
+// addAndFiltersJoin builds an AND of existing filter and equality filters for byFields.
+// Empty values are skipped.
+func addAndFiltersJoin(base filter, byFields, byValues []string) filter {
+	var fs []filter
+	if base != nil {
+		fs = append(fs, base)
+	}
+	for i, name := range byFields {
+		if i >= len(byValues) {
+			break
+		}
+		v := byValues[i]
+		if v == "" {
+			continue
+		}
+		fs = append(fs, &filterExact{
+			fieldName: name,
+			value:     v,
+		})
+	}
+	return filtersAndJoin(fs)
+}
+
+// filtersAndJoin builds AND over provided filters, skipping nils.
+func filtersAndJoin(fs []filter) filter {
+	dst := fs[:0]
+	for _, f := range fs {
+		if f != nil {
+			dst = append(dst, f)
+		}
+	}
+	if len(dst) == 0 {
+		return nil
+	}
+	if len(dst) == 1 {
+		return dst[0]
+	}
+	return &filterAnd{filters: dst}
+}
+
+// hasTimeFilter checks whether f (possibly composite) contains time filter.
+func hasTimeFilter(f filter) bool {
+	switch t := f.(type) {
+	case *filterTime:
+		return true
+	case *filterAnd:
+		for _, ch := range t.filters {
+			if hasTimeFilter(ch) {
+				return true
+			}
+		}
+	case *filterOr:
+		for _, ch := range t.filters {
+			if hasTimeFilter(ch) {
+				return true
+			}
+		}
+	case *filterNot:
+		return hasTimeFilter(t.f)
+	default:
+		return false
+	}
+	return false
+}
+
+// instantiateLateralQuery renders q to string, replaces ${field} with value from byValues,
+// and reparses it into a new Query. Falls back to nil on error.
+func instantiateLateralQuery(q *Query, byFields []string, byValues []string, outer map[string]string) (*Query, string, error) {
+	qs := q.String()
+
+	// seed map with byFields
+	if outer == nil {
+		outer = make(map[string]string, len(byFields))
+	}
+	for i, name := range byFields {
+		if i >= len(byValues) {
+			break
+		}
+		if outer[name] == "" {
+			outer[name] = byValues[i]
+		}
+	}
+
+	rendered := renderPlaceholders(qs, outer)
+
+	lex := newLexer(rendered, q.timestamp)
+	qNew, err := parseQuery(lex)
+	if err != nil {
+		return nil, rendered, err
+	}
+	return qNew, rendered, nil
+}
+
+func buildLateralCacheKey(rendered string, byValues []string) string {
+	var b strings.Builder
+	// rough capacity hint
+	b.Grow(len(rendered) + len(byValues)*8)
+	b.WriteString(rendered)
+	b.WriteByte('|')
+	for _, v := range byValues {
+		b.WriteString(strconv.Itoa(len(v)))
+		b.WriteByte(':')
+		b.WriteString(v)
+		b.WriteByte(';')
+	}
+	return b.String()
+}
+
+// renderPlaceholders replaces ${field} with value from outer map, quoting as needed.
+// Missing values are replaced with empty string.
+func renderPlaceholders(s string, outer map[string]string) string {
+	var b strings.Builder
+	start := 0
+	for {
+		idx := strings.Index(s[start:], "${")
+		if idx < 0 {
+			break
+		}
+		idx += start
+		b.WriteString(s[start:idx])
+		end := strings.IndexByte(s[idx:], '}')
+		if end < 0 {
+			// no closing brace, write remainder
+			b.WriteString(s[idx:])
+			return b.String()
+		}
+		end += idx
+		name := s[idx+2 : end]
+		val := outer[name]
+		b.WriteString(quoteTokenIfNeeded(val))
+		start = end + 1
+	}
+	if start == 0 {
+		return s
+	}
+	b.WriteString(s[start:])
+	return b.String()
+}
+
 func parsePipeJoin(lex *lexer) (pipe, error) {
 	if !lex.isKeyword("join") {
 		return nil, fmt.Errorf("unexpected token: %q; want %q", lex.token, "join")
 	}
 	lex.nextToken()
+
+	isLateral := false
+	if lex.isKeyword("lateral") {
+		isLateral = true
+		lex.nextToken()
+	}
 
 	// parse by (...)
 	if lex.isKeyword("by", "on") {
@@ -189,23 +601,118 @@ func parsePipeJoin(lex *lexer) (pipe, error) {
 	}
 
 	pj := &pipeJoin{
-		byFields: byFields,
-		q:        q,
+		byFields:  byFields,
+		q:         q,
+		isLateral: isLateral,
 	}
 
-	if lex.isKeyword("inner") {
-		lex.nextToken()
-		pj.isInner = true
-	}
-
-	if lex.isKeyword("prefix") {
-		lex.nextToken()
-		prefix, err := lex.nextCompoundToken()
-		if err != nil {
-			return nil, fmt.Errorf("cannot read prefix for [%s]: %w", pj, err)
+	parsedInner := false
+	parsedPrefix := false
+	parsedOptions := false
+	for {
+		switch {
+		case !parsedInner && lex.isKeyword("inner"):
+			parsedInner = true
+			lex.nextToken()
+			pj.isInner = true
+			continue
+		case !parsedPrefix && lex.isKeyword("prefix"):
+			parsedPrefix = true
+			lex.nextToken()
+			prefix, err := lex.nextCompoundToken()
+			if err != nil {
+				return nil, fmt.Errorf("cannot read prefix for [%s]: %w", pj, err)
+			}
+			pj.prefix = prefix
+			continue
+		case !parsedOptions && lex.isKeyword("options"):
+			parsedOptions = true
+			lex.nextToken()
+			if !lex.isKeyword("(") {
+				return nil, fmt.Errorf("missing '(' after options at [%s]", pj)
+			}
+			lex.nextToken()
+			for !lex.isKeyword(")") {
+				switch {
+				case lex.isKeyword("max_subqueries"):
+					lex.nextToken()
+					if lex.isKeyword("=") {
+						lex.nextToken()
+					}
+					n, err := parseIntToken(lex)
+					if err != nil {
+						return nil, fmt.Errorf("cannot parse max_subqueries for [%s]: %w", pj, err)
+					}
+					pj.maxSubqueries = n
+				case lex.isKeyword("max_per_key"):
+					lex.nextToken()
+					if lex.isKeyword("=") {
+						lex.nextToken()
+					}
+					n, err := parseIntToken(lex)
+					if err != nil {
+						return nil, fmt.Errorf("cannot parse max_per_key for [%s]: %w", pj, err)
+					}
+					pj.maxPerKey = n
+				case lex.isKeyword("concurrency"):
+					lex.nextToken()
+					if lex.isKeyword("=") {
+						lex.nextToken()
+					}
+					n, err := parseIntToken(lex)
+					if err != nil {
+						return nil, fmt.Errorf("cannot parse concurrency for [%s]: %w", pj, err)
+					}
+					pj.concurrency = n
+				case lex.isKeyword("timeout"):
+					lex.nextToken()
+					if lex.isKeyword("=") {
+						lex.nextToken()
+					}
+					d, err := parseDurationToken(lex)
+					if err != nil {
+						return nil, fmt.Errorf("cannot parse timeout for [%s]: %w", pj, err)
+					}
+					pj.subQueryTimeout = d
+				default:
+					return nil, fmt.Errorf("unexpected token %q in options for [%s]", lex.token, pj)
+				}
+				if lex.isKeyword(",") {
+					lex.nextToken()
+				} else if !lex.isKeyword(")") {
+					return nil, fmt.Errorf("unexpected token %q in options for [%s]", lex.token, pj)
+				}
+			}
+			lex.nextToken()
+			continue
+		default:
+			goto doneOptions
 		}
-		pj.prefix = prefix
 	}
-
+doneOptions:
 	return pj, nil
+}
+
+func parseIntToken(lex *lexer) (int, error) {
+	tok, err := lex.nextCompoundToken()
+	if err != nil {
+		return 0, err
+	}
+	n, err := strconv.Atoi(tok)
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+func parseDurationToken(lex *lexer) (time.Duration, error) {
+	tok, err := lex.nextCompoundToken()
+	if err != nil {
+		return 0, err
+	}
+	d, ok := tryParseDuration(tok)
+	if !ok {
+		return 0, fmt.Errorf("cannot parse duration %q", tok)
+	}
+	return time.Duration(d), nil
 }

--- a/lib/logstorage/pipe_join_test.go
+++ b/lib/logstorage/pipe_join_test.go
@@ -1,8 +1,232 @@
 package logstorage
 
 import (
+	"context"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 )
+
+func TestParseJoinLateralOptions(t *testing.T) {
+	qStr := `k:foo | join lateral by (k) (* | _time:1h) options(max_subqueries=10,max_per_key=5,concurrency=2,timeout=1s)`
+	lex := newLexer(qStr, 0)
+	q, err := parseQuery(lex)
+	if err != nil {
+		t.Fatalf("parseQuery failed: %s", err)
+	}
+	if len(q.pipes) != 1 {
+		t.Fatalf("expected 1 pipe, got %d", len(q.pipes))
+	}
+	pj, ok := q.pipes[0].(*pipeJoin)
+	if !ok {
+		t.Fatalf("expected pipeJoin, got %T", q.pipes[0])
+	}
+	if !pj.isLateral {
+		t.Fatalf("expected lateral join")
+	}
+	if pj.maxSubqueries != 10 {
+		t.Fatalf("maxSubqueries mismatch: got %d", pj.maxSubqueries)
+	}
+	if pj.maxPerKey != 5 {
+		t.Fatalf("maxPerKey mismatch: got %d", pj.maxPerKey)
+	}
+	if pj.concurrency != 2 {
+		t.Fatalf("concurrency mismatch: got %d", pj.concurrency)
+	}
+	if pj.subQueryTimeout != time.Second {
+		t.Fatalf("timeout mismatch: got %s", pj.subQueryTimeout)
+	}
+}
+
+func TestInstantiateLateralQueryReplacesPlaceholders(t *testing.T) {
+	ft := &filterTime{minTimestamp: 0, maxTimestamp: 1, stringRepr: "[0,1]"}
+	q := &Query{
+		f: filtersAndJoin([]filter{
+			&filterExact{fieldName: "name", value: "${k}"},
+			ft,
+		}),
+	}
+	qNew, rendered, err := instantiateLateralQuery(q, []string{"k"}, []string{"abc"}, map[string]string{"pod": "p1"})
+	if err != nil {
+		t.Fatalf("instantiate failed: %s", err)
+	}
+	if qNew == nil {
+		t.Fatalf("instantiate returned nil")
+	}
+	qs := qNew.String()
+	if strings.Contains(qs, "${") {
+		t.Fatalf("placeholder still present, got %q", qs)
+	}
+	if !strings.Contains(qs, "abc") {
+		t.Fatalf("placeholder value missing, got %q", qs)
+	}
+	if !strings.Contains(rendered, "abc") {
+		t.Fatalf("rendered missing value: %q", rendered)
+	}
+}
+
+func TestRunSubqueryForKeyGuardsTimeFilter(t *testing.T) {
+	q := &Query{
+		f: &filterExact{fieldName: "name", value: "${k}"},
+	}
+
+	called := false
+	pj := &pipeJoin{
+		isLateral: true,
+		q:         q,
+		// hasTimeFilter intentionally false to trigger guard
+		runSubQuery: func(_ context.Context, q *Query, _ writeBlockResultFunc) error {
+			called = true
+			return nil
+		},
+	}
+	pjp := &pipeJoinProcessor{pj: pj}
+
+	if rows := pjp.getOrRunSubquery([]string{"abc"}, map[string]string{"k": "abc"}); rows != nil {
+		t.Fatalf("expected nil rows when no time filter")
+	}
+	if called {
+		t.Fatalf("runSubQuery should not be called without time filter")
+	}
+}
+
+func TestRunSubqueryForKeyExecutesWithTimeFilter(t *testing.T) {
+	ft := &filterTime{minTimestamp: 0, maxTimestamp: 1, stringRepr: "[0,1]"}
+	q := &Query{
+		f: filtersAndJoin([]filter{
+			&filterExact{fieldName: "name", value: "${k}"},
+			ft,
+		}),
+	}
+
+	called := false
+	pj := &pipeJoin{
+		isLateral:     true,
+		q:             q,
+		maxPerKey:     1,
+		hasTimeFilter: true,
+		byFields:      []string{"k"},
+		runSubQuery: func(_ context.Context, q *Query, _ writeBlockResultFunc) error {
+			qs := q.String()
+			if strings.Contains(qs, "${") {
+				t.Fatalf("placeholder still present, got %q", qs)
+			}
+			if !strings.Contains(qs, "abc") {
+				t.Fatalf("expected placeholder value, got %q", qs)
+			}
+			called = true
+			return nil
+		},
+	}
+	pjp := &pipeJoinProcessor{pj: pj}
+
+	_ = pjp.getOrRunSubquery([]string{"abc"}, map[string]string{"k": "abc"})
+
+	if !called {
+		t.Fatalf("runSubQuery not called")
+	}
+}
+
+func TestLateralCacheKeyIncludesByValues(t *testing.T) {
+	ft := &filterTime{minTimestamp: 0, maxTimestamp: 1, stringRepr: "[0,1]"}
+	q := &Query{f: ft}
+
+	callCount := 0
+	pj := &pipeJoin{
+		isLateral: true,
+		q:         q,
+		byFields:  []string{"k"},
+		runSubQuery: func(_ context.Context, _ *Query, writeBlock writeBlockResultFunc) error {
+			callCount++
+			br := &blockResult{
+				rowsLen: 1,
+			}
+			br.csAdd(blockResultColumn{
+				name:          "val",
+				isConst:       true,
+				valueType:     valueTypeString,
+				valuesEncoded: []string{fmt.Sprintf("v%d", callCount)},
+			})
+			writeBlock(0, br)
+			return nil
+		},
+	}
+	pjp := &pipeJoinProcessor{pj: pj}
+
+	rowsA := pjp.getOrRunSubquery([]string{"a"}, map[string]string{"k": "a"})
+	rowsB := pjp.getOrRunSubquery([]string{"b"}, map[string]string{"k": "b"})
+
+	if callCount != 2 {
+		t.Fatalf("expected subquery executed twice for distinct keys; got %d", callCount)
+	}
+	if gotA, gotB := rowsA[0][0].Value, rowsB[0][0].Value; gotA == gotB {
+		t.Fatalf("expected different cached results per key; got %q and %q", gotA, gotB)
+	}
+}
+
+func TestLateralPrefixApplied(t *testing.T) {
+	ft := &filterTime{minTimestamp: 0, maxTimestamp: 1, stringRepr: "[0,1]"}
+	q := &Query{f: ft}
+
+	pj := &pipeJoin{
+		isLateral: true,
+		q:         q,
+		byFields:  []string{"k"},
+		prefix:    "p.",
+		runSubQuery: func(_ context.Context, _ *Query, writeBlock writeBlockResultFunc) error {
+			br := &blockResult{
+				rowsLen: 1,
+			}
+			br.csAdd(blockResultColumn{
+				name:          "foo",
+				isConst:       true,
+				valueType:     valueTypeString,
+				valuesEncoded: []string{"bar"},
+			})
+			writeBlock(0, br)
+			return nil
+		},
+	}
+	pjp := &pipeJoinProcessor{pj: pj}
+
+	rows := pjp.getOrRunSubquery([]string{"a"}, map[string]string{"k": "a"})
+	if len(rows) != 1 || len(rows[0]) != 1 {
+		t.Fatalf("unexpected rows: %#v", rows)
+	}
+	if rows[0][0].Name != "p.foo" {
+		t.Fatalf("expected prefixed field name, got %q", rows[0][0].Name)
+	}
+	if rows[0][0].Value != "bar" {
+		t.Fatalf("unexpected value: %q", rows[0][0].Value)
+	}
+}
+
+func TestLateralSubqueryUsesTimeoutContext(t *testing.T) {
+	ft := &filterTime{minTimestamp: 0, maxTimestamp: 1, stringRepr: "[0,1]"}
+	q := &Query{f: ft}
+
+	called := false
+	pj := &pipeJoin{
+		isLateral:       true,
+		q:               q,
+		byFields:        []string{"k"},
+		subQueryTimeout: time.Millisecond,
+		runSubQuery: func(ctx context.Context, _ *Query, _ writeBlockResultFunc) error {
+			called = true
+			if _, ok := ctx.Deadline(); !ok {
+				t.Fatalf("expected timeout deadline set on context")
+			}
+			return nil
+		},
+	}
+	pjp := &pipeJoinProcessor{pj: pj}
+
+	_ = pjp.getOrRunSubquery([]string{"a"}, map[string]string{"k": "a"})
+	if !called {
+		t.Fatalf("runSubQuery not called")
+	}
+}
 
 func TestParsePipeJoinSuccess(t *testing.T) {
 	f := func(pipeStr string) {
@@ -37,7 +261,42 @@ func TestParsePipeJoinFailure(t *testing.T) {
 	f(`join by (x) (abc`)
 	f(`join (x) (y) prefix`)
 	f(`join (x) (y) prefix |`)
-	f(`join by (x) (y) prefix x inner`)
+}
+
+func TestParsePipeJoinCanonicalizesOrder(t *testing.T) {
+	pipeStr := `join by (x) (y) prefix a inner`
+	lex := newLexer(pipeStr, 0)
+	p, err := parsePipe(lex)
+	if err != nil {
+		t.Fatalf("cannot parse [%s]: %s", pipeStr, err)
+	}
+	if !lex.isEnd() {
+		t.Fatalf("unexpected tail after parsing [%s]: %q", pipeStr, lex.s)
+	}
+	if got := p.String(); got != `join by (x) (y) inner prefix a` {
+		t.Fatalf("unexpected canonical string: %q", got)
+	}
+}
+
+func TestParseLateralPodExample(t *testing.T) {
+	qStr := `_time:10m | join lateral by (kubernetes.pod_name) (level:error | filter pod:"${kubernetes.pod_name}" _time:10m) prefix err. options(max_subqueries=200,max_per_key=10,concurrency=3)`
+	q, err := ParseQuery(qStr)
+	if err != nil {
+		t.Fatalf("cannot parse query: %s", err)
+	}
+	if len(q.pipes) != 1 {
+		t.Fatalf("expected 1 pipe, got %d", len(q.pipes))
+	}
+	pj, ok := q.pipes[0].(*pipeJoin)
+	if !ok || !pj.isLateral {
+		t.Fatalf("expected lateral pipeJoin, got %T", q.pipes[0])
+	}
+	if pj.prefix != "err." {
+		t.Fatalf("unexpected prefix: %q", pj.prefix)
+	}
+	if pj.maxSubqueries != 200 || pj.maxPerKey != 10 || pj.concurrency != 3 {
+		t.Fatalf("unexpected options: maxSubqueries=%d maxPerKey=%d concurrency=%d", pj.maxSubqueries, pj.maxPerKey, pj.concurrency)
+	}
 }
 
 func TestPipeJoinUpdateNeededFields(t *testing.T) {

--- a/lib/logstorage/storage_search.go
+++ b/lib/logstorage/storage_search.go
@@ -765,6 +765,12 @@ func initSubqueries(qctx *QueryContext, runQuery runQueryFunc, keepInSubquery bo
 		return nil, fmt.Errorf("cannot initialize `in` subqueries: %w", err)
 	}
 
+	runLateralQuery := func(ctx context.Context, q *Query, writeBlock writeBlockResultFunc) error {
+		qctxLocal := qctx.WithContextAndQuery(ctx, q)
+		return runQuery(qctxLocal, writeBlock)
+	}
+	qNew = initLateralJoinQueries(qNew, qctx.Context, runLateralQuery)
+
 	getJoinMap := func(q *Query, byFields []string, prefix string) (map[string][][]Field, error) {
 		qctxLocal := qctx.WithQuery(q)
 		return getJoinMapGeneric(qctxLocal, runQuery, byFields, prefix)
@@ -894,6 +900,55 @@ func initJoinMaps(q *Query, getJoinMap getJoinMapFunc) (*Query, error) {
 func hasJoinPipes(pipes []pipe) bool {
 	for _, p := range pipes {
 		if _, ok := p.(*pipeJoin); ok {
+			return true
+		}
+	}
+	return false
+}
+
+type runLateralQueryFunc func(ctx context.Context, q *Query, writeBlock writeBlockResultFunc) error
+
+func initLateralJoinQueries(q *Query, baseCtx context.Context, runQuery runLateralQueryFunc) *Query {
+	if !hasLateralJoinPipes(q.pipes) {
+		return q
+	}
+
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+
+	pipesNew := make([]pipe, len(q.pipes))
+	for i, p := range q.pipes {
+		if pj, ok := p.(*pipeJoin); ok && pj.isLateral {
+			pjCopy := *pj
+			pjCopy.baseCtx = baseCtx
+			pjCopy.runSubQuery = runQuery
+			// defaults
+			if pjCopy.maxSubqueries == 0 {
+				pjCopy.maxSubqueries = 1000
+			}
+			if pjCopy.maxPerKey == 0 {
+				pjCopy.maxPerKey = 100
+			}
+			if pjCopy.concurrency == 0 {
+				pjCopy.concurrency = 4
+			}
+			if pjCopy.subQueryTimeout == 0 {
+				pjCopy.subQueryTimeout = 5 * time.Second
+			}
+			p = &pjCopy
+		}
+		pipesNew[i] = p
+	}
+
+	qNew := q.cloneShallow()
+	qNew.pipes = pipesNew
+	return qNew
+}
+
+func hasLateralJoinPipes(pipes []pipe) bool {
+	for _, p := range pipes {
+		if pj, ok := p.(*pipeJoin); ok && pj.isLateral {
 			return true
 		}
 	}


### PR DESCRIPTION
implement lateral join variant for join pipe that evaluates `<q2>` dynamically per row instead of pre-computing it, so <q2> can reference current-row fields via `${field}` placeholders.

Key updates:

- Add `lateral` keyword to join pipe syntax; allow `inner`/`prefix`/`options` in any order and canonicalize output.
- Render `${field}` placeholders from outer row (not limited to by-fields); require _time filter or skip subquery to avoid full scans.
- Cache subquery results keyed by rendered query + by-values; cap total subqueries and per-key rows with defaults (`1000/100/4/5s`).
- Apply prefix to lateral results, clone field names/values to avoid reuse, and inject by-field equality filters for each subquery.
- Enforce per-subquery timeout with context cancellation; semaphore controls concurrent subqueries.

Example:
```
  _time:10m | join lateral by (kubernetes.pod_name) (
    level:error | filter pod:"${kubernetes.pod_name}" _time:10m
  ) prefix "err." options(max_subqueries=200,max_per_key=10,concurrency=3)
```
Performance notes:

- Always specify time window in subquery to avoid full scans
- Tune max_subqueries and concurrency for high-cardinality keys
- Subquery errors/timeouts return empty results without interrupting main query
- Best for correlated subquery scenarios (trace/user lookups), not suitable for large static broadcasts

Fixes https://github.com/VictoriaMetrics/VictoriaLogs/issues/635

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
