### PR TITLE
logsql: fix panic for _msg:~"." query during query clone/split

### DIFF
--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -44,6 +44,7 @@ Released at 2026-02-23
 * FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): change group-by toggle behavior to clear grouping instead of resetting it to `_stream`. See [#1059](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1059).
 * FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): add stream fields chips to the Log context modal. See [#1065](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1065).
 
+* BUGFIX: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): fix panic for valid query `_msg:~"."` in [VictoriaLogs cluster](https://docs.victoriametrics.com/victorialogs/cluster/). See [#1132](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1132).
 * BUGFIX: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): prevent from `cannot parse already verified regexp` panic when special regexp is passed to [regexp filter](https://docs.victoriametrics.com/victorialogs/logsql/#regexp-filter). See [#1112](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1112).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix markdown parsing for log lines starting with tabs in group view.
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix timestamp rendering according to the selected timezone. See [#63](https://github.com/VictoriaMetrics/VictoriaLogs/issues/63).

--- a/lib/logstorage/parser.go
+++ b/lib/logstorage/parser.go
@@ -3948,6 +3948,10 @@ func isNumberPrefix(s string) bool {
 }
 
 func needQuoteToken(s string) bool {
+	if s == "." {
+		return true
+	}
+
 	sLower := strings.ToLower(s)
 	if _, ok := reservedKeywords[sLower]; ok {
 		return true

--- a/lib/logstorage/parser_test.go
+++ b/lib/logstorage/parser_test.go
@@ -3461,6 +3461,10 @@ func TestQueryClone(t *testing.T) {
 
 	f("*")
 	f("error")
+	f(`"."`)
+	f(`foo:"."`)
+	f(`~"."`)
+	f(`seq(".")`)
 	f("_time:5m error | fields foo, bar")
 	f("ip:in(foo | fields user_ip) bar | stats by (x:1h, y) count(*) if (user_id:contains_any(q:w | fields abc)) as ccc")
 	f("ip:in(foo | fields user_ip) bar | stats by (x:1h, y) count(*) if (user_id:contains_all(q:w | fields abc)) as ccc")


### PR DESCRIPTION
### Describe Your Changes

Fixes https://github.com/VictoriaMetrics/VictoriaLogs/issues/1132

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
