### PR TITLE
app/vlagent/kubernetescollector: expose metrics of the log file processor

### DIFF
--- a/app/vlagent/kubernetescollector/file_collector.go
+++ b/app/vlagent/kubernetescollector/file_collector.go
@@ -30,6 +30,11 @@ type processor interface {
 	// ensuring log entries spanning multiple files are handled correctly.
 	tryAddLine(line []byte) bool
 
+	// flush flushes any internally accumulated state.
+	// The caller is responsible for invoking flush when no new log lines are expected for a while,
+	// ensuring the accumulated state is propagated without waiting for the next line.
+	flush()
+
 	// mustClose releases all resources associated with the processor and ensures proper cleanup of internal states.
 	// It must be called after the target log file is deleted or vlagent is shutting down.
 	mustClose()
@@ -197,6 +202,7 @@ func (fc *fileCollector) process(lf *logFile, commonFields []logstorage.Field) {
 		switch lf.status() {
 		case logFileStatusNotRotated:
 			// No more lines to read and file hasn't rotated - wait before checking again.
+			proc.flush()
 			bt.wait(fc.stopCh)
 			continue
 		case logFileStatusRotated:
@@ -335,12 +341,12 @@ func openFileWithInode(p string) (*os.File, uint64, bool) {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, 0, false
 		}
-		logger.Panicf("FATAL: cannot open file %q: %s", p, err)
+		logger.Panicf("FATAL: cannot open file: %s", err)
 	}
 
 	fi, err := f.Stat()
 	if err != nil {
-		logger.Panicf("FATAL: cannot stat file %q: %s", p, err)
+		logger.Panicf("FATAL: cannot stat file: %s", err)
 	}
 	inode := getInode(fi)
 

--- a/app/vlagent/kubernetescollector/file_collector_test.go
+++ b/app/vlagent/kubernetescollector/file_collector_test.go
@@ -226,6 +226,8 @@ func (pw *processorWrapper) tryAddLine(line []byte) bool {
 	return pw.proc.tryAddLine(line)
 }
 
+func (pw *processorWrapper) flush() {}
+
 func (pw *processorWrapper) mustClose() {
 	pw.proc.mustClose()
 }
@@ -246,6 +248,8 @@ func (lfp *testLogFileProcessor) tryAddLine(line []byte) bool {
 	lfp.logLines = append(lfp.logLines, string(line))
 	return true
 }
+
+func (lfp *testLogFileProcessor) flush() {}
 
 func (lfp *testLogFileProcessor) mustClose() {}
 

--- a/app/vlagent/kubernetescollector/logfile_timing_test.go
+++ b/app/vlagent/kubernetescollector/logfile_timing_test.go
@@ -60,4 +60,6 @@ func (noopLogFileHandler) tryAddLine(_ []byte) bool {
 	return true
 }
 
+func (noopLogFileHandler) flush() {}
+
 func (noopLogFileHandler) mustClose() {}

--- a/app/vlagent/kubernetescollector/processor.go
+++ b/app/vlagent/kubernetescollector/processor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fasttime"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
+	"github.com/VictoriaMetrics/metrics"
 	"github.com/valyala/fastjson"
 
 	"github.com/VictoriaMetrics/VictoriaLogs/app/vlinsert/insertutil"
@@ -57,13 +58,17 @@ type logFileProcessor struct {
 	tenantID logstorage.TenantID
 
 	// commonFields are common fields for the given log file.
-	commonFields []logstorage.Field
+	commonFields        []logstorage.Field
+	commonFieldsJSONLen int
 
 	// fieldsBuf is used for constructing log fields from commonFields and the actual log line fields before sending them to VictoriaLogs.
 	fieldsBuf []logstorage.Field
 
 	partialCRIStdout partialCRILineState
 	partialCRIStderr partialCRILineState
+
+	rowsIngestedLocal  int
+	bytesIngestedLocal int
 }
 
 // newLogFileProcessor returns a new logFileProcessor for the given storage.
@@ -76,6 +81,7 @@ func newLogFileProcessor(storage insertutil.LogRowsStorage, commonFields []logst
 		}
 	}
 	commonFields = fs
+	commonFieldsJSONLen := logstorage.EstimatedJSONRowLen(commonFields)
 
 	sfs := getStreamFields()
 	efs := getExtraFields()
@@ -83,10 +89,11 @@ func newLogFileProcessor(storage insertutil.LogRowsStorage, commonFields []logst
 	lr := logstorage.GetLogRows(sfs, *ignoreFields, *decolorizeFields, efs, defaultMsgValue)
 
 	return &logFileProcessor{
-		storage:      storage,
-		lr:           lr,
-		tenantID:     getTenantID(),
-		commonFields: commonFields,
+		storage:             storage,
+		lr:                  lr,
+		tenantID:            getTenantID(),
+		commonFields:        commonFields,
+		commonFieldsJSONLen: commonFieldsJSONLen,
 	}
 }
 
@@ -103,6 +110,7 @@ func (lfp *logFileProcessor) tryAddLine(logLine []byte) bool {
 
 		criLine, err := parseCRILineJSON(parser, logLine)
 		if err != nil {
+			rowsDroppedTotalInvalidCRI.Inc()
 			pod := mustGetFieldValByName(lfp.commonFields, "kubernetes.pod_name")
 			namespace := mustGetFieldValByName(lfp.commonFields, "kubernetes.pod_namespace")
 			invalidCRILineLogger.Errorf("skipping invalid json-file log line %q from Pod %q in Namespace %q: %s; "+
@@ -117,6 +125,7 @@ func (lfp *logFileProcessor) tryAddLine(logLine []byte) bool {
 
 	criLine, err := parseCRILine(logLine)
 	if err != nil {
+		rowsDroppedTotalInvalidCRI.Inc()
 		pod := mustGetFieldValByName(lfp.commonFields, "kubernetes.pod_name")
 		namespace := mustGetFieldValByName(lfp.commonFields, "kubernetes.pod_namespace")
 		lfp.partialCRIStdout.reset()
@@ -195,6 +204,7 @@ func (lfp *logFileProcessor) joinPartialLinesSlow(state *partialCRILineState, cr
 	state.size += len(criLine.content)
 	if state.size > maxLogLineSize {
 		// Discard the too large log line.
+		tooLongLinesSkipped.Inc()
 		pod := mustGetFieldValByName(lfp.commonFields, "kubernetes.pod_name")
 		namespace := mustGetFieldValByName(lfp.commonFields, "kubernetes.pod_namespace")
 		logLineExceedsMaxLineSizeLogger.Warnf("skipping log entry from Pod %q in namespace %q: entry size of %.2f MiB exceeds the maximum allowed size of %d MiB",
@@ -229,10 +239,17 @@ func (lfp *logFileProcessor) addLineInternal(criTimestamp int64, line []byte) {
 	if len(parser.Fields) > 1000 {
 		line := logstorage.MarshalFieldsToJSON(nil, parser.Fields)
 		logger.Warnf("dropping log line with %d fields; %s", len(parser.Fields), line)
+		rowsDroppedTotalTooManyFields.Inc()
 		return
 	}
 
 	lfp.addRow(timestamp, parser.Fields)
+
+	lfp.rowsIngestedLocal++
+	lfp.bytesIngestedLocal += lfp.commonFieldsJSONLen + len(line)
+	if lfp.rowsIngestedLocal > 128 {
+		lfp.flushMetrics()
+	}
 }
 
 func (lfp *logFileProcessor) addRow(timestamp int64, fields []logstorage.Field) {
@@ -430,7 +447,25 @@ func fieldIndex(fields []logstorage.Field, names []string) int {
 	return -1
 }
 
+func (lfp *logFileProcessor) flush() {
+	lfp.flushMetrics()
+}
+
+var rowsIngestedTotal = metrics.GetOrCreateCounter(fmt.Sprintf("vl_rows_ingested_total{type=%q}", "kubernetes_logs"))
+var bytesIngestedTotal = metrics.GetOrCreateCounter(fmt.Sprintf("vl_bytes_ingested_total{type=%q}", "kubernetes_logs"))
+
+func (lfp *logFileProcessor) flushMetrics() {
+	if lfp.rowsIngestedLocal == 0 {
+		return
+	}
+	rowsIngestedTotal.Add(lfp.rowsIngestedLocal)
+	bytesIngestedTotal.Add(lfp.bytesIngestedLocal)
+	lfp.rowsIngestedLocal = 0
+	lfp.bytesIngestedLocal = 0
+}
+
 func (lfp *logFileProcessor) mustClose() {
+	lfp.flush()
 	lfp.partialCRIStdout.reset()
 	lfp.partialCRIStderr.reset()
 	logstorage.PutLogRows(lfp.lr)
@@ -655,3 +690,7 @@ func mustGetFieldValByName(commonFields []logstorage.Field, fieldName string) st
 	}
 	return commonFields[n].Value
 }
+
+var tooLongLinesSkipped = metrics.GetOrCreateCounter("vl_too_long_lines_skipped_total")
+var rowsDroppedTotalTooManyFields = metrics.GetOrCreateCounter(`vl_rows_dropped_total{reason="too_many_fields"}`)
+var rowsDroppedTotalInvalidCRI = metrics.GetOrCreateCounter(`vl_rows_dropped_total{reason="invalid_cri_line"}`)

--- a/app/vlagent/kubernetescollector/processor_timing_test.go
+++ b/app/vlagent/kubernetescollector/processor_timing_test.go
@@ -73,13 +73,13 @@ func benchmarkProcessor(b *testing.B, logLines []string) {
 	storage := &benchmarkStorage{}
 
 	b.RunParallel(func(pb *testing.PB) {
+		proc := newLogFileProcessor(storage, commonFields)
 		for pb.Next() {
-			proc := newLogFileProcessor(storage, commonFields)
 			for _, line := range rawLines {
 				proc.tryAddLine(line)
 			}
-			proc.mustClose()
 		}
+		proc.mustClose()
 	})
 }
 

--- a/app/vlinsert/insertutil/common_params.go
+++ b/app/vlinsert/insertutil/common_params.go
@@ -378,7 +378,7 @@ func (cp *CommonParams) NewLogMessageProcessor(protocolName string, isStreamMode
 
 var (
 	rowsDroppedTotalDebug         = metrics.NewCounter(`vl_rows_dropped_total{reason="debug"}`)
-	rowsDroppedTotalTooManyFields = metrics.NewCounter(`vl_rows_dropped_total{reason="too_many_fields"}`)
+	rowsDroppedTotalTooManyFields = metrics.GetOrCreateCounter(`vl_rows_dropped_total{reason="too_many_fields"}`)
 	_                             = metrics.NewGauge(`vl_insert_processors_count`, func() float64 { return float64(messageProcessorCount.Load()) })
 	messageProcessorCount         atomic.Int64
 )

--- a/app/vlinsert/insertutil/line_reader.go
+++ b/app/vlinsert/insertutil/line_reader.go
@@ -124,7 +124,7 @@ func (lr *LineReader) readMoreData() bool {
 	return n > 0
 }
 
-var tooLongLinesSkipped = metrics.NewCounter("vl_too_long_lines_skipped_total")
+var tooLongLinesSkipped = metrics.GetOrCreateCounter("vl_too_long_lines_skipped_total")
 
 func (lr *LineReader) skipUntilNextLine() (bool, int) {
 

--- a/docs/victorialogs/vlagent-metrics.md
+++ b/docs/victorialogs/vlagent-metrics.md
@@ -20,6 +20,79 @@ aliases:
 This document provides a comprehensive reference for all metrics exposed by `vlagent` at the `http://localhost:9429/metrics` endpoint.
 These metrics follow the Prometheus exposition format and can be used for monitoring, alerting, and performance analysis of log collection and remote write operations.
 
+## Table of Contents
+
+- [HTTP Request Metrics](https://docs.victoriametrics.com/victorialogs/vlagent-metrics/#http-request-metrics)
+- [Data Ingestion Metrics](https://docs.victoriametrics.com/victorialogs/vlagent-metrics/#data-ingestion-metrics)
+- [Error and Network Metrics](https://docs.victoriametrics.com/victorialogs/vlagent-metrics/#error-and-network-metrics)
+
+## HTTP Request Metrics
+
+### vl_http_requests_total
+**Type:** Counter
+
+**Labels:**
+- `path`: `/select/logsql/query`, `/insert/jsonline`, `/insert/loki/api/v1/push`, etc.
+- `format`: `json`, `protobuf`
+
+**Description:** HTTP requests arriving at VictoriaLogs endpoints. Counts all requests immediately when received, before any validation or authentication happens.
+
+### vl_http_errors_total
+**Type:** Counter
+
+**Labels:**
+- `path`: endpoint path
+- `format`: request format when applicable (e.g. `protobuf`)
+
+**Description:** Errors encountered while processing requests for the given endpoint. The counter is incremented by endpoint handlers on non-trivial processing errors (e.g. request decoding/parsing failures or query execution errors) and may differ from the number of HTTP responses with error status. For line-oriented ingestion (e.g. `/insert/jsonline`), it is incremented per invalid log line inside a request.
+
+### vl_http_request_duration_seconds
+**Type:** Summary
+
+**Labels:**
+- `path`: endpoint path
+
+**Description:** Complete time spent processing each HTTP request from start to finish. Includes all processing steps: parsing request data, validating parameters, storing logs, and sending responses. Captured when requests complete successfully.
+
+## Data Ingestion Metrics
+
+### vl_rows_ingested_total
+**Type:** Counter
+
+**Labels:**
+- `type`: `jsonline`, `loki`, `elasticsearch`, `datadog`, `opentelemetry`, `journald`, `syslog`, `kubernetes_logs`
+
+**Description:** Log entries successfully parsed and added to the processing pipeline. Counts all entries that pass initial validation, including debug entries that are processed but not stored when `debug=1` is used.
+
+### vl_bytes_ingested_total
+**Type:** Counter
+
+**Labels:**
+- `type`: `jsonline`, `loki`, `elasticsearch`, `datadog`, `opentelemetry`, `journald`, `syslog`, `kubernetes_logs`
+
+**Description:** Estimated JSON size of ingested log entry fields. Calculated using field name lengths and values to provide consistent volume measurement across different input formats like JSON, Loki, or syslog.
+
+### vl_rows_dropped_total
+**Type:** Counter
+
+**Labels:**
+- `reason`: `debug`, `too_many_fields`, `too_big_timestamp`, `too_small_timestamp`, `invalid_cri_line`
+
+**Description:** Log entries rejected for specific reasons. `debug` counts entries processed with `debug=1` (parsed but not stored). `too_many_fields` counts entries exceeding `-insert.maxFieldsPerLine`. `too_small_timestamp` counts entries older than `-retentionPeriod`. `too_big_timestamp` counts entries newer than `-futureRetention`. `invalid_cri_line` counts entries that fail to parse as CRI-compatible log lines in the [Kubernetes Collector](https://docs.victoriametrics.com/victorialogs/vlagent/#collect-kubernetes-pod-logs) mode.
+
+### vl_insert_flush_duration_seconds
+**Type:** Summary
+
+**Labels:**
+- `type`: ingestion protocol
+
+**Description:** Time taken to flush accumulated logs from memory buffers to storage. Triggered when buffers fill up or during periodic flushes (every ~1 second with jitter). High values suggest storage bottlenecks or slow disk performance.
+
+### vl_too_long_lines_skipped_total
+**Type:** Counter
+
+**Description:** Log lines exceeding `-insert.maxLineSizeBytes` (default 256KB) during parsing. Lines are skipped to prevent memory exhaustion. Indicates malformed data, overly verbose logs, or need to increase the size limit.
+
 ## Remote Write Metrics
 
 ### vlagent_remotewrite_block_size_bytes
@@ -147,6 +220,32 @@ These metrics follow the Prometheus exposition format and can be used for monito
 - `url`: remote storage URL
 
 **Description:** Number of parallel transmission workers configured via `-remoteWrite.queues` flag. Higher values provide more concurrent transmission capacity but consume additional memory and connection resources.
+
+## Error and Network Metrics
+
+### vl_errors_total
+**Type:** Counter
+
+**Labels:**
+- `type`: `syslog`
+
+**Description:** Syslog parsing errors encountered during log line processing. Individual syslog messages that fail to parse due to malformed timestamps, invalid priorities, or other RFC3164/RFC5424 format violations. Syslog data quality monitoring.
+
+### vl_udp_requests_total
+**Type:** Counter
+
+**Labels:**
+- `type`: `syslog`
+
+**Description:** UDP packets received at syslog endpoints configured via `-syslog.listenAddr.udp`. Total network traffic volume to syslog UDP listeners regardless of content validity.
+
+### vl_udp_errors_total
+**Type:** Counter
+
+**Labels:**
+- `type`: `syslog`
+
+**Description:** UDP network errors at syslog endpoints including temporary network failures, connection resets, and socket read failures. Excludes parsing errors which are tracked separately. UDP network connectivity issues.
 
 ## Grafana Dashboards
 


### PR DESCRIPTION
### Describe Your Changes

The new `flush()` method in `LogMessageProcessor` also will allow us to implement stack trace joining.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
