### PR TITLE
app/vmui: update suggestion for development mode

### DIFF
--- a/app/vmui/packages/vmui/README.md
+++ b/app/vmui/packages/vmui/README.md
@@ -6,9 +6,9 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 In the project directory, you can run:
 
-### `npm start`
+### `npm run start:playground`
 
-Runs the app in the development mode.\
+Runs the app in the development mode and connects it to https://play-vmlogs.victoriametrics.com/ as backend.\
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.\
 Open [http://localhost:3000/#/icons](http://localhost:3000/#/icons) to view the icons used in the project.
 


### PR DESCRIPTION
Recommend using `npm run start:playground` as it runs vmui connected to https://play-vmlogs.victoriametrics.com/. This approach significantly improves developer experience.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update README to recommend using `npm run start:playground` for development, which runs vmui connected to https://play-vmlogs.victoriametrics.com/ as the backend. This simplifies setup and improves the developer experience.

<sup>Written for commit ae5f4c3ac376b7ea328b1fb22d0ba521ed19baa6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

