### PR TITLE
app/vlagent/kubernetescollector: fix false EOF errors 

### DIFF
--- a/app/vlagent/kubernetescollector/collector.go
+++ b/app/vlagent/kubernetescollector/collector.go
@@ -98,6 +98,9 @@ func (kc *kubernetesCollector) watchForPodsUpdates(ctx context.Context, resource
 	bt := newBackoffTimer(time.Millisecond*200, time.Second*30)
 	defer bt.stop()
 
+	// errGone is returned when the current resourceVersion is no longer valid.
+	var errGone = errors.New("gone")
+
 	errorFired := false
 
 	handleEvent := func(event watchEvent) error {
@@ -134,7 +137,7 @@ func (kc *kubernetesCollector) watchForPodsUpdates(ctx context.Context, resource
 			if errorMessage.Code == http.StatusGone && resourceVersion != "" {
 				// The resourceVersion is no longer valid, see: https://kubernetes.io/docs/reference/using-api/api-concepts/#410-gone-responses
 				resourceVersion = ""
-				return nil
+				return errGone
 			}
 
 			return fmt.Errorf("unexpected error message: %q", event.Object)
@@ -167,6 +170,9 @@ func (kc *kubernetesCollector) watchForPodsUpdates(ctx context.Context, resource
 			if ctx.Err() != nil {
 				return
 			}
+			if errors.Is(err, errGone) {
+				continue
+			}
 
 			isEOF := errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
 			if isEOF && time.Since(lastEOF) > time.Minute {
@@ -174,7 +180,6 @@ func (kc *kubernetesCollector) watchForPodsUpdates(ctx context.Context, resource
 				// This is expected to happen from time to time.
 				// Ignore EOF errors happening not more often than once per minute.
 				lastEOF = time.Now()
-				logger.Errorf("ignoring EOF error from Kubernetes API: %s", err)
 				continue
 			}
 

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -22,6 +22,8 @@ according to the following docs:
 
 ## tip
 
+* BUGFIX: [Kubernetes Collector](https://docs.victoriametrics.com/victorialogs/vlagent/#collect-kubernetes-pod-logs): fix spurious `cannot parse WatchEvent json response: EOF` errors in logs. These errors were harmless but could cause confusion when monitoring application health.
+
 ## [v1.47.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.47.0)
 
 Released at 2026-02-25


### PR DESCRIPTION
### Describe Your Changes

Fix false `EOF` errors when watching Kubernetes Pod events.

Previously, receiving a 410 Gone response from the Kubernetes API caused the watch stream to return nil from the event handler, which led to the following EOF error being logged incorrectly as a real failure.

The fix introduces an ` errGone ` error returned when a 410 Gone response is received. This causes readEvents to stop immediately and the main loop to reconnect silently without logging a spurious error.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
