### PR TITLE
logsql: return empty when offset >= rows in last-N optimization

### DIFF
--- a/app/vlstorage/lastnoptimization.go
+++ b/app/vlstorage/lastnoptimization.go
@@ -17,9 +17,10 @@ func runOptimizedLastNResultsQuery(qctx *logstorage.QueryContext, offset, limit 
 	if err != nil {
 		return err
 	}
-	if uint64(len(rows)) > offset {
-		rows = rows[offset:]
+	if offset >= uint64(len(rows)) {
+		return nil
 	}
+	rows = rows[offset:]
 
 	var db logstorage.DataBlock
 	var columns []logstorage.BlockColumn

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -54,6 +54,7 @@ according to the following docs:
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix UI freeze when selecting a long time range.
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): truncate long active filter badges and show full values in tooltip. See [#369](https://github.com/VictoriaMetrics/VictoriaLogs/issues/369#issuecomment-4080410326)
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): show active filters in Stream Fields empty state instead of "No stream fields found".
+* BUGFIX: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): properly apply `offset` when returning the last N logs sorted by `_time desc`, so queries like `| sort by (_time) desc | offset X | limit Y` return empty results when `X` is greater than or equal to the number of matched logs. Previously, such queries could incorrectly return all matched logs. See [#1190](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1190).
 
 ## [v1.48.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.48.0)
 


### PR DESCRIPTION
### Describe Your Changes

Fixes https://github.com/VictoriaMetrics/VictoriaLogs/issues/1190

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
