### PR TITLE
logsql/math: prevent panic in math modulo by zero

### DIFF
--- a/lib/logstorage/pipe_math.go
+++ b/lib/logstorage/pipe_math.go
@@ -908,7 +908,11 @@ func mathFuncMod(result []float64, args [][]float64) {
 		yInt := int64(y)
 		if float64(xInt) == x && float64(yInt) == y {
 			// Fast path - integer modulo
-			result[i] = float64(xInt % yInt)
+			if yInt == 0 {
+				result[i] = nan
+			} else {
+				result[i] = float64(xInt % yInt)
+			}
 		} else {
 			// Slow path - floating point modulo
 			result[i] = math.Mod(x, y)

--- a/lib/logstorage/pipe_math_test.go
+++ b/lib/logstorage/pipe_math_test.go
@@ -149,6 +149,17 @@ func TestPipeMath(t *testing.T) {
 		},
 	})
 
+	f("math 5 % 0 as x", [][]Field{
+		{
+			{"foo", "bar"},
+		},
+	}, [][]Field{
+		{
+			{"foo", "bar"},
+			{"x", "NaN"},
+		},
+	})
+
 	f("math round(exp(a), 0.01), round(ln(a), 0.01), ceil(exp(a)), floor(exp(a))", [][]Field{
 		{
 			{"a", "v1"},


### PR DESCRIPTION
`math` pipe could panic on integer fast-path modulo when divisor is 0 (`xInt % yInt`). This makes `%` behave differently depending on whether inputs are parsed as integers vs floats. Fix it by returning `NaN` when `yInt == 0`, matching `math.Mod(x, 0)` behavior.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
