### PR TITLE
.github: Set 21-day cooldown to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 21
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -23,6 +25,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 21
   - package-ecosystem: "npm"
     directory: "/app/vmui/packages/vmui"
     schedule:


### PR DESCRIPTION
Recent supply chain attacks on GitHub Actions and npm packages show the risk of pulling dependency updates too quickly:
  - https://socket.dev/blog/trivy-under-attack-again-github-actions-compromise
  - https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan

Related to https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10740