### PR TITLE
app/vmui: fix: removed per-item mouseleave reset bug

### DIFF
--- a/app/vmui/packages/vmui/src/components/Main/Autocomplete/Autocomplete.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Autocomplete/Autocomplete.tsx
@@ -107,10 +107,6 @@ const Autocomplete: FC<AutocompleteProps> = ({
     setFocusOption({ index, type: FocusType.mouse });
   };
 
-  const handlerMouseLeave = () => {
-    setFocusOption({ index: -1 });
-  };
-
   const scrollToValue = () => {
     if (!wrapperEl.current || focusOption.type === FocusType.mouse) return;
     const target = wrapperEl.current.childNodes[focusOption.index] as HTMLElement;
@@ -208,7 +204,6 @@ const Autocomplete: FC<AutocompleteProps> = ({
             key={`${i}${option.value}`}
             onClick={createHandlerSelect(option)}
             onMouseEnter={createHandlerMouseEnter(i)}
-            onMouseLeave={handlerMouseLeave}
           >
             {selected?.includes(option.value) && <DoneIcon/>}
             <>{option.icon}</>


### PR DESCRIPTION
### Describe Your Changes
![autocomplete-scroll](https://github.com/user-attachments/assets/d21d5cfd-812a-4ee5-a31b-09e6a82643fb)

Fixes: https://github.com/VictoriaMetrics/VictoriaLogs/issues/970

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
