### PR TITLE
app/vmui: clarify the multinenancy link text

### DIFF
--- a/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/TenantsConfiguration/TenantsFields.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/TenantsConfiguration/TenantsFields.tsx
@@ -62,7 +62,7 @@ const TenantsFields: FC<Props> = ({ accountId, projectId, onChange }) => {
             variant="text"
             color="primary"
           >
-            Read more
+            Multitenancy docs
           </Button>
         </a>
         <Button

--- a/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/TenantsConfiguration/TenantsSelect.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/TenantsConfiguration/TenantsSelect.tsx
@@ -71,7 +71,7 @@ const TenantsSelect: FC<Props> = ({ accountIds, tenantId, onChange }) => {
             variant="text"
             color="primary"
           >
-            Read more
+            Multitenancy docs
           </Button>
         </a>
       </div>


### PR DESCRIPTION
Link with `Read More` looks confusin, as it is not clear to user what is it they will read more. Renaming it to `Multitenancy Docs` bring useful context to link and a box it is displayed in.
