### PR TITLE
app/vmui: add an `Interval` selector instead of `Bars` for the logs hits chart

### DIFF
--- a/app/vmui/packages/vmui/package-lock.json
+++ b/app/vmui/packages/vmui/package-lock.json
@@ -15,7 +15,7 @@
         "lodash.throttle": "^4.1.1",
         "marked": "^17.0.1",
         "preact": "^10.28.2",
-        "qs": "^6.14.1",
+        "qs": "^6.15.0",
         "react-input-mask": "^2.0.4",
         "react-router-dom": "^7.12.0",
         "uplot": "^1.6.32",
@@ -5894,9 +5894,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/app/vmui/packages/vmui/package.json
+++ b/app/vmui/packages/vmui/package.json
@@ -27,7 +27,7 @@
     "lodash.throttle": "^4.1.1",
     "marked": "^17.0.1",
     "preact": "^10.28.2",
-    "qs": "^6.14.1",
+    "qs": "^6.15.0",
     "react-input-mask": "^2.0.4",
     "react-router-dom": "^7.12.0",
     "uplot": "^1.6.32",

--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsOptions/BarHitsOptions.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsOptions/BarHitsOptions.tsx
@@ -14,11 +14,13 @@ import classNames from "classnames";
 import Modal from "../../../Main/Modal/Modal";
 import useBoolean from "../../../../hooks/useBoolean";
 import SelectLimit from "../../../Main/Pagination/SelectLimit/SelectLimit";
-import { LOGS_BAR_COUNTS, WITHOUT_GROUPING } from "../../../../constants/logs";
+import { WITHOUT_GROUPING } from "../../../../constants/logs";
 import { useHitsChartConfig } from "../../../../pages/QueryPage/HitsChart/hooks/useHitsChartConfig";
 import { useExtraFilters } from "../../../../pages/OverviewPage/hooks/useExtraFilters";
 import { useTimeState } from "../../../../state/time/TimeStateContext";
 import { useFetchFieldNames } from "../../../../pages/OverviewPage/hooks/useFetchFieldNames";
+import { humanizeSeconds } from "../../../../utils/time";
+import { generateIntervalsMs } from "../../../../utils/intervals";
 
 interface Props {
   query?: string;
@@ -37,7 +39,7 @@ const BarHitsOptions: FC<Props> = ({ query, isHitsMode, isOverview, onChange }) 
 
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const { topHits, groupFieldHits, barsCount } = useHitsChartConfig();
+  const { topHits, groupFieldHits, step } = useHitsChartConfig();
 
   const { extraParams } = useExtraFilters();
   const { period: { start, end } } = useTimeState();
@@ -45,6 +47,9 @@ const BarHitsOptions: FC<Props> = ({ query, isHitsMode, isOverview, onChange }) 
 
   const [queryMode, setQueryMode] = useStateSearchParams(GRAPH_QUERY_MODE.hits, "graph_mode");
   const isStatsMode = queryMode === GRAPH_QUERY_MODE.stats;
+
+  const hasGroupField = groupFieldHits.value !== WITHOUT_GROUPING;
+  const isGroupsLimitVisible = (isHitsMode && hasGroupField) || isStatsMode;
 
   const [stacked, setStacked] = useStateSearchParams(false, "stacked");
   const [cumulative, setCumulative] = useStateSearchParams(false, "cumulative");
@@ -58,6 +63,13 @@ const BarHitsOptions: FC<Props> = ({ query, isHitsMode, isOverview, onChange }) 
     fill: true,
     hideChart,
   }), [stacked, cumulative, hideChart, queryMode]);
+
+  const intervals = useMemo(() => {
+    const msIntervals = generateIntervalsMs(start, end);
+    return msIntervals.map(ms => humanizeSeconds(ms / 1000));
+  }, [start, end]);
+
+  const defaultStep = intervals[Math.floor(intervals.length / 2)];
 
   const fieldNamesOptions = useMemo(() => {
     const fields = fieldNames.map(v => v.value).sort((a, b) => a.localeCompare(b));
@@ -102,23 +114,30 @@ const BarHitsOptions: FC<Props> = ({ query, isHitsMode, isOverview, onChange }) 
     onChange(options);
   }, [options]);
 
