### PR TITLE
dashboards: do not override all value for job selector

### DIFF
--- a/dashboards/victorialogs-cluster.json
+++ b/dashboards/victorialogs-cluster.json
@@ -10552,7 +10552,6 @@
         "type": "datasource"
       },
       {
-        "allValue": "",
         "current": {},
         "datasource": {
           "type": "prometheus",

--- a/dashboards/vm/victorialogs-cluster.json
+++ b/dashboards/vm/victorialogs-cluster.json
@@ -10553,7 +10553,6 @@
         "type": "datasource"
       },
       {
-        "allValue": "",
         "current": {},
         "datasource": {
           "type": "victoriametrics-metrics-datasource",


### PR DESCRIPTION
### Describe Your Changes

Overriding all value to `.*` forces dashboard to select metrics from `job=~".*"` and leads to confusion when metrics are duplicated in VictoriaMetrics/VictoriaTraces and VictoriaLogs. For exmaple, list of instances will show all components instead of VictoriaLogs only.

Removed override, so that Grafana builds regex-based OR match to pick only specific jobs. List of jobs for VictoriaLogs is usually quite short, so regex should perform well.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
