### PR TITLE
lib/logstorage: do not store _time field values as a separate data column

### DIFF
--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -22,7 +22,7 @@ according to the following docs:
 
 ## tip
 
-* BUGFIX: [data ingestion](https://docs.victoriametrics.com/victorialogs/data-ingestion/): fix mismatched timestamps when the `_time` field is used without being defined in [`VL-Time-Field`](https://docs.victoriametrics.com/victorialogs/data-ingestion/) or [`_time_field`](https://docs.victoriametrics.com/victorialogs/data-ingestion/) parameter. Previously, VictoriaLogs could store and return timestamps that didn't match the actual log time in such cases.
+* BUGFIX: [data ingestion](https://docs.victoriametrics.com/victorialogs/data-ingestion/): properly handle the case when the ingested logs contain `_time` field without the real timestamp, and this field is not mentioned in the `_time_field` query arg or in the `VL-Time-Field` request header according to [these docs](https://docs.victoriametrics.com/victorialogs/data-ingestion/#http-parameters). Previously this could lead to unexpected errors during querying such as `missing _time field in the query results`. See [#1168](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1168).
 
 ## [v1.48.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.48.0)
 

--- a/lib/logstorage/log_rows.go
+++ b/lib/logstorage/log_rows.go
@@ -483,6 +483,7 @@ func (lr *LogRows) addFieldsInternal(fields []Field, ignoreFields, decolorizeFie
 		}
 		if f.Name == "_time" {
 			// Values for the _time field are stored in lr.timestamps
+			// See https://github.com/VictoriaMetrics/VictoriaLogs/issues/1168
 			continue
 		}
 


### PR DESCRIPTION
### Describe Your Changes

Fixes #1168.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
