### PR TITLE
app/vmui: fix redundant `/select/logsql/query_time_range` requests

### DIFF
--- a/app/vmui/packages/vmui/src/pages/QueryPage/hooks/useFetchQueryTime.ts
+++ b/app/vmui/packages/vmui/src/pages/QueryPage/hooks/useFetchQueryTime.ts
@@ -4,6 +4,7 @@ import { useTenant } from "../../../hooks/useTenant";
 import { useAppState } from "../../../state/common/StateContext";
 import dayjs from "dayjs";
 import { getDurationFromPeriod, getTimeperiodForDuration } from "../../../utils/time";
+import { getOverrideValue } from "../../../components/Configurators/GlobalSettings/QueryTimeOverride/QueryTimeOverride";
 
 type ResponseTimeRange = {
   start: string;
@@ -15,6 +16,9 @@ interface ServerTimeParams extends TimeParams {
   hasTimeFilter: boolean;
 }
 
+const hasTimeFilter = (expr?: string) => {
+  return !!expr && expr.includes("_time");
+};
 
 export const useFetchQueryTime = (defaultQuery?: string) => {
   const { serverUrl } = useAppState();
@@ -28,6 +32,11 @@ export const useFetchQueryTime = (defaultQuery?: string) => {
     period: TimeParams,
     query?: string
   }): Promise<ServerTimeParams | undefined> => {
+    if (!getOverrideValue() || !hasTimeFilter(query)) {
+      // No need to fetch, as time filter override is disabled or query has no _time filter
+      return;
+    }
+
     const params = new URLSearchParams({
       query: query || defaultQuery || "",
       start: period.start.toString(),

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -32,6 +32,7 @@ according to the following docs:
 * BUGFIX: [dashboard/single-node](https://grafana.com/grafana/dashboards/22084): include `internalinsert` (`/internal/insert`) in `Logs ingestion rate` panels, so they work for data ingested via `vlagent` configured with `-remoteWrite.url=.../internal/insert`. See [#1053](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1053).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix cumulative bar chart by carrying over previous value for nullish bars. This ensures that the cumulative bar chart doesn't decrease over time.
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix missing first bar when it starts before the selected range but ends within it.
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix redundant `/select/logsql/query_time_range` requests.
 
 ## [v1.44.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.44.0)
 


### PR DESCRIPTION
### Describe Your Changes

When zooming the bar chart with `Ctrl + scroll` or dragging it left/right with`Ctrl`, the web UI was sending multiple redundant requests to `/select/logsql/query_time_range`.

This PR limits the frequency of these requests and skips `query_time_range` checks when the query doesn’t contain `_time` (simple substring check).

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces redundant /select/logsql/query_time_range requests in the logs UI to improve responsiveness when zooming or panning. Adds debouncing and skips time-range checks when not needed.

- **Bug Fixes**
  - Debounce run-query calls by 300ms to prevent burst requests on Ctrl+scroll/drag.
  - Skip query_time_range when Query Time Override is off or the query lacks _time.
  - Update changelog.

<sup>Written for commit 6dcfb9018a195820d7918a6914396f9ee98fb87d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

