### PR TITLE
lib/logstorage: fix options(time_offset) for day_range and week_range

### DIFF
--- a/lib/logstorage/parser.go
+++ b/lib/logstorage/parser.go
@@ -1287,11 +1287,11 @@ func updateFilterWithTimeOffset(f filter, timeOffset int64) filter {
 			return &ftCopy, nil
 		case *filterDayRange:
 			ftCopy := *ft
-			ft.offset = subNoOverflowInt64(ft.offset, -timeOffset)
+			ftCopy.offset = subNoOverflowInt64(ft.offset, -timeOffset)
 			return &ftCopy, nil
 		case *filterWeekRange:
 			ftCopy := *ft
-			ft.offset = subNoOverflowInt64(ft.offset, -timeOffset)
+			ftCopy.offset = subNoOverflowInt64(ft.offset, -timeOffset)
 			return &ftCopy, nil
 		default:
 			logger.Panicf("BUG: unexpected filter passed to copyFunc: %T; [%s]", f, f)

--- a/lib/logstorage/parser_test.go
+++ b/lib/logstorage/parser_test.go
@@ -565,6 +565,31 @@ func TestParseWeekRange(t *testing.T) {
 	f(`[Fri, Mon] offset -2h`, time.Friday, time.Monday, -2*nsecsPerHour)
 }
 
+func TestTimeOffsetUpdatesDayAndWeekRangeFilters(t *testing.T) {
+	f := func(qStr string, offsetExpected int64) {
+		t.Helper()
+		q, err := ParseQuery(qStr)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		switch fr := q.f.(type) {
+		case *filterDayRange:
+			if fr.offset != offsetExpected {
+				t.Fatalf("unexpected offset for day_range; got %d; want %d", fr.offset, offsetExpected)
+			}
+		case *filterWeekRange:
+			if fr.offset != offsetExpected {
+				t.Fatalf("unexpected offset for week_range; got %d; want %d", fr.offset, offsetExpected)
+			}
+		default:
+			t.Fatalf("unexpected filter; got %T; want *filterDayRange or *filterWeekRange; filter: %s", q.f, q.f)
+		}
+	}
+
+	f("options(time_offset=1h) _time:day_range[08:00, 18:00) offset 2h", 3*int64(nsecsPerHour))
+	f("options(time_offset=1h) _time:week_range[Mon, Fri] offset 2h", 3*int64(nsecsPerHour))
+}
+
 func TestParseTimeDuration(t *testing.T) {
 	f := func(s string, durationExpected time.Duration) {
 		t.Helper()


### PR DESCRIPTION
This fixes a bug in how LogsQL `options(time_offset=...)` is applied to `_time:day_range` and `_time:week_range`. The parser code was creating a copy of these filters but accidentally updated the original filter's `offset` instead of the copy, so the returned query filter ignored `time_offset` for `day_range`/`week_range` (and also mutated the original filter instance)

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
