### PR TITLE
Fix csv escaping panic

### DIFF
--- a/app/vlselect/logsql/csv.go
+++ b/app/vlselect/logsql/csv.go
@@ -40,7 +40,7 @@ func appendCSVField(dst []byte, s string) []byte {
 			break
 		}
 
-		n := strings.IndexByte(s, '"')
+		n = strings.IndexByte(s, '"')
 		if n < 0 {
 			dst = append(dst, s...)
 			break

--- a/app/vlselect/logsql/csv_test.go
+++ b/app/vlselect/logsql/csv_test.go
@@ -25,6 +25,7 @@ func TestAppendCSVField(t *testing.T) {
 	f("\t", "\t")
 
 	f(` foo, bar" baz`, `" foo, bar"" baz"`)
+	f(`foo bar" "baz`, `"foo bar"" ""baz"`) // test multiple quotes
 }
 
 func TestAppendCSVLine(t *testing.T) {

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -22,7 +22,6 @@ according to the following docs:
 
 ## tip
 
-* BUGFIX: [/select/logsql/query](https://docs.victoriametrics.com/victorialogs/querying/#querying-logs): fix panic when exporting query results in CSV format if a field contains multiple quoted segments. See [#1220](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1220).
 * FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): make legend click perform default action (hide/show series) and move additional actions to hover context menu.
 * FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): improve alert component and simplify error messages for stats view. See [#1128](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1128).
 * FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): use `extra_filters` instead of modifying query when adding legend filters. See [#411](https://github.com/VictoriaMetrics/VictoriaLogs/issues/411).
@@ -38,6 +37,7 @@ according to the following docs:
 * FEATURE: [`/select/logsql/stream_field_names` HTTP endpoint](https://docs.victoriametrics.com/victorialogs/querying/#querying-stream-field-names): add support for an optional `filter=substring` query arg, which allows returning only the field names containing the given `substring`. See [#1186](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1186).
 * FEATURE: [`/select/logsql/stream_field_values` HTTP endpoint](https://docs.victoriametrics.com/victorialogs/querying/#querying-stream-field-values): add support for an optional `filter=substring` query arg, which allows returning only the field values containing the given `substring`. See [#1186](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1186).
 
+* BUGFIX: [/select/logsql/query](https://docs.victoriametrics.com/victorialogs/querying/#querying-logs): fix panic when exporting query results in CSV format if a field contains multiple quoted segments. See [#1220](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1220).
 * BUGFIX: [data ingestion](https://docs.victoriametrics.com/victorialogs/data-ingestion/): properly handle the case when the ingested logs contain `_time` field without the real timestamp, and this field is not mentioned in the `_time_field` query arg or in the `VL-Time-Field` request header according to [these docs](https://docs.victoriametrics.com/victorialogs/data-ingestion/#http-parameters). Previously this could lead to unexpected errors during querying such as `missing _time field in the query results`. See [#1168](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1168).
 * BUGFIX: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): properly apply [query options](https://docs.victoriametrics.com/victorialogs/logsql/#query-options) at `vlselect` in [cluster setup](https://docs.victoriametrics.com/victorialogs/cluster/). Previously the options were sent to `vlstorage`, but were ignored at `vlselect`. This could lead to incorrect query results.
 

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -22,6 +22,7 @@ according to the following docs:
 
 ## tip
 
+* BUGFIX: [/select/logsql/query](https://docs.victoriametrics.com/victorialogs/querying/#querying-logs): fix panic when exporting query results in CSV format if a field contains multiple quoted segments. See [#1220](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1220).
 * FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): make legend click perform default action (hide/show series) and move additional actions to hover context menu.
 * FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): improve alert component and simplify error messages for stats view. See [#1128](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1128).
 * FEATURE: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): use `extra_filters` instead of modifying query when adding legend filters. See [#411](https://github.com/VictoriaMetrics/VictoriaLogs/issues/411).


### PR DESCRIPTION
### Describe Your Changes

Fixed a panic CSV export for fields containing multiple quotes.

`appendCSVField` shortens the remaining input on each loop & recalculates the position of the next ". But the recalculated position was stored in a shadowed var, so the position variable is not updated in each loop and always stays equal to the first position. Sometimes this causes an out-of-bounds panic when the first position is greater than the length of the remaining string.

I fixed it by updating the same pos var instead of shadowing it in the loop. Also added a test case with multiple " chars.

Fixes #1220

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
