### PR TITLE
app/vlstorage: clone _time field values

### DIFF
--- a/app/vlstorage/lastnoptimization.go
+++ b/app/vlstorage/lastnoptimization.go
@@ -185,7 +185,7 @@ func getLogRowsFromDataBlock(db *logstorage.DataBlock) ([]logRow, error) {
 		// The _time column must go first, since the query results are sorted by _time.
 		fieldsBuf = append(fieldsBuf, logstorage.Field{
 			Name:  "_time",
-			Value: timestampsColumn.Values[i],
+			Value: strings.Clone(timestampsColumn.Values[i]),
 		})
 
 		for j, c := range columns {


### PR DESCRIPTION
### Describe Your Changes

This commit fixes a bug in buffer reuse that could cause `_time` field to become invalid. The bug was introduced in 885f548f3f8de4bc5dc20c8e188b5a908bcf5d81 . See:

<img width="1280" height="375" alt="image" src="https://github.com/user-attachments/assets/d8795a9c-23a2-4e79-b739-213a1013e626" />


Changelog hasn't been updated because the commit hasn't been released yet.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
