### PR TITLE
docs: wrap vlagent with backticks

### DIFF
--- a/docs/victorialogs/Roadmap.md
+++ b/docs/victorialogs/Roadmap.md
@@ -16,7 +16,7 @@ aliases:
 
 - [ ] Ability to store data to object storage (such as S3, GCS, Minio).
 - [ ] Native support for ingesting logs via the Splunk HTTP Event Collector (HEC) into VictoriaLogs (PR [#710](https://github.com/VictoriaMetrics/VictoriaLogs/pull/710)).
-- [ ] Support for log transformations in vlagent (issue [#858](https://github.com/VictoriaMetrics/VictoriaLogs/issues/858)).
+- [ ] Support for log transformations in `vlagent` (issue [#858](https://github.com/VictoriaMetrics/VictoriaLogs/issues/858)).
 - [ ] Migration tooling from other logging systems to VictoriaLogs (similar to [vmctl](https://docs.victoriametrics.com/victoriametrics/vmctl/)).
-- [ ] Kafka support in vlagent (issue [#885](https://github.com/VictoriaMetrics/VictoriaLogs/issues/885)).
+- [ ] Kafka support in `vlagent` (issue [#885](https://github.com/VictoriaMetrics/VictoriaLogs/issues/885)).
 - [ ] Per-tenant stats (issue [#65](https://github.com/VictoriaMetrics/VictoriaLogs/issues/65)) for quotas (ingest rate, stream cardinality, query cost).

--- a/docs/victorialogs/vlagent-metrics.md
+++ b/docs/victorialogs/vlagent-metrics.md
@@ -17,7 +17,7 @@ aliases:
 - /victorialogs/vlagent-metrics/
 ---
 
-This document provides a comprehensive reference for all metrics exposed by vlagent at the `http://localhost:9429/metrics` endpoint.
+This document provides a comprehensive reference for all metrics exposed by `vlagent` at the `http://localhost:9429/metrics` endpoint.
 These metrics follow the Prometheus exposition format and can be used for monitoring, alerting, and performance analysis of log collection and remote write operations.
 
 ## Remote Write Metrics

--- a/docs/victorialogs/vlagent.md
+++ b/docs/victorialogs/vlagent.md
@@ -146,7 +146,7 @@ While it is recommended to keep the default stream fields, you can override them
 
 ### Filtering Kubernetes logs
 
-vlagent allows filtering Kubernetes container logs based on metadata fields. 
+`vlagent` allows filtering Kubernetes container logs based on metadata fields.
 It is applied before reading the log files, which saves CPU and I/O resources by skipping unwanted data.
 
 Supported metadata fields:
@@ -177,12 +177,12 @@ Example usage:
   -kubernetesCollector.excludeFilter='kubernetes.pod_annotations.logging.vlagent.io/exclude:=true or kubernetes.pod_namespace:in(test, logging)'
 ```
 
-This command starts vlagent with a filter that excludes logs from pods labeled with `logging.vlagent.io/exclude: true` 
+This command starts `vlagent` with a filter that excludes logs from pods labeled with `logging.vlagent.io/exclude: true`
 and skips all logs from the `test` and `logging` namespaces.
 
 ### Kubernetes metadata configuration
 
-vlagent automatically enriches collected logs with Kubernetes metadata. 
+`vlagent` automatically enriches collected logs with Kubernetes metadata.
 You can control which metadata fields are attached to every log entry using the following flags:
 
 * `-kubernetesCollector.includePodLabels` (default: `true`) - attach Pod labels to every log entry.
@@ -190,8 +190,8 @@ You can control which metadata fields are attached to every log entry using the 
 * `-kubernetesCollector.includeNodeLabels` (default: `false`) - attach Node labels to every log entry.
 * `-kubernetesCollector.includeNodeAnnotations` (default: `false`) - attach Node annotations to every log entry.
 
-Note that vlagent does not update node or pod labels during runtime. 
-Therefore, if node/pod metadata changes, you must restart vlagent to apply those changes.
+Note that `vlagent` does not update node or pod labels during runtime.
+Therefore, if node/pod metadata changes, you must restart `vlagent` to apply those changes.
 
 ## remote write format
 
@@ -379,7 +379,7 @@ It is safe to share the collected profiles from a security point of view, since 
 
 ## Building from source code
 
-Follow these steps to build vlagent from source code:
+Follow these steps to build `vlagent` from source code:
 
 - Check out the VictoriaLogs source code:
 
@@ -394,7 +394,7 @@ Follow these steps to build vlagent from source code:
   git checkout <commit-hash-here>
   ```
 
-- Build vlagent (requires Go to be installed on your computer. See [how to install Go](https://golang.org/doc/install)):
+- Build `vlagent` (requires Go to be installed on your computer. See [how to install Go](https://golang.org/doc/install)):
 
   ```sh
   make vlagent
@@ -406,7 +406,7 @@ Follow these steps to build vlagent from source code:
   bin/vlagent -remoteWrite.url=...
   ```
 
-An alternative approach is to build vlagent inside a Docker builder container. This approach doesn't require Go to be installed,
+An alternative approach is to build `vlagent` inside a Docker builder container. This approach doesn't require Go to be installed,
 but it does require Docker on your computer. See [how to install Docker](https://docs.docker.com/engine/install/):
 
 ```sh


### PR DESCRIPTION
### Describe Your Changes

This PR wraps `vlagent` in backticks for consistency.

However, I'd prefer to remove them because vlagent is the name of a product, not a command or a code snippet. By this logic, we would have to wrap FluentBit, Vector, and ClickHouse in backticks as well.

For context:

```
$ git branch --show-current
master

$ grep -E '`vlagent`' -R ./docs/victorialogs/vlagent.md | wc -l
      57

$ grep -E ' vlagent ' -R ./docs/victorialogs/vlagent.md | wc -l
       6
```

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
