### PR TITLE
dashboards: use custom all value for instance selector

### DIFF
--- a/dashboards/victorialogs-cluster.json
+++ b/dashboards/victorialogs-cluster.json
@@ -10951,6 +10951,7 @@
         "type": "query"
       },
       {
+        "allValue": ".*",
         "current": {},
         "datasource": {
           "type": "prometheus",

--- a/dashboards/victorialogs.json
+++ b/dashboards/victorialogs.json
@@ -7163,6 +7163,7 @@
         "type": "query"
       },
       {
+        "allValue": ".*",
         "current": {},
         "datasource": {
           "type": "prometheus",


### PR DESCRIPTION
Currently, instance selector is only populated on dashboard load. This leads to panels being empty when extending time range if instances list was updated, this is frequently happening in dynamic environments like k8s.

Fix this by using custom `.*` value so that all instances are always matched without need to re-populate the list of instances.