### PR TITLE
logsql: fix panic when filtering by "_stream" field

### DIFF
--- a/lib/logstorage/filter_phrase.go
+++ b/lib/logstorage/filter_phrase.go
@@ -2,6 +2,7 @@ package logstorage
 
 import (
 	"bytes"
+	"strconv"
 	"strings"
 	"sync"
 	"unicode/utf8"
@@ -315,6 +316,10 @@ func matchBloomFilterAllTokens(bs *blockSearch, ch *columnHeader, tokens []uint6
 func quoteFieldNameIfNeeded(s string) string {
 	if isMsgFieldName(s) {
 		return ""
+	}
+	if s == "_stream" {
+		// Always quote `_stream` when used as a plain field to avoid confusing it with the stream filter syntax.
+		return strconv.Quote(s) + ":"
 	}
 	return quoteTokenIfNeeded(s) + ":"
 }

--- a/lib/logstorage/parser_test.go
+++ b/lib/logstorage/parser_test.go
@@ -3299,6 +3299,22 @@ func TestQueryClone(t *testing.T) {
 	f("ip:in(foo | fields user_ip) bar | stats by (x:1h, y) count(*) if (user_id:contains_all(q:w | fields abc)) as ccc")
 }
 
+func TestQueryCloneStreamFieldFilter(t *testing.T) {
+	qStr := `_time:[2025-09-29T03:55:29.000000000Z,2025-09-29T06:55:29.999999999Z] "_stream":="" | sort by (_time) desc limit 500`
+
+	q, err := ParseQuery(qStr)
+	if err != nil {
+		t.Fatalf("cannot parse [%s]: %s", qStr, err)
+	}
+
+	qStrCanonical := q.String()
+
+	qCopy := q.Clone(q.GetTimestamp())
+	if got := qCopy.String(); got != qStrCanonical {
+		t.Fatalf("unexpected cloned query\n got\n%s\nwant\n%s", got, qStrCanonical)
+	}
+}
+
 func TestQueryGetFilterTimeRange(t *testing.T) {
 	f := func(qStr string, startExpected, endExpected int64) {
 		t.Helper()


### PR DESCRIPTION
### Describe Your Changes

<img width="886" height="70" alt="image" src="https://github.com/user-attachments/assets/276d316c-c76d-4b0a-8809-5af9e08d2e05" />

Fixes: https://github.com/VictoriaMetrics/VictoriaLogs/issues/717

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
