### PR TITLE
app/vlagent: support interleaved CRI log streams

### DIFF
--- a/app/vlagent/kubernetescollector/processor.go
+++ b/app/vlagent/kubernetescollector/processor.go
@@ -62,11 +62,16 @@ type logFileProcessor struct {
 	// fieldsBuf is used for constructing log fields from commonFields and the actual log line fields before sending them to VictoriaLogs.
 	fieldsBuf []logstorage.Field
 
-	// partialCRIContent accumulates the content of partial CRI log lines.
+	partialCRIStdout partialCRILineState
+	partialCRIStderr partialCRILineState
+}
+
+type partialCRILineState struct {
+	// content accumulates the content of partial CRI log lines.
 	// Can be truncated if it exceeds maxLineSize.
-	partialCRIContent *bytesutil.ByteBuffer
-	// partialCRIContentSize tracks the actual size of the partialCRIContent.
-	partialCRIContentSize int
+	content *bytesutil.ByteBuffer
+	// size tracks the actual size of the content.
+	size int
 }
 
 // newLogFileProcessor returns a new logFileProcessor for the given storage.
@@ -131,56 +136,69 @@ func (lfp *logFileProcessor) tryAddLine(logLine []byte) (bool, error) {
 	}
 
 	lfp.addLineInternal(timestamp, content)
