### PR TITLE
lib/logstorage: add pattern_match_prefix filter for logsql

### DIFF
--- a/docs/victorialogs/logsql.md
+++ b/docs/victorialogs/logsql.md
@@ -755,6 +755,14 @@ pattern_match("user_id=<N>, ip=<IP4>, time=<DATETIME>")
 
 If you need to match the whole `_msg` field value, then use the `pattern_match_full("pattern")` filter.
 
+If you need to match the pattern strictly at the beginning of a field, use `pattern_match_prefix("pattern")`. For example, the following filter matches messages that start with a datetime followed by a space and `foo`:
+
+```logsql
+pattern_match_prefix("<DATETIME> foo")
+```
+
+The filter can be applied to any given log field with the `log_field:pattern_match_prefix("pattern")` syntax.
+
 See also:
 
 - [`collapse_nums` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#collapse_nums-pipe)

--- a/lib/logstorage/filter_pattern_match.go
+++ b/lib/logstorage/filter_pattern_match.go
@@ -15,6 +15,7 @@ import (
 type filterPatternMatch struct {
 	fieldName string
 	pm        *patternMatcher
+	isPrefix  bool
 
 	tokensOnce   sync.Once
 	tokens       []string
@@ -23,7 +24,9 @@ type filterPatternMatch struct {
 
 func (fp *filterPatternMatch) String() string {
 	funcName := "pattern_match"
-	if fp.pm.isFull {
+	if fp.isPrefix {
+		funcName = "pattern_match_prefix"
+	} else if fp.pm.isFull {
 		funcName = "pattern_match_full"
 	}
 	return fmt.Sprintf("%s%s(%s)", quoteFieldNameIfNeeded(fp.fieldName), funcName, quoteTokenIfNeeded(fp.pm.String()))
@@ -120,14 +123,14 @@ func (fp *filterPatternMatch) initTokens() {
 
 func (fp *filterPatternMatch) matchRow(fields []Field) bool {
 	v := getFieldValueByName(fields, fp.fieldName)
-	return fp.pm.Match(v)
+	return fp.matchValue(v)
 }
 
 func (fp *filterPatternMatch) applyToBlockResult(br *blockResult, bm *bitmap) {
 	c := br.getColumnByName(fp.fieldName)
 	if c.isConst {
 		v := c.valuesEncoded[0]
-		if !fp.pm.Match(v) {
+		if !fp.matchValue(v) {
 			bm.resetBits()
 		}
 		return
@@ -144,7 +147,7 @@ func (fp *filterPatternMatch) applyToBlockResult(br *blockResult, bm *bitmap) {
 		bb := bbPool.Get()
 		for _, v := range c.dictValues {
 			c := byte(0)
-			if fp.pm.Match(v) {
+			if fp.matchValue(v) {
 				c = 1
 			}
 			bb.B = append(bb.B, c)
@@ -179,7 +182,7 @@ func (fp *filterPatternMatch) applyToBlockResult(br *blockResult, bm *bitmap) {
 func (fp *filterPatternMatch) matchColumnGeneric(br *blockResult, bm *bitmap, c *blockResultColumn) {
 	values := c.getValues(br)
 	bm.forEachSetBit(func(idx int) bool {
-		return fp.pm.Match(values[idx])
+		return fp.matchValue(values[idx])
 	})
 }
 
@@ -189,7 +192,7 @@ func (fp *filterPatternMatch) applyToBlockSearch(bs *blockSearch, bm *bitmap) {
 	// Verify whether fp matches const column
 	v := bs.getConstColumnValue(fieldName)
 	if v != "" {
-		if !fp.pm.Match(v) {
+		if !fp.matchValue(v) {
 			bm.resetBits()
 		}
 		return
@@ -199,7 +202,7 @@ func (fp *filterPatternMatch) applyToBlockSearch(bs *blockSearch, bm *bitmap) {
 	ch := bs.getColumnHeader(fieldName)
 	if ch == nil {
 		// Fast path - there are no matching columns.
-		if !fp.pm.Match("") {
+		if !fp.matchValue("") {
 			bm.resetBits()
 		}
 		return
@@ -214,13 +217,13 @@ func (fp *filterPatternMatch) applyToBlockSearch(bs *blockSearch, bm *bitmap) {
 			return
 		}
 		visitValues(bs, ch, bm, func(v string) bool {
-			return fp.pm.Match(v)
+			return fp.matchValue(v)
 		})
 	case valueTypeDict:
 		bb := bbPool.Get()
 		for _, v := range ch.valuesDict.values {
 			c := byte(0)
-			if fp.pm.Match(v) {
+			if fp.matchValue(v) {
 				c = 1
 			}
 			bb.B = append(bb.B, c)
@@ -235,7 +238,7 @@ func (fp *filterPatternMatch) applyToBlockSearch(bs *blockSearch, bm *bitmap) {
 		bb := bbPool.Get()
 		visitValues(bs, ch, bm, func(v string) bool {
 			s := toUint8String(bs, bb, v)
-			return fp.pm.Match(s)
+			return fp.matchValue(s)
 		})
 		bbPool.Put(bb)
 	case valueTypeUint16:
@@ -246,7 +249,7 @@ func (fp *filterPatternMatch) applyToBlockSearch(bs *blockSearch, bm *bitmap) {
 		bb := bbPool.Get()
 		visitValues(bs, ch, bm, func(v string) bool {
 			s := toUint16String(bs, bb, v)
-			return fp.pm.Match(s)
+			return fp.matchValue(s)
 		})
 		bbPool.Put(bb)
 	case valueTypeUint32:
@@ -257,7 +260,7 @@ func (fp *filterPatternMatch) applyToBlockSearch(bs *blockSearch, bm *bitmap) {
 		bb := bbPool.Get()
 		visitValues(bs, ch, bm, func(v string) bool {
 			s := toUint32String(bs, bb, v)
-			return fp.pm.Match(s)
+			return fp.matchValue(s)
 		})
 		bbPool.Put(bb)
 	case valueTypeUint64:
@@ -268,7 +271,7 @@ func (fp *filterPatternMatch) applyToBlockSearch(bs *blockSearch, bm *bitmap) {
 		bb := bbPool.Get()
 		visitValues(bs, ch, bm, func(v string) bool {
 			s := toUint64String(bs, bb, v)
-			return fp.pm.Match(s)
+			return fp.matchValue(s)
 		})
 		bbPool.Put(bb)
 	case valueTypeInt64:
@@ -279,7 +282,7 @@ func (fp *filterPatternMatch) applyToBlockSearch(bs *blockSearch, bm *bitmap) {
 		bb := bbPool.Get()
 		visitValues(bs, ch, bm, func(v string) bool {
 			s := toInt64String(bs, bb, v)
-			return fp.pm.Match(s)
+			return fp.matchValue(s)
 		})
 		bbPool.Put(bb)
 	case valueTypeFloat64:
@@ -290,7 +293,7 @@ func (fp *filterPatternMatch) applyToBlockSearch(bs *blockSearch, bm *bitmap) {
 		bb := bbPool.Get()
 		visitValues(bs, ch, bm, func(v string) bool {
 			s := toFloat64String(bs, bb, v)
-			return fp.pm.Match(s)
+			return fp.matchValue(s)
 		})
 		bbPool.Put(bb)
 	case valueTypeIPv4:
@@ -301,7 +304,7 @@ func (fp *filterPatternMatch) applyToBlockSearch(bs *blockSearch, bm *bitmap) {
 		bb := bbPool.Get()
 		visitValues(bs, ch, bm, func(v string) bool {
 			s := toIPv4String(bs, bb, v)
-			return fp.pm.Match(s)
+			return fp.matchValue(s)
 		})
 		bbPool.Put(bb)
 	case valueTypeTimestampISO8601:
@@ -312,10 +315,17 @@ func (fp *filterPatternMatch) applyToBlockSearch(bs *blockSearch, bm *bitmap) {
 		bb := bbPool.Get()
 		visitValues(bs, ch, bm, func(v string) bool {
 			s := toTimestampISO8601String(bs, bb, v)
-			return fp.pm.Match(s)
+			return fp.matchValue(s)
 		})
 		bbPool.Put(bb)
 	default:
 		logger.Panicf("FATAL: %s: unknown valueType=%d", bs.partPath(), ch.valueType)
 	}
+}
+
+func (fp *filterPatternMatch) matchValue(s string) bool {
+	if fp.isPrefix {
+		return fp.pm.MatchPrefix(s)
+	}
+	return fp.pm.Match(s)
 }

--- a/lib/logstorage/filter_pattern_match_test.go
+++ b/lib/logstorage/filter_pattern_match_test.go
@@ -725,6 +725,33 @@ func TestFilterPatternMatch(t *testing.T) {
 		testFilterMatchForColumns(t, columns, fp, "foo", nil)
 	})
 
+	t.Run("prefix", func(t *testing.T) {
+		columns := []column{
+			{
+				name: "_msg",
+				values: []string{
+					"2025-01-02 foo bar",
+					"x 2025-01-02 foo bar",
+					"2025-01-02 foo",
+				},
+			},
+		}
+
+		fp := &filterPatternMatch{
+			fieldName: "_msg",
+			pm:        newPatternMatcher("<DATE> foo", false),
+			isPrefix:  true,
+		}
+		testFilterMatchForColumns(t, columns, fp, "_msg", []int{0, 2})
+
+		fp = &filterPatternMatch{
+			fieldName: "_msg",
+			pm:        newPatternMatcher("foo", false),
+			isPrefix:  true,
+		}
+		testFilterMatchForColumns(t, columns, fp, "_msg", nil)
+	})
+
 	t.Run("ipv4", func(t *testing.T) {
 		columns := []column{
 			{

--- a/lib/logstorage/parser.go
+++ b/lib/logstorage/parser.go
@@ -2047,6 +2047,8 @@ func parseFilterGeneric(lex *lexer, fieldName string) (filter, error) {
 		return parseFilterPatternMatch(lex, fieldName)
 	case lex.isKeyword("pattern_match_full"):
 		return parseFilterPatternMatch(lex, fieldName)
+	case lex.isKeyword("pattern_match_prefix"):
+		return parseFilterPatternMatch(lex, fieldName)
 	case lex.isKeyword("range"):
 		return parseFilterRange(lex, fieldName)
 	case lex.isKeyword("re"):
@@ -2457,10 +2459,12 @@ func parseFilterExact(lex *lexer, fieldName string) (filter, error) {
 
 func parseFilterPatternMatch(lex *lexer, fieldName string) (filter, error) {
 	isFull := lex.isKeyword("pattern_match_full")
+	isPrefix := lex.isKeyword("pattern_match_prefix")
 	return parseFuncArg(lex, fieldName, func(arg string) (filter, error) {
 		fp := &filterPatternMatch{
 			fieldName: getCanonicalColumnName(fieldName),
 			pm:        newPatternMatcher(arg, isFull),
+			isPrefix:  isPrefix,
 		}
 		return fp, nil
 	})
@@ -3831,6 +3835,7 @@ var reservedKeywords = func() map[string]struct{} {
 		"lt_field",
 		"pattern_match",
 		"pattern_match_full",
+		"pattern_match_prefix",
 		"range",
 		"re",
 		"seq",

--- a/lib/logstorage/parser_test.go
+++ b/lib/logstorage/parser_test.go
@@ -1469,10 +1469,13 @@ func TestParseQuery_Success(t *testing.T) {
 	f("len_range-foo:b", `"len_range-foo":b`)
 	f("pattern_match", `"pattern_match"`)
 	f("pattern_match_full", `"pattern_match_full"`)
+	f("pattern_match_prefix", `"pattern_match_prefix"`)
 	f("pattern_match:a", `"pattern_match":a`)
 	f("pattern_match_full:a", `"pattern_match_full":a`)
+	f("pattern_match_prefix:a", `"pattern_match_prefix":a`)
 	f("a:pattern_match", `a:"pattern_match"`)
 	f("a:pattern_match_full", `a:"pattern_match_full"`)
+	f("a:pattern_match_prefix", `a:"pattern_match_prefix"`)
 	f("range", `"range"`)
 	f("range:a", `"range":a`)
 	f("range-foo", `"range-foo"`)
@@ -1633,6 +1636,9 @@ func TestParseQuery_Success(t *testing.T) {
 
 	// pattern_match_full filter
 	f(`pattern_match_full("<N> foo <DATE>, bar")`, `pattern_match_full("<N> foo <DATE>, bar")`)
+
+	// pattern_match_prefix filter
+	f(`pattern_match_prefix("<DATETIME> foo")`, `pattern_match_prefix("<DATETIME> foo")`)
 
 	// range filter
 	f(`range(1.234, 5656.43454)`, `range(1.234, 5656.43454)`)
@@ -2489,6 +2495,10 @@ func TestParseQuery_Failure(t *testing.T) {
 	// invalid pattern_match
 	f(`pattern_match()`)
 	f(`pattern_match(`)
+
+	// invalid pattern_match_prefix
+	f(`pattern_match_prefix()`)
+	f(`pattern_match_prefix(`)
 
 	// invalid pattern_match_all
 	f(`pattern_match_all()`)

--- a/lib/logstorage/pattern_matcher.go
+++ b/lib/logstorage/pattern_matcher.go
@@ -137,6 +137,12 @@ func (pm *patternMatcher) Match(s string) bool {
 	return pm.matchSubstring(s)
 }
 
+// MatchPrefix returns true if s starts with the given pattern.
+func (pm *patternMatcher) MatchPrefix(s string) bool {
+	end := pm.indexEnd(s, 0)
+	return end >= 0
+}
+
 func (pm *patternMatcher) matchSubstring(s string) bool {
 	offset := 0
 	for {

--- a/lib/logstorage/pattern_matcher_test.go
+++ b/lib/logstorage/pattern_matcher_test.go
@@ -124,4 +124,18 @@ func TestPatternMatcherMatch(t *testing.T) {
 	// regression: leading separator present many times but placeholder doesn't match after it
 	f("xx<N>", "xxxxxxxxxxxxxxxx", false, false)
 	f("xx<N>", "xxxxxx123", false, true)
+
+	fPrefix := func(pattern, s string, expected bool) {
+		pm := newPatternMatcher(pattern, false)
+		if got := pm.MatchPrefix(s); got != expected {
+			t.Fatalf("unexpected MatchPrefix(%q, %q); got %v; want %v", pattern, s, got, expected)
+		}
+	}
+
+	// prefix matching
+	fPrefix("<DATETIME> foo", "2025-10-20T10:20:30Z foo bar", true)
+	fPrefix("<DATETIME> foo", "x 2025-10-20T10:20:30Z foo bar", false)
+	fPrefix("error", "error: disk full", true)
+	fPrefix("error", "INFO error: disk full", false)
+	fPrefix("", "anything", true)
 }


### PR DESCRIPTION
Add LogsQL filter `pattern_match_prefix()` to match patterns anchored at the start of a field while keeping existing `pattern_match_full` behavior.


Fixes https://github.com/VictoriaMetrics/VictoriaLogs/issues/762


### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
