### PR TITLE
logsql: prevent stack overflow on too deep nested queries

### DIFF
--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -28,6 +28,7 @@ according to the following docs:
 * FEATURE: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): add [`last`](https://docs.victoriametrics.com/victorialogs/logsql/#last-running_stats) function at the [`running_stats` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#running_stats-pipe). This can be used for comparing sequential log field values. See [#932](https://github.com/VictoriaMetrics/VictoriaLogs/issues/932).
 
 * BUGFIX: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): fix panic when executing the query `_stream_id:in`. See [#1136](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1136).
+* BUGFIX: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): prevent stack overflow on too deep nested queries.
 * BUGFIX: fix VictoriaLogs Docker OCI labels `org.opencontainers.image.source` and `org.opencontainers.image.documentation`: point them to VictoriaLogs repo/docs instead of VictoriaMetrics.
 * BUGFIX: [Kubernetes Collector](https://docs.victoriametrics.com/victorialogs/vlagent/#collect-kubernetes-pod-logs): fix spurious `cannot parse WatchEvent json response: EOF` errors in logs. These errors were harmless but could cause confusion when monitoring application health.
 * BUGFIX: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): preserve existing target field values for `extract if (...)` and `extract_regexp if (...)` when the `if (...)` condition doesn't match. See [#1153](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1153).

--- a/lib/logstorage/parser.go
+++ b/lib/logstorage/parser.go
@@ -48,7 +48,12 @@ type lexer struct {
 
 	// opts is a stack of options for nested parsed queries
 	optss []*queryOptions
+
+	// nestedDepth prevents stack overflow on deeply nested parenthesized filters and subqueries.
+	nestedDepth int
 }
+
+const maxNestedDepth = 1000
 
 type lexerState struct {
 	lex lexer
@@ -75,6 +80,19 @@ func (lex *lexer) pushQueryOptions(opts *queryOptions) {
 
 func (lex *lexer) popQueryOptions() {
 	lex.optss = lex.optss[:len(lex.optss)-1]
+}
+
+func (lex *lexer) incNestedDepth() error {
+	lex.nestedDepth++
+	if lex.nestedDepth > maxNestedDepth {
+		// The parser descends recursively through nested groups, so reject pathological depth early.
+		return fmt.Errorf("too deep query nesting; it mustn't exceed %d", maxNestedDepth)
+	}
+	return nil
+}
+
+func (lex *lexer) decNestedDepth() {
+	lex.nestedDepth--
 }
 
 func (lex *lexer) getQueryOptions() *queryOptions {
@@ -1829,6 +1847,10 @@ func parseQueryInParens(lex *lexer) (*Query, error) {
 	if !lex.isKeyword("(") {
 		return nil, fmt.Errorf("missing '('")
 	}
+	if err := lex.incNestedDepth(); err != nil {
+		return nil, err
+	}
+	defer lex.decNestedDepth()
 	lex.nextToken()
 
 	q, err := parseQuery(lex)
@@ -2212,6 +2234,10 @@ func parseFilterPhrase(lex *lexer, fieldName string) (filter, error) {
 }
 
 func parseFilterParens(lex *lexer, fieldName string) (filter, error) {
+	if err := lex.incNestedDepth(); err != nil {
+		return nil, err
+	}
+	defer lex.decNestedDepth()
 	lex.nextToken()
 
 	f, err := parseFilterOr(lex, fieldName)

--- a/lib/logstorage/parser_test.go
+++ b/lib/logstorage/parser_test.go
@@ -2649,6 +2649,16 @@ func TestParseQuery_Failure(t *testing.T) {
 	f(`contains_all(x | limit 10)`)
 	f(`contains_all(x | fields a,b)`)
 
+	// prevent stack overflow on too deep nested filters and nested subqueries
+	s := strings.Repeat("(", maxNestedDepth+1) + "a" + strings.Repeat(")", maxNestedDepth+1)
+	f(s)
+
+	q := "* | fields x"
+	for i := 0; i < maxNestedDepth+1; i++ {
+		q = "x:in(" + q + ") | fields x"
+	}
+	f(q)
+
 	// invalid ipv4_range
 	f(`ipv4_range(`)
 	f(`ipv4_range(foo,bar)`)


### PR DESCRIPTION
### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
