### PR TITLE
app/vmui: add `offset` parameter to align bar chart data with the user-selected timezone

### DIFF
--- a/app/vmui/packages/vmui/src/pages/QueryPage/hooks/useFetchLogHits.ts
+++ b/app/vmui/packages/vmui/src/pages/QueryPage/hooks/useFetchLogHits.ts
@@ -10,8 +10,7 @@ import { useSearchParams } from "react-router-dom";
 import { useAppState } from "../../../state/common/StateContext";
 import { GRAPH_QUERY_MODE } from "../../../components/Chart/BarHitsChart/types";
 import useProcessStatsQueryRange from "./useProcessStatsQueryRange";
-
-
+import dayjs from "dayjs";
 
 type ResponseHits = {
   hits: LogHits[];
@@ -57,10 +56,12 @@ export const useFetchLogHits = (defaultQuery = "*") => {
 
   const getOptions = ({ query = defaultQuery, period, extraParams, signal, fieldsLimit, field, barsCount }: OptionsParams) => {
     const { start, end, step } = getHitsTimeParams(period, barsCount);
+    const offsetMinutes = dayjs().tz().utcOffset();
 
     const params = new URLSearchParams({
       query: query.trim(),
       step: `${step}ms`,
+      offset: `${offsetMinutes}m`,
       start: start.toISOString(),
       end: end.toISOString(),
       fields_limit: `${fieldsLimit || LOGS_LIMIT_HITS}`,

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -24,6 +24,7 @@ according to the following docs:
 
 * FEATURE: [`/select/logsql/stats_query_range` endpoint](https://docs.victoriametrics.com/victorialogs/querying/#querying-log-range-stats): support optional `offset` query arg, which can contain timezone offset for the returned timestamps. This is needed for the consistency with the [`/select/logsql/hits` endpoint](https://docs.victoriametrics.com/victorialogs/querying/#querying-hits-stats).
 * FEATURE: [dashboard/single-node](https://grafana.com/grafana/dashboards/22084) and [dashboard/cluster](https://grafana.com/grafana/dashboards/23274): improve and fix dashboard descriptions, make them more compatible with the Prometheus datasource, and add a `cluster` variable for easier selection of components from the same cluster. See [#933](https://github.com/VictoriaMetrics/VictoriaLogs/pull/933).
+* FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add the `offset` parameter so bar chart data is aligned with the user-selected timezone. See [#1039](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1039).
 
 * BUGFIX: [`/select/logsql/hits` endpoint](https://docs.victoriametrics.com/victorialogs/querying/#querying-hits-stats): properly apply `offset` arg. Previously it resulted in incorrect calculations for the returned timestamps.
 


### PR DESCRIPTION
### Describe Your Changes

Add the `offset` parameter to bar chart queries, passing the timezone display offset (in minutes) so log aggregation is aligned with the user-selected timezone.

Related issue: #1039

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align bar chart buckets with the selected timezone by sending a timezone offset to the hits query. This fixes shifted buckets when viewing logs in non-UTC time (addresses #1039).

- **New Features**
  - Send offset=<minutes>m to /select/logsql/hits based on the current display timezone.
  - Update changelog to document the new web UI behavior.

<sup>Written for commit c73fea375d545bca6c48916d8cfa24ef19dee8a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

