### PR TITLE
app/vlagent/kubernetescollector: properly handle 410 Gone

### DIFF
--- a/app/vlagent/kubernetescollector/client.go
+++ b/app/vlagent/kubernetescollector/client.go
@@ -126,14 +126,16 @@ type podWatchStream struct {
 	r io.ReadCloser
 }
 
-func (pws podWatchStream) readEvents(h func(event watchEvent)) error {
+func (pws podWatchStream) readEvents(h func(event watchEvent) error) error {
 	d := json.NewDecoder(pws.r)
 	for {
 		var e watchEvent
 		if err := d.Decode(&e); err != nil {
 			return fmt.Errorf("cannot parse WatchEvent json response: %w", err)
 		}
-		h(e)
+		if err := h(e); err != nil {
+			return err
+		}
 	}
 }
 

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -22,6 +22,7 @@ according to the following docs:
 ## tip
 
 * BUGFIX: [`/select/logsql/facets` endpoint](https://docs.victoriametrics.com/victorialogs/querying/#querying-facets): fix `expecting 3 columns; got 4 columns` panic when `/select/logsql/facets` endpoint is queried at [cluster version of VictoriaLogs](https://docs.victoriametrics.com/victorialogs/cluster/). See [#940](https://github.com/VictoriaMetrics/VictoriaLogs/issues/940). The issue has been introduced in [this commit](https://github.com/VictoriaMetrics/VictoriaLogs/commit/7f66493f5939de08b8af608b5ab2ed04b9c64c72) in the [release v1.35.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.35.0).
+* BUGFIX: [Kubernetes Collector](https://docs.victoriametrics.com/victorialogs/vlagent/#collect-kubernetes-pod-logs): properly handle "410 Gone" responses from the Kubernetes API server. Previously, vlagent could report 410 errors and fail to collect logs from newly discovered Pods. The bug has been introduced in [v1.43.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.43.0). 
 
 ## [v1.43.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.43.0)
 


### PR DESCRIPTION
### Describe Your Changes

It turns out that the Kubernetes API can return status codes such as http.StatusGatewayTimeout, http.StatusInternalServerError, and http.StatusGone within the response body rather than the HTTP headers. 

This commit accounts for this behavior by correctly parsing status codes from the body. Additionally, this change fixes the backoff timer logic, ensuring that sleep intervals now correctly increase exponentially upon encountering errors.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
