### PR TITLE
Add link to the release for better discovering new versions

### DIFF
--- a/app/vmui/packages/vmui/src/layouts/Footer/Footer.tsx
+++ b/app/vmui/packages/vmui/src/layouts/Footer/Footer.tsx
@@ -42,7 +42,13 @@ const Footer: FC<Props> = memo(({ links = footerLinksToLogs }) => {
       </a>
     ))}
     <div className="vm-footer__copyright">&copy; {copyrightYears} VictoriaMetrics.</div>
-    {version && <span className="vm-footer__version">&nbsp;Version: {version}</span>}
+    {version && <span className="vm-footer__version">&nbsp;Version:
+      <a
+        href={`https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/${version}`}
+        target="_blank"
+        rel="noreferrer"
+      >{version}</a>
+    </span>}
   </footer>;
 });
 


### PR DESCRIPTION
### Describe Your Changes
Add the release link to improve the discovery of new versions.

I am constantly making the same cycle:
* scroll to the footer;
* click on the “Create an issue” link;
* click on the “VictoriaLogs” home;
* click on the Releases.

Seems like this path can be shortened.


P.S.: Thanks for the great product!


### Checklist
The following checks are **mandatory**:
- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
