### PR TITLE
docs: fix vlselect to vlstorage query flow method in cluster docs

### DIFF
--- a/docs/victorialogs/cluster.md
+++ b/docs/victorialogs/cluster.md
@@ -61,8 +61,8 @@ sequenceDiagram
 
     Note over QC,VL: Query Flow
     QC->>VL: Query via HTTP endpoints
-    VL->>VS1: GET /internal/select/* (HTTP)
-    VL->>VS2: GET /internal/select/* (HTTP)
+    VL->>VS1: POST /internal/select/* (HTTP)
+    VL->>VS2: POST /internal/select/* (HTTP)
     VS1-->>VL: Return local results
     VS2-->>VL: Return local results
     VL->>QC: Processed & aggregated results


### PR DESCRIPTION
### Describe Your Changes

I was reading the docs on Cluster and noticed a mismatch between the flow diagram vs the current implementation.

Specifically, vlselect use method POST (not GET) when sending requests to `internal/select/*`

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
