### PR TITLE
go.mod: remove replace directive blocking go install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,6 +317,22 @@ benchmark-pure:
 	CGO_ENABLED=0 go test -run=NO_TESTS -bench=. ./lib/...
 	CGO_ENABLED=0 go test -run=NO_TESTS -bench=. ./app/...
 
+vendor-update-vm:
+	@set -e; \
+	if grep -q 'VictoriaMetrics-enterprise' go.mod; then \
+		vm_module=github.com/VictoriaMetrics/VictoriaMetrics-enterprise; \
+		vm_ref=enterprise-single-node; \
+		vm_env="GOPRIVATE=$$vm_module"; \
+		vm_version=$$(env GOFLAGS=-mod=mod $$vm_env go list -m -f '{{.Version}}' $$vm_module@$$vm_ref); \
+		echo "updating replace to $$vm_module $$vm_version"; \
+		env $$vm_env go mod edit -replace=github.com/VictoriaMetrics/VictoriaMetrics=$$vm_module@$$vm_version; \
+	else \
+		echo "updating require for github.com/VictoriaMetrics/VictoriaMetrics@master"; \
+		go get github.com/VictoriaMetrics/VictoriaMetrics@master; \
+	fi; \
+	go mod tidy -compat=1.26; \
+	go mod vendor
+
 vendor-update:
 	go get -u ./lib/...
 	go get -u ./app/...

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,8 @@ module github.com/VictoriaMetrics/VictoriaLogs
 
 go 1.26.1
 
-replace github.com/VictoriaMetrics/VictoriaMetrics => github.com/VictoriaMetrics/VictoriaMetrics v1.138.1-0.20260402121830-815cc97952c1
-
 require (
-	github.com/VictoriaMetrics/VictoriaMetrics v1.138.0
+	github.com/VictoriaMetrics/VictoriaMetrics v1.138.1-0.20260402121830-815cc97952c1
 	github.com/VictoriaMetrics/easyproto v1.2.0
 	github.com/VictoriaMetrics/metrics v1.43.0
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/VictoriaMetrics/VictoriaMetrics v1.138.0 => github.com/VictoriaMetrics/VictoriaMetrics v1.138.1-0.20260402121830-815cc97952c1
+# github.com/VictoriaMetrics/VictoriaMetrics v1.138.1-0.20260402121830-815cc97952c1
 ## explicit; go 1.26.1
 github.com/VictoriaMetrics/VictoriaMetrics/lib/appmetrics
 github.com/VictoriaMetrics/VictoriaMetrics/lib/atomicutil
@@ -136,4 +136,3 @@ golang.org/x/text/width
 # gopkg.in/yaml.v2 v2.4.0
 ## explicit; go 1.15
 gopkg.in/yaml.v2
-# github.com/VictoriaMetrics/VictoriaMetrics => github.com/VictoriaMetrics/VictoriaMetrics v1.138.1-0.20260402121830-815cc97952c1


### PR DESCRIPTION
### Describe Your Changes

Fixes https://github.com/VictoriaMetrics/VictoriaLogs/issues/1229

The commit https://github.com/VictoriaMetrics/VictoriaLogs/commit/82aca88cecd87e0c4bff4d67ba91acb9738c7857 removed the replace directive, but this commit https://github.com/VictoriaMetrics/VictoriaLogs/commit/1f065000f8 added it back without explanation.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