-
-	if lfp.partialCRIContent != nil {
-		partialCRIContentBufPool.Put(lfp.partialCRIContent)
-		lfp.partialCRIContent = nil
+	// Release buffers if possible.
+	if lfp.partialCRIStderr.content != nil && lfp.partialCRIStderr.content.Len() == 0 {
+		lfp.partialCRIStderr.mustClose()
+	}
+	if lfp.partialCRIStdout.content != nil && lfp.partialCRIStdout.content.Len() == 0 {
+		lfp.partialCRIStdout.mustClose()
 	}
 
 	return true, nil
 }
 
 func (lfp *logFileProcessor) joinPartialLines(criLine criLine) (int64, []byte, bool) {
+	state := lfp.getPartialCRILineState(criLine.stream)
+
 	if criLine.partial {
 		// The log line is split into multiple lines.
 		// Accumulate the content until the full line is received.
 
-		if lfp.partialCRIContent == nil {
-			lfp.partialCRIContent = partialCRIContentBufPool.Get()
+		if state.content == nil {
+			state.content = partialCRIContentBufPool.Get()
 		}
 
-		lfp.partialCRIContentSize += len(criLine.content)
-		if lfp.partialCRIContentSize <= maxLogLineSize {
-			lfp.partialCRIContent.MustWrite(criLine.content)
+		state.size += len(criLine.content)
+		if state.size <= maxLogLineSize {
+			state.content.MustWrite(criLine.content)
 		}
 		return 0, nil, false
 	}
 
-	if lfp.partialCRIContent == nil || lfp.partialCRIContent.Len() == 0 {
+	if state.content == nil || state.content.Len() == 0 {
 		// The log line is complete and not split.
 		return criLine.timestamp, criLine.content, true
 	}
 
 	// The final part of the split log line received.
 
-	lfp.partialCRIContentSize += len(criLine.content)
-	if lfp.partialCRIContentSize > maxLogLineSize {
+	state.size += len(criLine.content)
+	if state.size > maxLogLineSize {
 		// Discard the too large log line.
-		reportLogRowSizeExceeded(lfp.commonFields, lfp.partialCRIContentSize)
+		reportLogRowSizeExceeded(lfp.commonFields, state.size)
 
-		lfp.partialCRIContent.Reset()
-		lfp.partialCRIContentSize = 0
+		state.content.Reset()
+		state.size = 0
 
 		return 0, nil, true
 	}
 
-	lfp.partialCRIContent.MustWrite(criLine.content)
-	content := lfp.partialCRIContent.B
+	state.content.MustWrite(criLine.content)
+	content := state.content.B
 
-	lfp.partialCRIContent.Reset()
-	lfp.partialCRIContentSize = 0
+	state.content.Reset()
+	state.size = 0
 
 	return criLine.timestamp, content, true
+}
+
+func (lfp *logFileProcessor) getPartialCRILineState(stream string) *partialCRILineState {
+	if stream == "stderr" {
+		return &lfp.partialCRIStderr
+	}
+	// Should be "stdout", no other stream is expected in CRI logs.
+	// Treat unknown streams as "stdout" to be safe.
+	return &lfp.partialCRIStdout
 }
 
 func (lfp *logFileProcessor) addLineInternal(criTimestamp int64, line []byte) {
@@ -405,13 +423,25 @@ func fieldIndex(fields []logstorage.Field, names []string) int {
 }
 
 func (lfp *logFileProcessor) mustClose() {
+	lfp.partialCRIStdout.mustClose()
+	lfp.partialCRIStderr.mustClose()
 	logstorage.PutLogRows(lfp.lr)
 	lfp.lr = nil
+}
+
+func (pcs *partialCRILineState) mustClose() {
+	if pcs.content != nil {
+		partialCRIContentBufPool.Put(pcs.content)
+		pcs.content = nil
+	}
+	pcs.size = 0
 }
 
 type criLine struct {
 	// timestamp of the log entry, from the perspective of Container Runtime.
 	timestamp int64
+	// stream contains the output stream name such as stdout or stderr.
+	stream string
 	// partial is true if the log line is split into multiple lines.
 	partial bool
 	// content of the log entry.
@@ -435,7 +465,7 @@ func parseCRILine(b []byte) (criLine, error) {
 	if n < 0 {
 		return criLine{}, fmt.Errorf("unexpected end of stream")
 	}
-	// Skip stream value.
+	stream := bytesutil.ToUnsafeString(b[:n])
 	b = b[n+1:]
 
 	n = bytes.IndexByte(b, ' ')
@@ -453,6 +483,7 @@ func parseCRILine(b []byte) (criLine, error) {
 
 	return criLine{
 		timestamp: timestamp,
+		stream:    stream,
 		partial:   partial,
 		content:   content,
 	}, nil

--- a/app/vlagent/kubernetescollector/processor_test.go
+++ b/app/vlagent/kubernetescollector/processor_test.go
@@ -74,6 +74,19 @@ func TestProcessor(t *testing.T) {
 	}
 	f(in, expectedContents)
 
+	// Interleaved streams must keep independent partial state.
+	in = []string{
+		`2025-10-16T15:37:36.1Z stdout P 1`,
+		`2025-10-16T15:37:36.2Z stderr F 2`,
+		`2025-10-16T15:37:36.3Z stdout P 3`,
+		`2025-10-16T15:37:36.4Z stdout F 4`,
+	}
+	expectedContents = []string{
+		`{"_msg":"2","_stream":"{}","_time":"2025-10-16T15:37:36.2Z"}`,
+		`{"_msg":"134","_stream":"{}","_time":"2025-10-16T15:37:36.4Z"}`,
+	}
+	f(in, expectedContents)
+
 	// Max log line size
 	firstLine := strings.Repeat("a", maxLogLineSize/2-len("2025-10-16T15:37:36Z stderr P "))
 	secondLine := strings.Repeat("b", maxLogLineSize/2-len("2025-10-16T15:37:36.330062387Z stderr F "))
@@ -214,7 +227,7 @@ func TestParseKlogFailure(t *testing.T) {
 }
 
 func TestParseCRILine(t *testing.T) {
-	f := func(line string, timestampExpected int64, partialExpected bool, contentExpected string) {
+	f := func(line, streamExpected string, timestampExpected int64, partialExpected bool, contentExpected string) {
 		t.Helper()
 		criLine, err := parseCRILine([]byte(line))
 		if err != nil {
@@ -222,6 +235,9 @@ func TestParseCRILine(t *testing.T) {
 		}
 		if criLine.timestamp != timestampExpected {
 			t.Fatalf("unexpected timestamp; got %d; want %d", criLine.timestamp, timestampExpected)
+		}
+		if criLine.stream != streamExpected {
+			t.Fatalf("unexpected stream; got %q; want %q", criLine.stream, streamExpected)
 		}
 		if criLine.partial != partialExpected {
 			t.Fatalf("unexpected partial; got %v; want %v", criLine.partial, partialExpected)
@@ -232,17 +248,17 @@ func TestParseCRILine(t *testing.T) {
 	}
 
 	// Full line
-	f(`2025-10-16T15:37:36.330062387Z stderr F foo bar`, 1760629056330062387, false, "foo bar")
+	f(`2025-10-16T15:37:36.330062387Z stderr F foo bar`, "stderr", 1760629056330062387, false, "foo bar")
 
 	// Partial line
-	f(`2025-10-16T15:37:36Z stdout P partial log line`, 1760629056000000000, true, "partial log line")
+	f(`2025-10-16T15:37:36Z stdout P partial log line`, "stdout", 1760629056000000000, true, "partial log line")
 
 	// Empty content
-	f(`2025-10-16T15:37:36Z stdout P `, 1760629056000000000, true, "")
+	f(`2025-10-16T15:37:36Z stdout P `, "stdout", 1760629056000000000, true, "")
 
 	// Content with spaces
-	f(`2025-10-16T15:37:36Z stdout F  `, 1760629056000000000, false, " ")
-	f(`2025-10-16T15:37:36Z stdout F      `, 1760629056000000000, false, "     ")
+	f(`2025-10-16T15:37:36Z stdout F  `, "stdout", 1760629056000000000, false, " ")
+	f(`2025-10-16T15:37:36Z stdout F      `, "stdout", 1760629056000000000, false, "     ")
 }
 
 // Storage implements insertutil.LogRowsStorage interface

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -39,6 +39,7 @@ according to the following docs:
 
 * BUGFIX: [data ingestion](https://docs.victoriametrics.com/victorialogs/data-ingestion/): properly handle the case when the ingested logs contain `_time` field without the real timestamp, and this field is not mentioned in the `_time_field` query arg or in the `VL-Time-Field` request header according to [these docs](https://docs.victoriametrics.com/victorialogs/data-ingestion/#http-parameters). Previously this could lead to unexpected errors during querying such as `missing _time field in the query results`. See [#1168](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1168).
 * BUGFIX: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): properly apply [query options](https://docs.victoriametrics.com/victorialogs/logsql/#query-options) at `vlselect` in [cluster setup](https://docs.victoriametrics.com/victorialogs/cluster/). Previously the options were sent to `vlstorage`, but were ignored at `vlselect`. This could lead to incorrect query results.
+* BUGFIX: [vlagent](https://docs.victoriametrics.com/victorialogs/vlagent/): added support for interleaved stdout/stderr partial CRI log lines merging when acting as a Kubernetes log collector. Previously, if a CRI log file contained interleaved stdout and stderr lines, `vlagent` treated them as a same log stream, which could lead to incorrect partial log merging. See [#1215](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1215).
 
 ## [v1.48.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.48.0)
 


### PR DESCRIPTION
### Describe Your Changes

Fixes #1215

Support interleaved stdout/stderr CRI lines.

### Benchmarks

#### Before

```
go test ./kubernetescollector -run '^$' -bench 'BenchmarkProcessor*' -benchmem
goos: darwin
goarch: arm64
pkg: github.com/VictoriaMetrics/VictoriaLogs/app/vlagent/kubernetescollector
cpu: Apple M1 Max
BenchmarkProcessorFullLines-10           4219987               284.4 ns/op       453.56 MB/s         224 B/op          4 allocs/op
BenchmarkProcessorPartialLines-10        5699594               203.0 ns/op       635.49 MB/s         225 B/op          4 allocs/op
BenchmarkProcessorKlog-10                 896455              1465 ns/op        1206.89 MB/s         642 B/op          5 allocs/op
BenchmarkProcessorJSON-10                 666926              1808 ns/op        1713.29 MB/s         418 B/op          4 allocs/op
PASS
ok      github.com/VictoriaMetrics/VictoriaLogs/app/vlagent/kubernetescollector 5.426s
```


#### After

```
go test ./kubernetescollector -run '^$' -bench 'BenchmarkProcessor*' -benchmem
goos: darwin
goarch: arm64
pkg: github.com/VictoriaMetrics/VictoriaLogs/app/vlagent/kubernetescollector
cpu: Apple M1 Max
BenchmarkProcessorFullLines-10           4156406               289.0 ns/op       446.34 MB/s         240 B/op          4 allocs/op
BenchmarkProcessorPartialLines-10        5323438               208.3 ns/op       619.17 MB/s         241 B/op          4 allocs/op
BenchmarkProcessorKlog-10                 846778              1414 ns/op        1250.24 MB/s         658 B/op          5 allocs/op
BenchmarkProcessorJSON-10                 682664              1758 ns/op        1762.11 MB/s         434 B/op          4 allocs/op
PASS
ok      github.com/VictoriaMetrics/VictoriaLogs/app/vlagent/kubernetescollector 5.275s
```

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
