### PR TITLE
docs/vmalert: show how to attach sample log row via annotations

### DIFF
--- a/docs/victorialogs/vmalert.md
+++ b/docs/victorialogs/vmalert.md
@@ -122,7 +122,6 @@ groups:
           description: "Connection from address {{$labels.ip}} has {{$value}}% failed requests in the last 5 minutes"
 ```
 
-
 #### Recording rules
 
 Examples:


### PR DESCRIPTION
Adds a vmalert+VictoriaLogs example showing how to attach a sample log line via annotation queries (`row_any`/`row_max`/`row_min`).

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a docs example for vmalert + VictoriaLogs showing how to attach a sample log line to alert annotations using query with row_any, row_max, and row_min. Includes a YAML snippet and a note to avoid using these in expr to prevent label changes and alert flapping.

<sup>Written for commit df3e090a083961613027ccdcc723374aac4c04a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

