### PR TITLE
app/vmui: add 'none' hit chart grouping option as default

### DIFF
--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsOptions/BarHitsOptions.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsOptions/BarHitsOptions.tsx
@@ -14,7 +14,7 @@ import classNames from "classnames";
 import Modal from "../../../Main/Modal/Modal";
 import useBoolean from "../../../../hooks/useBoolean";
 import SelectLimit from "../../../Main/Pagination/SelectLimit/SelectLimit";
-import { LOGS_BAR_COUNTS } from "../../../../constants/logs";
+import { LOGS_BAR_COUNTS, WITHOUT_GROUPING } from "../../../../constants/logs";
 import { useHitsChartConfig } from "../../../../pages/QueryPage/HitsChart/hooks/useHitsChartConfig";
 import { useExtraFilters } from "../../../../pages/OverviewPage/hooks/useExtraFilters";
 import { useTimeState } from "../../../../state/time/TimeStateContext";
@@ -60,11 +60,12 @@ const BarHitsOptions: FC<Props> = ({ query, isHitsMode, isOverview, onChange }) 
   }), [stacked, cumulative, hideChart, queryMode]);
 
   const fieldNamesOptions = useMemo(() => {
-    return fieldNames.map(v => v.value).sort((a, b) => a.localeCompare(b));
+    const fields = fieldNames.map(v => v.value).sort((a, b) => a.localeCompare(b));
+    return [WITHOUT_GROUPING, ...fields];
   }, [fieldNames]);
 
   const handleOpenFields = useCallback(() => {
-    fetchFieldNames({ start, end, extraParams, showAllFields: true, query });
+    fetchFieldNames({ start, end, extraParams, skipNoiseFields: true, query });
   }, [start, end, extraParams.toString(), fetchFieldNames, query]);
 
   const handleChangeSearchParams = useCallback((key: string, shouldSet: boolean, paramValue?: string) => {
@@ -101,7 +102,7 @@ const BarHitsOptions: FC<Props> = ({ query, isHitsMode, isOverview, onChange }) 
     onChange(options);
   }, [options]);
 
-  const Controls = () => (
+  const controls = (
     <>
       <div className="vm-bar-hits-options vm-bar-hits-options_selections">
         <div className="vm-bar-hits-options-item">
@@ -174,7 +175,7 @@ const BarHitsOptions: FC<Props> = ({ query, isHitsMode, isOverview, onChange }) 
     >
       {!isMobile && (
         <>
-          <Controls/>
+          {controls}
           <ShortcutKeys withHotkey={false}>
             <Button
               variant="text"
@@ -213,7 +214,7 @@ const BarHitsOptions: FC<Props> = ({ query, isHitsMode, isOverview, onChange }) 
             })}
           >
             <div className="vm-bar-hits-options vm-bar-hits-options_mobile">
-              <Controls/>
+              {controls}
             </div>
           </Modal>
         </>

--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsPlot/BarHitsPlot.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsPlot/BarHitsPlot.tsx
@@ -81,6 +81,10 @@ const BarHitsPlot: FC<Props> = ({ graphOptions, logHits, totalHits, data: _data,
     }).sort(sortLogHits("total"));
   }, [logHits, totalHits, series]);
 
+  const isSingleOtherSeries = useMemo(() => {
+    return legendDetails.length === 1 && legendDetails.every(l => l.isOther);
+  }, [legendDetails]);
+
   useEffect(() => {
     if (!uPlotInst) return;
 
@@ -152,11 +156,13 @@ const BarHitsPlot: FC<Props> = ({ graphOptions, logHits, totalHits, data: _data,
           />
         )}
       </div>
-      {uPlotInst && <BarHitsLegend
-        uPlotInst={uPlotInst}
-        onApplyFilter={onApplyFilter}
-        legendDetails={legendDetails}
-      />}
+      {uPlotInst && !isSingleOtherSeries && (
+        <BarHitsLegend
+          uPlotInst={uPlotInst}
+          onApplyFilter={onApplyFilter}
+          legendDetails={legendDetails}
+        />
+      )}
     </>
   );
 };

--- a/app/vmui/packages/vmui/src/components/Views/GroupView/GroupLogs.tsx
+++ b/app/vmui/packages/vmui/src/components/Views/GroupView/GroupLogs.tsx
@@ -1,7 +1,6 @@
 import { createPortal, FC, useCallback, useEffect, useMemo, useState, RefObject } from "preact/compat";
 import "./style.scss";
 import { Logs } from "../../../api/types";
