### PR TITLE
Fix documentation of default vlogscli query port

### DIFF
--- a/docs/victorialogs/querying/vlogscli.md
+++ b/docs/victorialogs/querying/vlogscli.md
@@ -32,7 +32,7 @@ tar xzf vlutils-linux-amd64-v1.45.0.tar.gz
 
 ## Configuration
 
-By default `vlogscli` sends queries to [`http://localhost:8429/select/logsql/query`](https://docs.victoriametrics.com/victorialogs/querying/#querying-logs).
+By default `vlogscli` sends queries to [`http://localhost:9428/select/logsql/query`](https://docs.victoriametrics.com/victorialogs/querying/#querying-logs).
 The url to query can be changed via `-datasource.url` command-line flag. For example, the following command instructs
 `vlogscli` sending queries to `https://victoria-logs.some-domain.com/select/logsql/query`:
 


### PR DESCRIPTION
### Describe Your Changes

Docs did not match CLI default

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
