### PR TITLE
app/vlinsert/journald: parse journald.tenantID flag value during init only

### DIFF
--- a/app/vlinsert/journald/journald.go
+++ b/app/vlinsert/journald/journald.go
@@ -43,16 +43,25 @@ var (
 	journaldUseRemoteIP          = flag.Bool("journald.useRemoteIP", false, "Whether to add the remote IP address as the remote_ip log field for ingested journald messages.")
 )
 
+var tenantID logstorage.TenantID
+
+// MustInit initializes journald parser
+//
+// This function must be called after flag.Parse().
+func MustInit() {
+	t, err := logstorage.ParseTenantID(*journaldTenantID)
+	if err != nil {
+		logger.Panicf("cannot parse -journald.tenantID=%q for journald: %s", *journaldTenantID, err)
+	}
+	tenantID = t
+}
+
 func getCommonParams(r *http.Request) (*insertutil.CommonParams, error) {
 	cp, err := insertutil.GetCommonParams(r)
 	if err != nil {
 		return nil, err
 	}
 	if cp.TenantID.AccountID == 0 && cp.TenantID.ProjectID == 0 {
-		tenantID, err := logstorage.ParseTenantID(*journaldTenantID)
-		if err != nil {
-			return nil, fmt.Errorf("cannot parse -journald.tenantID=%q for journald: %w", *journaldTenantID, err)
-		}
 		cp.TenantID = tenantID
 	}
 

--- a/app/vlinsert/main.go
+++ b/app/vlinsert/main.go
@@ -28,6 +28,7 @@ var (
 // Init initializes vlinsert
 func Init() {
 	syslog.MustInit()
+	journald.MustInit()
 }
 
 // Stop stops vlinsert


### PR DESCRIPTION

### Describe Your Changes

previously value from `-journald.tenantID` flag was parsed on each ingestion request. this PR moves this logic to a dedicated MustInit function, which parses value just once during startup

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
