### PR TITLE
app/vlagent/kubernetescollector: exclude containers earlier 

### DIFF
--- a/app/vlagent/kubernetescollector/collector.go
+++ b/app/vlagent/kubernetescollector/collector.go
@@ -28,6 +28,10 @@ type kubernetesCollector struct {
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 
+	// excludeFilter specifies criteria for excluding containers from processing, matched against common metadata fields.
+	// See getCommonFields for available fields.
+	excludeFilter *logstorage.Filter
+
 	// logsPath is the path to the directory containing Kubernetes container logs.
 	// This is typically /var/log/containers in standard Kubernetes deployments,
 	// but may vary depending on the vlagent mount configuration.
@@ -55,18 +59,19 @@ func startKubernetesCollector(client *kubeAPIClient, currentNodeName, logsPath, 
 	}
 
 	kc := &kubernetesCollector{
-		client:      client,
-		currentNode: currentNode,
-		ctx:         ctx,
-		cancel:      cancel,
-		logsPath:    logsPath,
+		client:        client,
+		currentNode:   currentNode,
+		ctx:           ctx,
+		cancel:        cancel,
+		excludeFilter: excludeFilter,
+		logsPath:      logsPath,
 	}
 
 	storage := &remotewrite.Storage{}
 	newProcessor := func(commonFields []logstorage.Field) processor {
 		return newLogFileProcessor(storage, commonFields)
 	}
-	fc := startFileCollector(checkpointsPath, excludeFilter, newProcessor)
+	fc := startFileCollector(checkpointsPath, newProcessor)
 	kc.fileCollector = fc
 
 	pl, err := client.getNodePods(ctx, currentNodeName)
@@ -195,6 +200,10 @@ func (kc *kubernetesCollector) watchForPodsUpdates(ctx context.Context, resource
 func (kc *kubernetesCollector) startReadPodLogs(pod pod) {
 	startRead := func(pc podContainer, cs containerStatus) {
 		commonFields := getCommonFields(kc.currentNode, pod, cs)
+		if kc.excludeFilter != nil && kc.excludeFilter.MatchRow(commonFields) {
+			// Filter matches - skip this container.
+			return
+		}
 
 		filePath := kc.getLogFilePath(pod, pc, cs)
 

--- a/app/vlagent/kubernetescollector/file_collector.go
+++ b/app/vlagent/kubernetescollector/file_collector.go
@@ -39,13 +39,6 @@ type fileCollector struct {
 	logFiles     map[string]struct{}
 	logFilesLock sync.Mutex
 
-	// excludeFilter defines the criteria for excluding log files from processing.
-	// It matches against common metadata fields associated with the log source,
-	// such as 'kubernetes.container_name', 'kubernetes.pod_node_name', or 'kubernetes.pod_namespace'.
-	//
-	// See getCommonFields for the full list of available metadata fields.
-	excludeFilter *logstorage.Filter
-
 	newProcessor func(commonFields []logstorage.Field) processor
 
 	checkpointsDB *checkpointsDB
@@ -60,7 +53,7 @@ type fileCollector struct {
 // The fileCollector maintains a checkpoint file that serves as persistent state storage.
 // This allows resuming log reading from the exact position where it was interrupted
 // when vlagent is restarted, preventing duplication.
-func startFileCollector(checkpointsPath string, excludeFilter *logstorage.Filter, newProcessor func(commonFields []logstorage.Field) processor) *fileCollector {
+func startFileCollector(checkpointsPath string, newProcessor func(commonFields []logstorage.Field) processor) *fileCollector {
 	checkpointsDB, err := startCheckpointsDB(checkpointsPath)
 	if err != nil {
 		logger.Panicf("FATAL: cannot start checkpoints DB: %s", err)
@@ -68,7 +61,6 @@ func startFileCollector(checkpointsPath string, excludeFilter *logstorage.Filter
 
 	return &fileCollector{
 		logFiles:      make(map[string]struct{}),
-		excludeFilter: excludeFilter,
 		newProcessor:  newProcessor,
 		checkpointsDB: checkpointsDB,
 		stopCh:        make(chan struct{}),
@@ -180,12 +172,6 @@ func getFileFingerprint(f *os.File) uint64 {
 
 func (fc *fileCollector) process(lf *logFile, commonFields []logstorage.Field) {
 	defer lf.close()
-
-	if fc.excludeFilter != nil && fc.excludeFilter.MatchRow(commonFields) {
-		// Filter matches - skip this file.
-		fc.forgetFile(lf.path)
-		return
-	}
 
 	bt := newBackoffTimer(time.Millisecond*100, time.Second*10)
 	defer bt.stop()

--- a/app/vlagent/kubernetescollector/file_collector_test.go
+++ b/app/vlagent/kubernetescollector/file_collector_test.go
@@ -25,7 +25,7 @@ func TestFileCollector(t *testing.T) {
 			return pw
 		}
 
-		fc := startFileCollector(checkpointsPath, nil, newProc)
+		fc := startFileCollector(checkpointsPath, newProc)
 
 		fc.startRead(logFilePath, nil)
 		pw.wait()
@@ -84,7 +84,7 @@ func TestCommitPartialLines(t *testing.T) {
 			return pw
 		}
 
-		fc := startFileCollector(checkpointsPath, nil, newProc)
+		fc := startFileCollector(checkpointsPath, newProc)
 		fc.startRead(logFilePath, nil)
 
 		pw.wait()
@@ -153,7 +153,7 @@ func TestRestoringFromFingerprint(t *testing.T) {
 			_ = f.Sync()
 			_ = f.Close()
 
-			fc := startFileCollector(checkpointsPath, nil, newProc)
+			fc := startFileCollector(checkpointsPath, newProc)
 			fc.startRead(logFilePath, nil)
 			pw.wait()
 			fc.stop()


### PR DESCRIPTION
### Describe Your Changes

Exclude containers earlier to avoid creating goroutines for them.

This shouldn't impact performance, but it should make the code clearer, so I'm not mentioning this change in the changelog.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
