### PR TITLE
app/vmui: show stream fields in Log context modal

### DIFF
--- a/app/vmui/packages/vmui/src/components/Views/GroupView/style.scss
+++ b/app/vmui/packages/vmui/src/components/Views/GroupView/style.scss
@@ -100,6 +100,7 @@ $actions-width: calc(($actions-buttons * 30px) + 10px);
         border-radius: $border-radius-medium;
         transition: background-color 0.3s ease-in, transform 0.1s ease-in, opacity 0.3s ease-in;
         white-space: nowrap;
+        cursor: pointer;
 
         &_hide {
           order: 2;

--- a/app/vmui/packages/vmui/src/pages/StreamContext/StreamContextList.tsx
+++ b/app/vmui/packages/vmui/src/pages/StreamContext/StreamContextList.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { Logs } from "../../api/types";
-import { useEffect, useState } from "preact/compat";
+import { useEffect, useMemo, useState } from "preact/compat";
 import { useFetchStreamContext } from "./hooks/useFetchStreamContext";
 import GroupLogsItem from "../../components/Views/GroupView/GroupLogsItem";
 import LineLoader from "../../components/Main/LineLoader/LineLoader";
@@ -14,6 +14,8 @@ import router from "../../router";
 import classNames from "classnames";
 import "./style.scss";
 import { OpenNewIcon } from "../../components/Main/Icons";
+import { getStreamPairs } from "../../utils/logs";
+import GroupLogsHeaderItem from "../../components/Views/GroupView/GroupLogsHeaderItem";
 
 interface Props {
   log: Logs;
@@ -37,6 +39,11 @@ const StreamContextList: FC<Props> = ({ log, displayFields, isModal }) => {
     resetContextLogs,
     abortController
   } = useFetchStreamContext();
+
+  const streamFields = useMemo(() => {
+    const stream = logsBefore[0]?._stream || logsAfter[0]?._stream || log._stream || "";
+    return getStreamPairs(stream);
+  }, [logsBefore, logsAfter, log._stream]);
 
   const handleLoadMoreAfter = () => {
     const target = logsAfter[0];
@@ -66,6 +73,17 @@ const StreamContextList: FC<Props> = ({ log, displayFields, isModal }) => {
     };
   }, []);
 
+  const streamPairs = (
+    <div className="vm-steam-context-header-streams">
+      {streamFields.map(streamPair => (
+        <GroupLogsHeaderItem
+          key={streamPair}
+          pair={streamPair}
+        />
+      ))}
+    </div>
+  );
+
   return (
     <div
       className={classNames({
@@ -76,16 +94,11 @@ const StreamContextList: FC<Props> = ({ log, displayFields, isModal }) => {
       {isLoading && <LineLoader/>}
       {error && <Alert variant="error">{error}</Alert>}
 
-      <div className="vm-steam-context-header">
+      <div className={classNames("vm-steam-context-header", { "vm-steam-context-header_page": !isModal })}>
         {!isModal && (
-          <div className="vm-steam-context-header-title">
-            <h1 className="vm-modal-content-header__title">Log context</h1>
-            <p className="vm-steam-context-header-title__info">
-              <span>_stream_id: {log._stream_id}</span>
-              <span>_time: {log._time}</span>
-            </p>
-          </div>
+          <h1 className="vm-modal-content-header__title vm-steam-context-header-title">Log context</h1>
         )}
+        {streamPairs}
         {isModal && (
           <div className="vm-steam-context-header__link">
             <Link

--- a/app/vmui/packages/vmui/src/pages/StreamContext/style.scss
+++ b/app/vmui/packages/vmui/src/pages/StreamContext/style.scss
@@ -18,6 +18,8 @@
   }
 
   &__target-row {
+    background-color: rgba($color-dodger-blue, 0.15);
+    border-radius: $border-radius-small;
     position: sticky;
     top: 59px;
     bottom: 0;
@@ -63,23 +65,29 @@
     display: flex;
     align-items: center;
     justify-content: flex-end;
+    flex-wrap: wrap;
     gap: $padding-large;
     border-bottom: $border-divider;
     background-color: $color-background-block;
     z-index: 1;
 
+    &_page {
+      border-top: $border-divider;
+    }
+
     &-title {
-      flex-grow: 1;
       display: grid;
       gap: $padding-small;
+    }
 
-      &__info {
-        display: flex;
-        align-items: center;
-        gap: $padding-large;
-        font-size: $font-size-small;
-        color: $color-text-secondary;
-      }
+    &-streams {
+      flex-grow: 1;
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+      flex-wrap: wrap;
+      gap: calc($padding-small / 2);
+      font-size: $font-size-small;
     }
 
     &__link {

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -26,6 +26,7 @@ according to the following docs:
 * FEATURE: [querying](https://docs.victoriametrics.com/victorialogs/querying/): sort response fields by their name unless the query ends with a pipe, which preserves the order of the returned fields such as [`fields`](https://docs.victoriametrics.com/victorialogs/logsql/#fields-pipe) and [`stats`](https://docs.victoriametrics.com/victorialogs/logsql/#stats-pipe). Previously the order of the returned fields was undefined. See [#1011](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1011).
 * FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): improve group view readability with zebra rows. See [#1058](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1058).
 * FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add `none` option for hit chart grouping and set it as the default. See [#1086](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1086).
+* FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add stream fields chips to the Log context modal. See [#1065](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1065).
 
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix markdown parsing for log lines starting with tabs in group view.
 


### PR DESCRIPTION
### Describe Your Changes

Improves the "Log context" modal by displaying stream fields (`_stream`) as chips in the modal header.

Related issue: #1065

<img width="1563" height="671" alt="image" src="https://github.com/user-attachments/assets/dd308e0c-fc5c-4688-a8d9-2e3bba0672a9" />


### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
