### PR TITLE
app/vmui: fix markdown parsing for tab-indented log lines

### DIFF
--- a/app/vmui/packages/vmui/src/constants/markedPlugins.ts
+++ b/app/vmui/packages/vmui/src/constants/markedPlugins.ts
@@ -12,4 +12,7 @@ marked.use({
       token.text = token.raw ?? token.text ?? "";
     }
   },
+  tokenizer: {
+    code() { return undefined; }
+  }
 });

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -25,6 +25,8 @@ according to the following docs:
 * FEATURE: upgrade Go builder from Go1.25.7 to Go1.26.0. See [Go 1.26 release notes](https://go.dev/doc/go1.26).
 * FEATURE: [querying](https://docs.victoriametrics.com/victorialogs/querying/): sort response fields by their name unless the query ends with a pipe, which preserves the order of the returned fields such as [`fields`](https://docs.victoriametrics.com/victorialogs/logsql/#fields-pipe) and [`stats`](https://docs.victoriametrics.com/victorialogs/logsql/#stats-pipe). Previously the order of the returned fields was undefined. See [#1011](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1011).
 
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix markdown parsing for log lines starting with tabs in group view.
+
 ## [v1.45.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.45.0)
 
 Released at 2026-02-05


### PR DESCRIPTION
### Describe Your Changes

Log messages starting with tabs were parsed as Markdown code blocks in group view. This was fixed by preventing leading tab indentation from triggering code block formatting.

| | |
|--------|-------|
| Before | <img width="1412" height="784" alt="image" src="https://github.com/user-attachments/assets/50663e92-4e9d-40ee-830f-43189022fe33" /> |
| After | <img width="1412" height="784" alt="image" src="https://github.com/user-attachments/assets/eb788985-3796-48a6-a1f0-8888bad334dd" /> |


### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
