### PR TITLE
app/vlagent/remotewrite: include missing `_time` field when using `jsonline` format

### DIFF
--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -36,6 +36,7 @@ according to the following docs:
 * BUGFIX: fix VictoriaLogs Docker OCI labels `org.opencontainers.image.source` and `org.opencontainers.image.documentation`: point them to VictoriaLogs repo/docs instead of VictoriaMetrics.
 * BUGFIX: [Kubernetes Collector](https://docs.victoriametrics.com/victorialogs/vlagent/#collect-kubernetes-pod-logs): fix spurious `cannot parse WatchEvent json response: EOF` errors in logs. These errors were harmless but could cause confusion when monitoring application health.
 * BUGFIX: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): preserve existing target field values for `extract if (...)` and `extract_regexp if (...)` when the `if (...)` condition doesn't match. See [#1153](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1153).
+* BUGFIX: [vlagent](https://docs.victoriametrics.com/victorialogs/vlagent/): include missing `_time` field for outgoing logs when using [jsonline format](https://docs.victoriametrics.com/victorialogs/vlagent/#remote-write-format). Previously, `vlagent` omitted the `_time` field when sending logs to remote storage in this format.
 
 ## [v1.47.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.47.0)
 

--- a/lib/logstorage/log_rows.go
+++ b/lib/logstorage/log_rows.go
@@ -709,7 +709,24 @@ func (r *InsertRow) Marshal(dst []byte) []byte {
 
 // AppendJSON appends marshaled r to dst in JSON format and returns the result.
 func (r *InsertRow) AppendJSON(dst []byte) []byte {
-	return MarshalFieldsToJSON(dst, r.Fields)
+	fields := r.Fields
+	fields = SkipLeadingFieldsWithoutValues(fields)
+
+	dst = append(dst, `{"_time":"`...)
+	dst = marshalTimestampRFC3339NanoString(dst, r.Timestamp)
+	dst = append(dst, '"')
+
+	for i := range fields {
+		f := &fields[i]
+		if f.Value == "" {
+			// Skip fields without values
+			continue
+		}
+		dst = append(dst, ',')
+		dst = f.marshalToJSON(dst)
+	}
+	dst = append(dst, '}')
+	return dst
 }
 
 // UnmarshalInplace unmarshals r from src and returns the remaining tail.

--- a/lib/logstorage/log_rows_test.go
+++ b/lib/logstorage/log_rows_test.go
@@ -348,3 +348,62 @@ func TestInsertRow_MarshalUnmarshal(t *testing.T) {
 		t.Fatalf("unexpected tail left after unmarshaling InsertRow; len(tail)=%d; tail=%X", len(tail), tail)
 	}
 }
+
+func TestInsertRow_MarshalJSON(t *testing.T) {
+	f := func(ts int64, fields []Field, expected string) {
+		t.Helper()
+
+		r := InsertRow{
+			Timestamp: ts,
+			Fields:    fields,
+		}
+		got := r.AppendJSON(nil)
+
+		if string(got) != expected {
+			t.Fatalf("unexpected result\ngot\n%q\nwant\n%q", got, expected)
+		}
+	}
+
+	// empty fields
+	f(0, nil, `{"_time":"1970-01-01T00:00:00Z"}`)
+
+	// non-empty fields
+	f(123456789, []Field{
+		{
+			Name:  "x",
+			Value: "y",
+		},
+		{
+			Name:  "qwe",
+			Value: "rty",
+		},
+	}, `{"_time":"1970-01-01T00:00:00.123456789Z","x":"y","qwe":"rty"}`)
+
+	// empty values
+	f(123456789, []Field{
+		{
+			Name:  "x",
+			Value: "",
+		},
+		{
+			Name:  "qwe",
+			Value: "",
+		},
+	}, `{"_time":"1970-01-01T00:00:00.123456789Z"}`)
+
+	// empty field name
+	f(123456789, []Field{
+		{
+			Name:  "",
+			Value: "y",
+		},
+	}, `{"_time":"1970-01-01T00:00:00.123456789Z","_msg":"y"}`)
+
+	// escape quotes
+	f(123456789, []Field{
+		{
+			Name:  "x",
+			Value: `"y"`,
+		},
+	}, `{"_time":"1970-01-01T00:00:00.123456789Z","x":"\"y\""}`)
+}


### PR DESCRIPTION
### Describe Your Changes

Previously, `vlagent` omitted the `_time` field when sending logs to remote storage in this format.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