+  useEffect(() => {
+    const isAllowed = (v: string | null) => !!v && intervals.includes(v);
+    const shouldReset = (v: string | null) => !isAllowed(v) && v !== defaultStep;
+
+    if (!shouldReset(step.value)) return;
+
+    const t = setTimeout(() => {
+      if (shouldReset(step.value)) step.set(defaultStep);
+    }, 200);
+
+    return () => clearTimeout(t);
+  }, [intervals, defaultStep, step.value]);
+
   const controls = (
     <>
       <div className="vm-bar-hits-options vm-bar-hits-options_selections">
         <div className="vm-bar-hits-options-item">
           <SelectLimit
-            label="Top hits"
-            options={[5, 10, 25, 50]}
-            limit={topHits.value}
-            onChange={topHits.set}
-          />
-        </div>
-        <div className="vm-bar-hits-options-item">
-          <SelectLimit
-            label="Bars"
-            options={LOGS_BAR_COUNTS}
-            limit={barsCount.value}
-            onChange={barsCount.set}
+            label="Interval"
+            options={intervals}
+            allowUnlimited={false}
+            emptyValueLabel="-"
+            limit={step.value || defaultStep}
+            onChange={step.set}
           />
         </div>
         {isHitsMode && (
@@ -138,9 +157,19 @@ const BarHitsOptions: FC<Props> = ({ query, isHitsMode, isOverview, onChange }) 
             </div>
           </>
         )}
+        {isGroupsLimitVisible && (
+          <div className="vm-bar-hits-options-item">
+            <SelectLimit
+              label="Groups limit"
+              options={[5, 10, 25, 50]}
+              limit={topHits.value}
+              onChange={topHits.set}
+            />
+          </div>
+        )}
       </div>
 
-      <div className="vm-bar-hits-options-item">
+      <div className="vm-bar-hits-options-item vm-bar-hits-options-item_switch">
         <Switch
           label={"Cumulative"}
           value={cumulative}
@@ -148,7 +177,7 @@ const BarHitsOptions: FC<Props> = ({ query, isHitsMode, isOverview, onChange }) 
         />
       </div>
       {!isOverview && (
-        <div className="vm-bar-hits-options-item">
+        <div className="vm-bar-hits-options-item vm-bar-hits-options-item_switch">
           <Switch
             label="Stats view"
             value={isStatsMode}
@@ -156,7 +185,7 @@ const BarHitsOptions: FC<Props> = ({ query, isHitsMode, isOverview, onChange }) 
           />
         </div>
       )}
-      <div className="vm-bar-hits-options-item">
+      <div className="vm-bar-hits-options-item vm-bar-hits-options-item_switch">
         <Switch
           label={"Stacked"}
           value={stacked}
@@ -171,7 +200,7 @@ const BarHitsOptions: FC<Props> = ({ query, isHitsMode, isOverview, onChange }) 
       className={classNames({
         "vm-bar-hits-options": true,
         "vm-bar-hits-options_mobile": isMobile,
-        "vm-bar-hits-options_hidden": hideChart,
+      "vm-bar-hits-options_hidden": hideChart,
       })}
     >
       {!isMobile && !hideChart && (

--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsOptions/style.scss
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsOptions/style.scss
@@ -20,10 +20,15 @@
   &_selections {
     flex-grow: 1;
     justify-content: flex-start;
+    display: flex;
+    flex-wrap: wrap;
+    gap: $padding-small;
   }
 
   &-item {
-    padding-right: $padding-global;
+    &_switch {
+      padding-right: $padding-global;
+    }
   }
 
   &_mobile {

--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsStats/BarHitsStats.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsStats/BarHitsStats.tsx
@@ -21,12 +21,12 @@ const BarHitsStats: FC<Props> = ({ totalHits, isHitsMode, durationMs }) => {
     <div className="vm-bar-hits-stats">
       {isHitsMode && (
         <p className="vm-bar-hits-stats__item">
-          Total: <b>{totalHitsFormat}</b> hits
+          Total: <b>{totalHitsFormat}</b>
         </p>
       )}
       {durationFormat && (
       <p className="vm-bar-hits-stats__item">
-        Duration: <b>{durationFormat}</b>
+        Query time: <b>{durationFormat}</b>
       </p>
       )}
     </div>

--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/style.scss
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/style.scss
@@ -21,7 +21,7 @@
     flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
-    gap: $padding-global;
+    gap: $padding-small;
     padding: $padding-small;
   }
 }

--- a/app/vmui/packages/vmui/src/components/Main/Pagination/SelectLimit/SelectLimit.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Pagination/SelectLimit/SelectLimit.tsx
@@ -15,6 +15,7 @@ interface SelectLimitProps<T extends string | number> {
   label?: string;
   options?: T[];
   allowUnlimited?: boolean;
+  emptyValueLabel?: string;
   isLoading?: boolean;
   error?: string;
   searchable?: boolean;
@@ -32,6 +33,7 @@ export const SelectLimit = <T extends string | number>(props: SelectLimitProps<T
     label,
     options,
     allowUnlimited,
+    emptyValueLabel,
     isLoading,
     error,
     searchable,
@@ -73,6 +75,12 @@ export const SelectLimit = <T extends string | number>(props: SelectLimitProps<T
     handleClose();
   };
 
+  const defaultLabel = isMobile ? "Rows" : "Rows per page";
+  const displayLabel = label || defaultLabel;
+
+  const defaultValue = limit || emptyValueLabel || "All";
+  const displayValue = renderOptionLabel ? renderOptionLabel(limit, true) : defaultValue;
+
   return (
     <>
       <div
@@ -81,7 +89,7 @@ export const SelectLimit = <T extends string | number>(props: SelectLimitProps<T
         ref={buttonRef}
       >
         <div>
-          {label || (isMobile ? "Rows" : "Rows per page")}: <b>{renderOptionLabel ? renderOptionLabel(limit, true) : limit || "All"}</b>
+          {displayLabel}: <b>{displayValue}</b>
         </div>
         <ArrowDropDownIcon/>
       </div>

--- a/app/vmui/packages/vmui/src/components/Views/GroupView/style.scss
+++ b/app/vmui/packages/vmui/src/components/Views/GroupView/style.scss
@@ -184,13 +184,16 @@ $actions-width: calc(($actions-buttons * 30px) + 10px);
         display: flex;
         align-items: center;
         justify-content: center;
-        width: $font-size;
-        height: $font-size;
         transform: rotate(-90deg);
         transition: transform 0.2s ease-out;
 
         &_open {
           transform: rotate(0deg);
+        }
+
+        svg {
+          width: $font-size;
+          height: $font-size;
         }
       }
 

--- a/app/vmui/packages/vmui/src/constants/logs.ts
+++ b/app/vmui/packages/vmui/src/constants/logs.ts
@@ -10,7 +10,6 @@ export const LOGS_LIMIT_WARN_DISMISSED_KEY = "vmui.logs.limit.warn.dismissed";
 export const LOGS_LIMIT_HITS = 5;
 
 export const LOGS_BAR_COUNT_DEFAULT = getIsMobile() ? 24 : 96;
-export const LOGS_BAR_COUNTS = [12, 24, 48, 96, 288, 720, 1440];
 
 export const WITHOUT_GROUPING = "none";
 

--- a/app/vmui/packages/vmui/src/pages/OverviewPage/OverviewHits/OverviewHits.tsx
+++ b/app/vmui/packages/vmui/src/pages/OverviewPage/OverviewHits/OverviewHits.tsx
@@ -14,7 +14,7 @@ const OverviewHits: FC = () => {
   const {
     topHits: { value: topHits },
     groupFieldHits: { value: groupFieldHits },
-    barsCount: { value: barsCount },
+    step: { value: step },
   } = useHitsChartConfig();
 
   const { extraParams, addNewFilter } = useExtraFilters();
@@ -31,12 +31,12 @@ const OverviewHits: FC = () => {
       period,
       extraParams,
       query,
-      barsCount,
+      step,
       field: groupFieldHits,
       fieldsLimit: topHits,
     });
 
-  }, [hideChart, period, extraParams.toString(), topHits, groupFieldHits]);
+  }, [hideChart, period, extraParams.toString(), step, topHits, groupFieldHits]);
 
   return (
     <div>

--- a/app/vmui/packages/vmui/src/pages/QueryPage/HitsChart/hooks/useHitsChartConfig.ts
+++ b/app/vmui/packages/vmui/src/pages/QueryPage/HitsChart/hooks/useHitsChartConfig.ts
@@ -1,11 +1,11 @@
 import { useSearchParams } from "react-router-dom";
 import { useCallback, useMemo } from "preact/compat";
-import { LOGS_BAR_COUNT_DEFAULT, LOGS_LIMIT_HITS, WITHOUT_GROUPING } from "../../../../constants/logs";
+import { LOGS_LIMIT_HITS, WITHOUT_GROUPING } from "../../../../constants/logs";
 
 enum  HITS_PARAMS {
   TOP = "top_hits",
   GROUP = "group_hits",
-  BARS_COUNT = "bars_count",
+  STEP = "step",
 }
 
 export const useHitsChartConfig = () => {
@@ -16,24 +16,22 @@ export const useHitsChartConfig = () => {
     return Number.isFinite(n) && n > 0 ? n : LOGS_LIMIT_HITS;
   }, [searchParams]);
 
-  const barsCount = useMemo(() => {
-    const n = Number(searchParams.get(HITS_PARAMS.BARS_COUNT));
-    return Number.isFinite(n) && n > 0 ? n : LOGS_BAR_COUNT_DEFAULT;
+  const step = useMemo(() => {
+    return searchParams.get(HITS_PARAMS.STEP);
   }, [searchParams]);
 
   const groupFieldHits = searchParams.get(HITS_PARAMS.GROUP) || WITHOUT_GROUPING;
 
   const setValue = useCallback((param: HITS_PARAMS, newValue?: string | number) => {
     setSearchParams(prev => {
+      const prevValue = prev.get(param);
+
+      const nextValue = newValue ? String(newValue) : null;
+      const isEqual = nextValue === prevValue;
+      if (isEqual) return prev;
+
       const next = new URLSearchParams(prev);
-      const currentValue = prev.get(param);
-
-      if (newValue && newValue !== currentValue) {
-        next.set(param, String(newValue));
-      } else {
-        next.delete(param);
-      }
-
+      nextValue ? next.set(param, nextValue) : next.delete(param);
       return next;
     });
   }, [setSearchParams]);
@@ -46,13 +44,13 @@ export const useHitsChartConfig = () => {
     setValue(HITS_PARAMS.GROUP, value);
   }, [setValue]);
 
-  const setBarsCount = useCallback((value?: number) => {
-    setValue(HITS_PARAMS.BARS_COUNT, value);
+  const setStep = useCallback((value?: string) => {
+    setValue(HITS_PARAMS.STEP, value);
   }, [setValue]);
 
   return {
     topHits: { value: topHits, set: setTopHits },
     groupFieldHits: { value: groupFieldHits, set: setGroupFieldHits },
-    barsCount: { value: barsCount, set: setBarsCount },
+    step: { value: step, set: setStep },
   };
 };

--- a/app/vmui/packages/vmui/src/pages/QueryPage/QueryPage.tsx
+++ b/app/vmui/packages/vmui/src/pages/QueryPage/QueryPage.tsx
@@ -40,11 +40,11 @@ const QueryPage: FC = () => {
   const {
     topHits: { value: topHits },
     groupFieldHits: { value: groupFieldHits },
-    barsCount: { value: barsCount },
+    step: { value: step },
   } = useHitsChartConfig();
   const prevTopHits = usePrevious(topHits);
   const prevGroupFieldHits = usePrevious(groupFieldHits);
-  const prevBarsCount = usePrevious(barsCount);
+  const prevStep = usePrevious(step);
 
   const [searchParams] = useSearchParams();
 
@@ -98,7 +98,7 @@ const QueryPage: FC = () => {
     if (flags.hits) {
       await fetchLogHits({
         period,
-        barsCount,
+        step,
         field: groupFieldHits,
         fieldsLimit: topHits,
         queryMode: graphQueryMode,
@@ -188,17 +188,17 @@ const QueryPage: FC = () => {
     if (hideChart) return;
     // TODO: refactor effect logic
     const topChanged = prevTopHits && (topHits !== prevTopHits);
-    const barsCountChanged = prevBarsCount && (barsCount !== prevBarsCount);
+    const stepChanged = prevStep && (step !== prevStep);
     const groupChanged = prevGroupFieldHits && (groupFieldHits !== prevGroupFieldHits);
     const becameVisible = prevHideChart && !hideChart;
     const queryModeChanged = prevGraphMode && (graphQueryMode !== prevGraphMode);
 
-    if (!(topChanged || groupChanged || becameVisible || queryModeChanged || barsCountChanged)) return;
+    if (!(topChanged || groupChanged || becameVisible || queryModeChanged || stepChanged)) return;
 
     dataLogHits.abortController.abort?.();
     fetchLogHits({
       period,
-      barsCount,
+      step,
       field: groupFieldHits,
       fieldsLimit: topHits,
       queryMode: graphQueryMode,
@@ -211,8 +211,8 @@ const QueryPage: FC = () => {
     prevGroupFieldHits,
     topHits,
     prevTopHits,
-    barsCount,
-    prevBarsCount,
+    step,
+    prevStep,
     graphQueryMode,
     prevGraphMode,
     fetchLogHits,

--- a/app/vmui/packages/vmui/src/pages/QueryPage/hooks/useFetchLogHits.ts
+++ b/app/vmui/packages/vmui/src/pages/QueryPage/hooks/useFetchLogHits.ts
@@ -22,7 +22,7 @@ interface FetchHitsParams {
   extraParams?: URLSearchParams;
   field?: string;
   fieldsLimit?: number;
-  barsCount: number;
+  step: string | null;
   queryMode?: GRAPH_QUERY_MODE
 }
 
@@ -54,13 +54,13 @@ export const useFetchLogHits = (defaultQuery = "*") => {
     }
   }, [serverUrl]);
 
-  const getOptions = ({ query = defaultQuery, period, extraParams, signal, fieldsLimit, field, barsCount }: OptionsParams) => {
-    const { start, end, step } = getHitsTimeParams(period, barsCount);
+  const getOptions = ({ query = defaultQuery, period, extraParams, signal, fieldsLimit, field, step }: OptionsParams) => {
+    const { start, end, step: fallbackStepMs } = getHitsTimeParams(period);
     const offsetMinutes = dayjs().tz().utcOffset();
 
     const params = new URLSearchParams({
       query: query.trim(),
-      step: `${step}ms`,
+      step: step || `${fallbackStepMs}ms`,
       offset: `${offsetMinutes}m`,
       start: start.toISOString(),
       end: end.toISOString(),
@@ -107,6 +107,10 @@ export const useFetchLogHits = (defaultQuery = "*") => {
     abortControllerRef.current.abort();
     abortControllerRef.current = new AbortController();
     const { signal } = abortControllerRef.current;
+
+    if (!params.step) {
+      console.warn("Missing step; using fallback interval", params.period);
+    }
 
     const id = Date.now();
     setIsLoading(prev => ({ ...prev, [id]: true }));

--- a/app/vmui/packages/vmui/src/utils/intervals.test.ts
+++ b/app/vmui/packages/vmui/src/utils/intervals.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { generateIntervalsMs } from "./intervals";
+
+function expectStrictlyIncreasing(values: number[]) {
+  for (let i = 1; i < values.length; i++) {
+    expect(values[i]).toBeGreaterThan(values[i - 1]);
+  }
+}
+
+function expectAllFinitePositive(values: number[]) {
+  for (const value of values) {
+    expect(Number.isFinite(value)).toBe(true);
+    expect(value).toBeGreaterThan(0);
+  }
+}
+
+describe("generateIntervalsMs", () => {
+  it("returns [] for zero-length or invalid ranges", () => {
+    expect(generateIntervalsMs(0, 0)).toEqual([]);
+    expect(generateIntervalsMs(Number.NaN, 10)).toEqual([]);
+    expect(generateIntervalsMs(10, Number.NaN)).toEqual([]);
+    expect(generateIntervalsMs(Number.POSITIVE_INFINITY, 10)).toEqual([]);
+    expect(generateIntervalsMs(10, Number.NEGATIVE_INFINITY)).toEqual([]);
+  });
+
+  it("does not depend on start/end order", () => {
+    expect(generateIntervalsMs(100, 10_000)).toEqual(
+      generateIntervalsMs(10_000, 100),
+    );
+  });
+
+  it("returns 7 unique ascending intervals for a valid range", () => {
+    const out = generateIntervalsMs(0, 10 * 24 * 60 * 60); // 10 days
+
+    expect(out).toHaveLength(7);
+    expect(new Set(out).size).toBe(7);
+    expectStrictlyIncreasing(out);
+    expectAllFinitePositive(out);
+  });
+
+  it("allows sub-500ms intervals for ranges below 1 minute", () => {
+    const out = generateIntervalsMs(0, 10); // 10 seconds
+
+    expect(out).toHaveLength(7);
+    expectStrictlyIncreasing(out);
+    expect(out.some((v) => v < 500)).toBe(true);
+  });
+
+  it("does not use intervals below 500ms for ranges >= 1 minute", () => {
+    const out = generateIntervalsMs(0, 60); // exactly 1 minute
+
+    expect(out).toHaveLength(7);
+    expectStrictlyIncreasing(out);
+    expect(Math.min(...out)).toBeGreaterThanOrEqual(500);
+  });
+
+  it("keeps the exact regression output for a 5-minute range", () => {
+    const start = 1771418375.671;
+    const end = 1771418675.671; // +300s
+
+    expect(generateIntervalsMs(start, end)).toEqual([
+      500, 1000, 2000, 5000, 10000, 15000, 30000,
+    ]);
+  });
+});

--- a/app/vmui/packages/vmui/src/utils/intervals.ts
+++ b/app/vmui/packages/vmui/src/utils/intervals.ts
@@ -1,0 +1,171 @@
+const TARGET_BARS = 96;
+
+// Seven log2 offsets around the base interval.
+const SCALE_POWERS = [-3, -2, -1, 0, 1, 2, 3] as const;
+
+// For ranges >= 1 minute, do not use intervals below 500 ms.
+const SUBSECOND_CUTOFF_RANGE_MS = 60_000;
+const MIN_INTERVAL_FOR_LONG_RANGES_MS = 500;
+
+// Precompute once at module load.
+const NICE_INTERVALS_MS = buildNiceIntervalsMs();
+
+/**
+ * Input: start/end in UNIX seconds.
+ * Output: 7 ascending intervals in milliseconds.
+ * Returns [] for invalid or zero-length ranges.
+ */
+export function generateIntervalsMs(start: number, end: number): number[] {
+  const rangeMs = Math.abs(end - start) * 1000;
+  if (!Number.isFinite(rangeMs) || rangeMs <= 0) return [];
+
+  const minNice =
+    rangeMs >= SUBSECOND_CUTOFF_RANGE_MS ? MIN_INTERVAL_FOR_LONG_RANGES_MS : 1;
+
+  const nice =
+    minNice <= 1 ? NICE_INTERVALS_MS : NICE_INTERVALS_MS.filter((v) => v >= minNice);
+
+  const base = snapToNice(rangeMs / TARGET_BARS, nice);
+  const picked = SCALE_POWERS.map((p) => snapToNice(base * 2 ** p, nice));
+
+  const uniqSorted = Array.from(new Set(picked)).sort((a, b) => a - b);
+
+  return fillToCount(uniqSorted, nice, 7);
+}
+
+function buildNiceIntervalsMs(): number[] {
+  const SECOND_MS = 1_000;
+  const MINUTE_MS = 60 * SECOND_MS;
+  const HOUR_MS = 60 * MINUTE_MS;
+  const DAY_MS = 24 * HOUR_MS;
+  const APPROX_MONTH_MS = 30 * DAY_MS;
+  const APPROX_YEAR_MS = 365 * DAY_MS;
+
+  const multipliers = [1, 2, 5, 10, 15, 30] as const;
+  const baseUnits = [
+    1, // ms
+    SECOND_MS,
+    MINUTE_MS,
+    HOUR_MS,
+    DAY_MS,
+    7 * DAY_MS, // week
+    APPROX_MONTH_MS, // ~month
+    APPROX_YEAR_MS, // ~year
+  ] as const;
+
+  const intervals = new Set<number>();
+
+  // Base intervals: 1/2/5/10/15/30 * unit.
+  for (const unit of baseUnits) {
+    for (const mult of multipliers) {
+      intervals.add(unit * mult);
+    }
+  }
+
+  // Extra useful intervals.
+  const extras = [
+    100, // 100ms
+    200, // 200ms
+    250, // 250ms
+    500, // 500ms
+    45 * SECOND_MS, // 45s
+    12 * MINUTE_MS, // 12m
+    4 * HOUR_MS, // 4h
+    6 * HOUR_MS, // 6h
+    12 * HOUR_MS, // 12h
+    2 * DAY_MS, // 2d
+    3 * DAY_MS, // 3d
+    14 * DAY_MS, // 14d
+    90 * DAY_MS, // ~3mo
+    180 * DAY_MS, // ~6mo
+    2 * APPROX_YEAR_MS, // 2y
+    5 * APPROX_YEAR_MS, // 5y
+    10 * APPROX_YEAR_MS, // 10y
+  ] as const;
+
+  for (const value of extras) {
+    intervals.add(value);
+  }
+
+  return [...intervals].sort((a, b) => a - b);
+}
+
+function snapToNice(x: number, nice: readonly number[]): number {
+  const first = nice[0];
+  const last = nice[nice.length - 1];
+
+  if (x <= first) return first;
+  if (x >= last) return last;
+
+  const i = lowerBound(nice, x);
+  const upper = nice[i];
+  const lower = nice[i - 1];
+
+  // Prefer the lower value on ties.
+  return x - lower <= upper - x ? lower : upper;
+}
+
+function fillToCount(
+  baseSortedAsc: readonly number[],
+  nice: readonly number[],
+  count: number,
+): number[] {
+  if (count <= 0) return [];
+  if (nice.length === 0) return [];
+  if (baseSortedAsc.length === 0) return nice.slice(0, count);
+
+  if (baseSortedAsc.length >= count) {
+    return baseSortedAsc.slice(0, count);
+  }
+
+  const set = new Set(baseSortedAsc);
+  const out = [...baseSortedAsc];
+
+  // Expand from the median anchor to nearby values in `nice`.
+  const anchor = baseSortedAsc[Math.floor(baseSortedAsc.length / 2)];
+  const idx = lowerBound(nice, anchor);
+
+  const anchorExistsInNice = idx < nice.length && nice[idx] === anchor;
+
+  let left = idx - 1;
+  let right = anchorExistsInNice ? idx + 1 : idx;
+
+  while (out.length < count && (left >= 0 || right < nice.length)) {
+    if (left >= 0) {
+      const v = nice[left--];
+      if (!set.has(v)) {
+        set.add(v);
+        out.push(v);
+      }
+    }
+
+    if (out.length >= count) break;
+
+    if (right < nice.length) {
+      const v = nice[right++];
+      if (!set.has(v)) {
+        set.add(v);
+        out.push(v);
+      }
+    }
+  }
+
+  return out.sort((a, b) => a - b);
+}
+
+function lowerBound(values: readonly number[], target: number): number {
+  let left = 0;
+  let right = values.length;
+
+  while (left < right) {
+    const mid = (left + right) >>> 1;
+
+    if (values[mid] < target) {
+      left = mid + 1;
+    } else {
+      right = mid;
+    }
+  }
+
+  return left;
+}

--- a/app/vmui/packages/vmui/src/utils/logs.ts
+++ b/app/vmui/packages/vmui/src/utils/logs.ts
@@ -1,6 +1,6 @@
 import { TimeParams } from "../types";
 import dayjs from "dayjs";
-import { LOGS_GROUP_BY } from "../constants/logs";
+import { LOGS_BAR_COUNT_DEFAULT, LOGS_GROUP_BY } from "../constants/logs";
 import { LogHits, Logs } from "../api/types";
 import { OTHER_HITS_LABEL } from "../components/Chart/BarHitsChart/hooks/useBarHitsOptions";
 
@@ -77,12 +77,12 @@ export const getAllStreamKeys = (data: Array<Record<string, unknown>>): string[]
   return [...keys];
 };
 
-export const getHitsTimeParams = (period: TimeParams, bars: number) => {
+export const getHitsTimeParams = (period: TimeParams) => {
   const start = dayjs(period.start * 1000);
   const end = dayjs(period.end * 1000);
   const totalMs = Math.max(1, end.diff(start, "ms"));
 
-  const step = Math.max(1, Math.ceil(totalMs / bars));
+  const step = Math.max(1, Math.ceil(totalMs / LOGS_BAR_COUNT_DEFAULT));
 
   return { start, end, step };
 };

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -30,6 +30,7 @@ according to the following docs:
 * FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add `none` option for hit chart grouping and set it as the default. See [#1086](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1086).
 * FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): change group-by toggle behavior to clear grouping instead of resetting it to `_stream`. See [#1059](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1059).
 * FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add stream fields chips to the Log context modal. See [#1065](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1065).
+* FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add an `Interval` selector instead of `Bars` for the logs hits chart. See [#1054](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1054).
 
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix markdown parsing for log lines starting with tabs in group view.
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix timestamp rendering according to the selected timezone. See [#63](https://github.com/VictoriaMetrics/VictoriaLogs/issues/63).


### PR DESCRIPTION
### Describe Your Changes

* The `Bars` selector was replaced with `Interval`.
* `Top N` is now shown only when grouping or stats is used, and it was moved closer to the grouping setting.
* `Total: N hits` was renamed to `Total: N`.
* `Duration` was renamed to `Query time`.

**Interval**:

* Instead of selecting the number of bars (`Bars`), the user now selects the interval directly.
* For the selected time range, the UI automatically generates 7 interval options (from more detailed to more coarse) to quickly adjust chart density.
* For a 24h range, these values match the previous Bars behavior (`[12, 24, 48, 96, 288, 720, 1440]`).
* For other ranges, the values are calculated using the same logic and scaled to the selected time range.

<img width="1806" height="369" alt="image" src="https://github.com/user-attachments/assets/9d209b09-6109-4365-907f-e9e372a35889" />

Related issue: #1054

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
