### PR TITLE
victoria-logs: use generic root page title

### DIFF
--- a/app/victoria-logs/main.go
+++ b/app/victoria-logs/main.go
@@ -79,7 +79,7 @@ func requestHandler(w http.ResponseWriter, r *http.Request) bool {
 			return false
 		}
 		w.Header().Add("Content-Type", "text/html; charset=utf-8")
-		fmt.Fprintf(w, "<h2>Single-node VictoriaLogs</h2></br>")
+		fmt.Fprintf(w, "<h2>VictoriaLogs</h2></br>")
 		fmt.Fprintf(w, "Version %s<br>", buildinfo.Version)
 		fmt.Fprintf(w, "See docs at <a href='https://docs.victoriametrics.com/victorialogs/'>https://docs.victoriametrics.com/victorialogs/</a></br>")
 		fmt.Fprintf(w, "Useful endpoints:</br>")


### PR DESCRIPTION
### Describe Your Changes

Related to https://github.com/VictoriaMetrics/VictoriaLogs/issues/944

There is no reliable way to determine whether a component is vlinsert, vlselect, single-node, vlstorage, etc., so keep it simple.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