-import Accordion from "../../Main/Accordion/Accordion";
 import { groupByMultipleKeys } from "../../../utils/array";
 import Tooltip from "../../Main/Tooltip/Tooltip";
 import GroupLogsItem from "./GroupLogsItem";
@@ -18,6 +17,7 @@ import SelectLimit from "../../Main/Pagination/SelectLimit/SelectLimit";
 import { usePaginateGroups } from "../../../pages/QueryPage/hooks/usePaginateGroups";
 import { GroupLogsType } from "../../../types";
 import useDeviceDetect from "../../../hooks/useDeviceDetect";
+import GroupLogsItemWrapper from "./GroupLogsItemWrapper";
 
 interface Props {
   logs: Logs[];
@@ -105,10 +105,11 @@ const GroupLogs: FC<Props> = ({ logs, settingsRef }) => {
             className="vm-group-logs-section"
             key={group.keysString}
           >
-            <Accordion
-              defaultExpanded={expandGroups[groupN]}
-              onChange={handleChangeExpand(groupN)}
-              title={(
+            <GroupLogsItemWrapper
+              groupBy={groupBy}
+              expand={expandGroups[groupN]}
+              onExpandChange={handleChangeExpand(groupN)}
+              header={(
                 <GroupLogsHeader
                   group={group}
                   index={groupN}
@@ -124,7 +125,7 @@ const GroupLogs: FC<Props> = ({ logs, settingsRef }) => {
                   />
                 ))}
               </div>
-            </Accordion>
+            </GroupLogsItemWrapper>
           </div>
         ))}
 

--- a/app/vmui/packages/vmui/src/components/Views/GroupView/GroupLogsHeader.tsx
+++ b/app/vmui/packages/vmui/src/components/Views/GroupView/GroupLogsHeader.tsx
@@ -6,7 +6,7 @@ import useEventListener from "../../../hooks/useEventListener";
 import Popper from "../../Main/Popper/Popper";
 import useBoolean from "../../../hooks/useBoolean";
 import GroupLogsHeaderItem from "./GroupLogsHeaderItem";
-import { LOGS_GROUP_BY, LOGS_URL_PARAMS, WITHOUT_GROUPING } from "../../../constants/logs";
+import { LOGS_GROUP_BY, LOGS_URL_PARAMS } from "../../../constants/logs";
 import { GroupLogsType } from "../../../types";
 import useDeviceDetect from "../../../hooks/useDeviceDetect";
 
@@ -78,7 +78,7 @@ const GroupLogsHeader: FC<Props> = ({ group, index }) => {
       ref={containerRef}
     >
       <span className="vm-group-logs-section-keys__title">
-        {groupBy === WITHOUT_GROUPING ? WITHOUT_GROUPING : <>{index + 1}. Group by <code>{groupBy}</code>:</>}
+        {index + 1}. Group by <code>{groupBy}</code>
       </span>
       {pairs.map((pair, i) => (
         <GroupLogsHeaderItem

--- a/app/vmui/packages/vmui/src/components/Views/GroupView/GroupLogsItemWrapper.tsx
+++ b/app/vmui/packages/vmui/src/components/Views/GroupView/GroupLogsItemWrapper.tsx
@@ -1,0 +1,33 @@
+import { FC, ReactNode } from "preact/compat";
+import { WITHOUT_GROUPING } from "../../../constants/logs";
+import Accordion from "../../Main/Accordion/Accordion";
+
+type Props = {
+  groupBy: string;
+  expand: boolean;
+  onExpandChange: (expand: boolean) => void;
+  header: ReactNode;
+  children: ReactNode;
+}
+
+const GroupLogsItemWrapper: FC<Props> = ({ groupBy, expand, onExpandChange, header, children }) => {
+  if (groupBy === WITHOUT_GROUPING) {
+    return (
+      <div className="vm-group-logs-section__ungrouped">
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <Accordion
+      defaultExpanded={expand}
+      onChange={onExpandChange}
+      title={header}
+    >
+      {children}
+    </Accordion>
+  );
+};
+
+export default GroupLogsItemWrapper;

--- a/app/vmui/packages/vmui/src/components/Views/GroupView/style.scss
+++ b/app/vmui/packages/vmui/src/components/Views/GroupView/style.scss
@@ -35,6 +35,10 @@ $actions-width: calc(($actions-buttons*30px) + 10px);
     border-bottom: $border-divider;
     padding-bottom: $padding-small;
 
+    &__ungrouped {
+      padding-top: $padding-small;
+    }
+
     &-keys {
       position: relative;
       display: flex;

--- a/app/vmui/packages/vmui/src/components/Views/JsonView/JsonLogsView.tsx
+++ b/app/vmui/packages/vmui/src/components/Views/JsonView/JsonLogsView.tsx
@@ -2,7 +2,6 @@ import { FC, useCallback, createPortal, memo } from "preact/compat";
 import { ViewProps } from "../../../pages/QueryPage/QueryPageBody/types";
 import EmptyLogs from "../../EmptyLogs/EmptyLogs";
 import "./style.scss";
-import { Logs } from "../../../api/types";
 import ScrollToTopButton from "../../ScrollToTopButton/ScrollToTopButton";
 import { CopyButton } from "../../CopyButton/CopyButton";
 import { JsonView as JsonViewComponent } from "./JsonView";

--- a/app/vmui/packages/vmui/src/constants/logs.ts
+++ b/app/vmui/packages/vmui/src/constants/logs.ts
@@ -12,8 +12,7 @@ export const LOGS_LIMIT_HITS = 5;
 export const LOGS_BAR_COUNT_DEFAULT = getIsMobile() ? 24 : 96;
 export const LOGS_BAR_COUNTS = [12, 24, 48, 96, 288, 720, 1440];
 
-// "Ungrouped" is a string that is used as a value for the "groupBy" parameter.
-export const WITHOUT_GROUPING = "Ungrouped";
+export const WITHOUT_GROUPING = "none";
 
 // Default values for the logs configurators.
 export const LOGS_GROUP_BY = "_stream";

--- a/app/vmui/packages/vmui/src/pages/OverviewPage/OverviewFields/OverviewFieldsTables/TopFieldNames.tsx
+++ b/app/vmui/packages/vmui/src/pages/OverviewPage/OverviewFields/OverviewFieldsTables/TopFieldNames.tsx
@@ -66,7 +66,7 @@ const TopFieldNames: FC = () => {
   };
 
   useEffect(() => {
-    fetchFieldNames({ start, end, extraParams });
+    fetchFieldNames({ start, end, extraParams, skipStreamFields: true });
   }, [start, end, extraParams.toString(), fetchFieldNames]);
 
   const TableAction = (row: LogsFiledValues) => {

--- a/app/vmui/packages/vmui/src/pages/OverviewPage/hooks/useFetchFieldNames.ts
+++ b/app/vmui/packages/vmui/src/pages/OverviewPage/hooks/useFetchFieldNames.ts
@@ -9,7 +9,8 @@ interface FetchOptions {
   end: number;
   query?: string;
   extraParams?: URLSearchParams;
-  showAllFields?: boolean;
+  skipNoiseFields?: boolean;
+  skipStreamFields?: boolean;
 }
 
 const NOISE_FIELDS = ["_msg", "_time"];
@@ -25,10 +26,13 @@ export const useFetchFieldNames = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | string>("");
 
-  const setterFieldNames = (values: LogsFiledValues[], showAllFields?: boolean) => {
-    const filteredFieldNames = showAllFields
+  const setterFieldNames = (values: LogsFiledValues[],  skipNoiseFields = true, skipStreamFields = false) => {
+    const noiseFields = skipNoiseFields ? NOISE_FIELDS : [];
+    const streamFields = skipStreamFields ? STREAM_FIELDS : [];
+    const skipFields = noiseFields.concat(streamFields);
+    const filteredFieldNames = !skipFields.length
       ? values
-      : values.filter(v => !NOISE_FIELDS.concat(STREAM_FIELDS).includes(v.value));
+      : values.filter(v => !skipFields.includes(v.value));
     setFieldNames(filteredFieldNames);
   };
 
@@ -53,7 +57,7 @@ export const useFetchFieldNames = () => {
       const cacheKey = queryParams + JSON.stringify(tenant);
 
       if (fieldNamesParamsKey === cacheKey) {
-        setterFieldNames(fieldNamesState, options.showAllFields);
+        setterFieldNames(fieldNamesState, options.skipNoiseFields, options.skipStreamFields);
         setLoading(false);
         return;
       }
@@ -74,7 +78,7 @@ export const useFetchFieldNames = () => {
       }
 
       const data: { values: LogsFiledValues[] } = await response.json();
-      setterFieldNames(data.values, options.showAllFields);
+      setterFieldNames(data.values, options.skipNoiseFields, options.skipStreamFields);
       dispatch({
         type: "SET_FIELD_NAMES",
         payload: { rows: data.values, key: cacheKey }

--- a/app/vmui/packages/vmui/src/pages/QueryPage/HitsChart/hooks/useHitsChartConfig.ts
+++ b/app/vmui/packages/vmui/src/pages/QueryPage/HitsChart/hooks/useHitsChartConfig.ts
@@ -1,6 +1,6 @@
 import { useSearchParams } from "react-router-dom";
 import { useCallback, useMemo } from "preact/compat";
-import { LOGS_BAR_COUNT_DEFAULT, LOGS_GROUP_BY, LOGS_LIMIT_HITS } from "../../../../constants/logs";
+import { LOGS_BAR_COUNT_DEFAULT, LOGS_LIMIT_HITS, WITHOUT_GROUPING } from "../../../../constants/logs";
 
 enum  HITS_PARAMS {
   TOP = "top_hits",
@@ -21,7 +21,7 @@ export const useHitsChartConfig = () => {
     return Number.isFinite(n) && n > 0 ? n : LOGS_BAR_COUNT_DEFAULT;
   }, [searchParams]);
 
-  const groupFieldHits = searchParams.get(HITS_PARAMS.GROUP) || LOGS_GROUP_BY;
+  const groupFieldHits = searchParams.get(HITS_PARAMS.GROUP) || WITHOUT_GROUPING;
 
   const setValue = useCallback((param: HITS_PARAMS, newValue?: string | number) => {
     setSearchParams(prev => {

--- a/app/vmui/packages/vmui/src/pages/QueryPage/hooks/useFetchLogHits.ts
+++ b/app/vmui/packages/vmui/src/pages/QueryPage/hooks/useFetchLogHits.ts
@@ -3,7 +3,7 @@ import { getLogHitsUrl, getStatsQueryRangeUrl } from "../../../api/logs";
 import { ErrorTypes, TimeParams } from "../../../types";
 import { LogHits } from "../../../api/types";
 import { getHitsTimeParams } from "../../../utils/logs";
-import { LOGS_GROUP_BY, LOGS_LIMIT_HITS } from "../../../constants/logs";
+import { LOGS_LIMIT_HITS, WITHOUT_GROUPING } from "../../../constants/logs";
 import { isEmptyObject } from "../../../utils/object";
 import { useTenant } from "../../../hooks/useTenant";
 import { useSearchParams } from "react-router-dom";
@@ -65,8 +65,11 @@ export const useFetchLogHits = (defaultQuery = "*") => {
       start: start.toISOString(),
       end: end.toISOString(),
       fields_limit: `${fieldsLimit || LOGS_LIMIT_HITS}`,
-      field: field || LOGS_GROUP_BY,
     });
+
+    if (field && field !== WITHOUT_GROUPING) {
+      params.set("field", field);
+    }
 
     const body = new URLSearchParams([
       ...params,

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -24,6 +24,7 @@ according to the following docs:
 
 * FEATURE: upgrade Go builder from Go1.25.7 to Go1.26.0. See [Go 1.26 release notes](https://go.dev/doc/go1.26).
 * FEATURE: [querying](https://docs.victoriametrics.com/victorialogs/querying/): sort response fields by their name unless the query ends with a pipe, which preserves the order of the returned fields such as [`fields`](https://docs.victoriametrics.com/victorialogs/logsql/#fields-pipe) and [`stats`](https://docs.victoriametrics.com/victorialogs/logsql/#stats-pipe). Previously the order of the returned fields was undefined. See [#1011](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1011).
+* FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add `none` option for hit chart grouping and set it as the default. See [#1086](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1086).
 
 ## [v1.45.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.45.0)
 


### PR DESCRIPTION
### Describe Your Changes

* Added `none` to the hit chart "Group by" selector.
* Set `none` as the default grouping option.
* When `none` is selected, hits are shown as a single aggregated series (no grouping).

<img width="1810" height="259" alt="image" src="https://github.com/user-attachments/assets/ede06671-f286-46a8-850c-965c8560156e" />

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
