### PR TITLE
bugfix: fix unsupported metric type for summary

### DIFF
--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -57,6 +57,7 @@ according to the following docs:
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): truncate long active filter badges and show full values in tooltip. See [#369](https://github.com/VictoriaMetrics/VictoriaLogs/issues/369#issuecomment-4080410326)
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): show active filters in Stream Fields empty state instead of "No stream fields found".
 * BUGFIX: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): properly apply `offset` when returning the last N logs sorted by `_time desc`, so queries like `| sort by (_time) desc | offset X | limit Y` return empty results when `X` is greater than or equal to the number of matched logs. Previously, such queries could incorrectly return all matched logs. See [#1190](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1190).
+* BUGFIX: All VictoriaLogs components: Fix `unsupported` metric type display in exposed metric metadata for summaries and quantiles. This `unsupported` type exists when a summary is not updated within a certain time window. See [#120](https://github.com/VictoriaMetrics/metrics/issues/120) for details.
 
 ## [v1.48.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.48.0)
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/VictoriaMetrics/VictoriaMetrics => github.com/VictoriaMetrics
 require (
 	github.com/VictoriaMetrics/VictoriaMetrics v1.138.0
 	github.com/VictoriaMetrics/easyproto v1.2.0
-	github.com/VictoriaMetrics/metrics v1.43.0
+	github.com/VictoriaMetrics/metrics v1.43.1
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/ergochat/readline v0.1.3
 	github.com/golang/snappy v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/VictoriaMetrics/VictoriaMetrics v1.138.1-0.20260402121830-815cc97952c
 github.com/VictoriaMetrics/VictoriaMetrics v1.138.1-0.20260402121830-815cc97952c1/go.mod h1:g9nOOVBJCzzVelHLmk0IOq9/ISgtNogFjI9FsQ0iq/8=
 github.com/VictoriaMetrics/easyproto v1.2.0 h1:FJT9uNXA2isppFuJErbLqD306KoFlehl7Wn2dg/6oIE=
 github.com/VictoriaMetrics/easyproto v1.2.0/go.mod h1:QlGlzaJnDfFd8Lk6Ci/fuLxfTo3/GThPs2KH23mv710=
-github.com/VictoriaMetrics/metrics v1.43.0 h1:mtzzl30hG28FtrsqfffKgtf5X3I8CdYCuToSr/bHw6M=
-github.com/VictoriaMetrics/metrics v1.43.0/go.mod h1:xDM82ULLYCYdFRgQ2JBxi8Uf1+8En1So9YUwlGTOqTc=
+github.com/VictoriaMetrics/metrics v1.43.1 h1:j3Ba4l2K1q3pkvzPqt6aSiQ2DBlAEj3VPVeBtpR3t/Y=
+github.com/VictoriaMetrics/metrics v1.43.1/go.mod h1:xDM82ULLYCYdFRgQ2JBxi8Uf1+8En1So9YUwlGTOqTc=
 github.com/VictoriaMetrics/metricsql v0.85.0 h1:xI+EfqsOgY0T2yd7p8hcYQ52LOtf+1i8fQQzQ+RGtZM=
 github.com/VictoriaMetrics/metricsql v0.85.0/go.mod h1:d4EisFO6ONP/HIGDYTAtwrejJBBeKGQYiRl095bS4QQ=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/vendor/github.com/VictoriaMetrics/metrics/metrics.go
+++ b/vendor/github.com/VictoriaMetrics/metrics/metrics.go
@@ -25,7 +25,11 @@ import (
 type namedMetric struct {
 	name   string
 	metric metric
-	isAux  bool
+
+	// isAux indicates whether it is an auxiliary metric.
+	// Currently only set for quantileValue, as it is part of the Summary.
+	// This field affects sorting when quantileValue and Summary are compared.
+	isAux bool
 }
 
 type metric interface {

--- a/vendor/github.com/VictoriaMetrics/metrics/set.go
+++ b/vendor/github.com/VictoriaMetrics/metrics/set.go
@@ -47,12 +47,10 @@ func (s *Set) WritePrometheus(w io.Writer) {
 			return fName1 < fName2
 		}
 
-		// Only summary and quantile(s) have different metric types.
-		// Sorting by metric type will stabilize the order for summary and quantile(s).
-		mType1 := s.a[i].metric.metricType()
-		mType2 := s.a[j].metric.metricType()
-		if mType1 != mType2 {
-			return mType1 < mType2
+		// if both has same family, check the auxiliary first.
+		// only summary quantile(s) is registered as auxiliary, and quantile(s) in summary should go first.
+		if s.a[i].isAux != s.a[j].isAux {
+			return s.a[i].isAux
 		}
 
 		// lastly by metric names, which is for quantiles and histogram buckets.

--- a/vendor/github.com/VictoriaMetrics/metrics/summary.go
+++ b/vendor/github.com/VictoriaMetrics/metrics/summary.go
@@ -120,13 +120,7 @@ func (sm *Summary) marshalTo(prefix string, w io.Writer) {
 }
 
 func (sm *Summary) metricType() string {
-	// this metric type should not be printed, because summary (sum and count)
-	// of the same metric family will be printed after quantile(s).
-	// If metadata is needed, the metadata from quantile(s) should be used.
-	// quantile will be printed first, so its metrics type won't be printed as metadata.
-	// Printing quantiles before sum and count aligns this code with Prometheus behavior.
-	// See: https://github.com/VictoriaMetrics/metrics/pull/99
-	return "unsupported"
+	return "summary"
 }
 
 func splitMetricName(name string) (string, string) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -48,7 +48,7 @@ github.com/VictoriaMetrics/VictoriaMetrics/lib/writeconcurrencylimiter
 # github.com/VictoriaMetrics/easyproto v1.2.0
 ## explicit; go 1.18
 github.com/VictoriaMetrics/easyproto
-# github.com/VictoriaMetrics/metrics v1.43.0
+# github.com/VictoriaMetrics/metrics v1.43.1
 ## explicit; go 1.24.0
 github.com/VictoriaMetrics/metrics
 # github.com/VictoriaMetrics/metricsql v0.85.0


### PR DESCRIPTION
### Describe Your Changes

Fix `unsupported` metric type display in exposed metric metadata for summaries and quantiles by bumping `metrics` SDK version.

This `unsupported` type exists when a summary is not updated within a certain time window. See [#120](https://github.com/VictoriaMetrics/metrics/issues/120) and pull request https://github.com/VictoriaMetrics/metrics/pull/121 for details.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
