### PR TITLE
app/vlagent/filecollector: implement log collection from text files by glob patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /victoria-logs-data
 /vlagent-remotewrite-data
 /vlagent-kubernetes-checkpoints.json
+/vlagent-file-checkpoints.json
 .DS_store
 Gemfile.lock
 /_site

--- a/app/vlagent/filecollector/file_collector.go
+++ b/app/vlagent/filecollector/file_collector.go
@@ -1,0 +1,175 @@
+package filecollector
+
+import (
+	"flag"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
+
+	"github.com/VictoriaMetrics/VictoriaLogs/app/vlagent/remotewrite"
+	"github.com/VictoriaMetrics/VictoriaLogs/app/vlagent/tail"
+)
+
+var (
+	glob = flagutil.NewArrayString("fileCollector.glob", "Glob pattern for log files to collect. Can be specified multiple times. "+
+		"The pattern must match files, not directories. "+
+		`Example: -fileCollector.glob="/var/log/my_app/*.log"`)
+	excludeGlob = flagutil.NewArrayString("fileCollector.excludeGlob", "Glob pattern for log files to exclude from collection. Can be specified multiple times. "+
+		`Example: -fileCollector.excludeGlob="/var/log/my_app/*.gz"`)
+	checkpointsPath = flag.String("fileCollector.checkpointsPath", "", "Path to the file where vlagent stores its read position for each collected file. "+
+		"By default, stored in the directory specified by -tmpDataPath. "+
+		"Example: -fileCollector.checkpointsPath=/var/lib/vlagent/file-checkpoints.json")
+
+	refreshInterval = flag.Duration("fileCollector.refreshInterval", time.Second*10, "How often vlagent checks for new files matching the glob pattern")
+)
+
+var stopCh = make(chan struct{})
+var wg sync.WaitGroup
+
+func Init(tmpDataPath string) {
+	if len(*glob) == 0 {
+		return
+	}
+
+	if *checkpointsPath == "" {
+		*checkpointsPath = filepath.Join(tmpDataPath, "vlagent-file-checkpoints.json")
+	}
+
+	// Ensure glob patterns are valid.
+	for _, pattern := range *glob {
+		_, err := path.Match(pattern, ".")
+		if err != nil {
+			logger.Panicf("FATAL: cannot start fileCollector: invalid glob pattern %q: %s", pattern, err)
+		}
+	}
+	for _, pattern := range *excludeGlob {
+		_, err := path.Match(pattern, ".")
+		if err != nil {
+			logger.Panicf("FATAL: cannot start fileCollector: invalid exclude glob pattern %q: %s", pattern, err)
+		}
+	}
+
+	if *refreshInterval < time.Second*1 {
+		logger.Warnf("fileCollector.refreshInterval=%q too small, setting to 1 second", *refreshInterval)
+		*refreshInterval = time.Second * 1
+	}
+
+	initTenantIDs()
+	initExtraFields()
+	initHostname()
+
+	tailer = tail.Start(*checkpointsPath)
+
+	wg.Go(func() {
+		for i, pattern := range *glob {
+			processGlob(i, pattern)
+		}
+
+		ticker := time.NewTicker(*refreshInterval)
+		for {
+			select {
+			case <-stopCh:
+				ticker.Stop()
+			case <-ticker.C:
+				for i, pattern := range *glob {
+					processGlob(i, pattern)
+				}
+			}
+		}
+	})
+}
+
+func processGlob(argIdx int, pattern string) {
+	if pattern == "" {
+		return
+	}
+
+	// Handle regular paths as a special case with verbose logging for better UX,
+	// as fs.Glob and filepath.Glob ignore I/O errors.
+	if !isGlob(pattern) {
+		startRead(argIdx, pattern)
+		return
+	}
+
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		// Pattern must be valid since we validate it in the Init function.
+		logger.Panicf("BUG: pattern %q should be valid; got: %s", pattern, err)
+	}
+	for _, f := range matches {
+		startRead(argIdx, f)
+	}
+}
+
+var tailer *tail.Tailer
+var storage = &remotewrite.Storage{}
+
+func startRead(argIdx int, filePath string) {
+	if tailer.IsTailing(filePath) {
+		return
+	}
+
+	if excludePattern := excludeGlob.GetOptionalArg(argIdx); excludePattern != "" {
+		if ok, _ := filepath.Match(excludePattern, filePath); ok {
+			return
+		}
+	}
+
+	if filepath.Ext(filePath) == ".gz" {
+		logger.Warnf("skipping gzipped file %q; vlagent does not support reading archived files", filePath)
+		return
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logger.Warnf("cannot start reading logs from file %q: file does not exist", filePath)
+			return
+		}
+		if os.IsPermission(err) {
+			logger.Warnf("cannot start reading logs from file %q: permission denied", filePath)
+			return
+		}
+		logger.Errorf("cannot open file %q: %s", filePath, err)
+		return
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		logger.Warnf("cannot stat file: %s", err)
+		return
+	}
+	if fi.IsDir() {
+		suggestedPath := filepath.Join(filePath, "*.log")
+		logger.Warnf("cannot start reading logs from file %q: is a directory; probably you meant %q", filePath, suggestedPath)
+		return
+	}
+
+	proc := newProcessor(argIdx, filePath, storage)
+	tailer.StartRead(filePath, proc)
+}
+
+func Stop() {
+	if len(*glob) == 0 {
+		return
+	}
+	close(stopCh)
+	wg.Wait()
+	tailer.Stop()
+}
+
+func isGlob(pattern string) bool {
+	// See https://github.com/golang/go/blob/e87b10ea2a2c6c65b80c4374af42b9c02ac9fb20/src/path/filepath/match.go#L352
+	if runtime.GOOS == "windows" {
+		return strings.ContainsAny(pattern, "*?[")
+	}
+	return strings.ContainsAny(pattern, `*?[\`)
+}

--- a/app/vlagent/filecollector/processor.go
+++ b/app/vlagent/filecollector/processor.go
@@ -1,0 +1,242 @@
+package filecollector
+
+import (
+	"cmp"
+	"flag"
+	"fmt"
+	"os"
+	"slices"
+	"time"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
+	"github.com/VictoriaMetrics/metrics"
+
+	"github.com/VictoriaMetrics/VictoriaLogs/app/vlinsert/insertutil"
+	"github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage"
+)
+
+var (
+	tenantIDs = flagutil.NewArrayString("fileCollector.tenantID", "Default tenant ID to use for logs collected from files in format: <accountID>:<projectID>. "+
+		"See https://docs.victoriametrics.com/victorialogs/vlagent/#multitenancy")
+	ignoreFields     = flagutil.NewArrayString("fileCollector.ignoreFields", "Fields to ignore across logs ingested from files")
+	decolorizeFields = flagutil.NewArrayString("fileCollector.decolorizeFields", "Fields to remove ANSI color codes across logs ingested from files")
+	msgField         = flagutil.NewArrayString("fileCollector.msgField", "Fields that may contain the _msg field. "+
+		"Default: message, msg, log. See https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field")
+	timeField = flagutil.NewArrayString("fileCollector.timeField", "Fields that may contain the _time field. "+
+		"Default: time, timestamp, ts. If none of the specified fields is found in the log line, then the read time will be used. "+
+		"See https://docs.victoriametrics.com/victorialogs/keyconcepts/#time-field")
+	extraFields = flagutil.NewArrayString("fileCollector.extraFields", "Extra fields in JSON format to add to each log line collected from files. "+
+		`For example, -fileCollector.extraFields='{"app":"nginx", "hostname":"%{HOST}"}'. `+
+		`The "hostname" and "file" fields are injected automatically; `+
+		"see -fileCollector.hostnameField and -fileCollector.fileField for details")
+	fileField     = flag.String("fileCollector.fileField", "file", "Field name used to store the source file path in collected log entries. Set to empty string to disable")
+	hostnameField = flag.String("fileCollector.hostnameField", "hostname", "Field name used to store the hostname in collected log entries. Set to empty string to disable")
+	streamFields  = flagutil.NewArrayString("fileCollector.streamFields", "Comma-separated list of fields to use as log stream fields for logs ingested from files. "+
+		"Default: -fileCollector.fileField and -fileCollector.hostnameField. See: https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields")
+)
+
+type processor struct {
+	storage            insertutil.LogRowsStorage
+	extraFieldsJSONLen int
+	tenantID           logstorage.TenantID
+
+	logRows *logstorage.LogRows
+
+	rowsIngestedLocal  int
+	bytesIngestedLocal int
+}
+
+func newProcessor(argIdx int, filePath string, storage insertutil.LogRowsStorage) *processor {
+	efs := getExtraFields(argIdx)
+	var defaultStreamFields []string
+
+	if *fileField != "" {
+		efs = append(efs, logstorage.Field{
+			Name:  *fileField,
+			Value: filePath,
+		})
+		defaultStreamFields = append(defaultStreamFields, *fileField)
+	}
+
+	if *hostnameField != "" {
+		efs = append(efs, logstorage.Field{
+			Name:  *hostnameField,
+			Value: hostname,
+		})
+		defaultStreamFields = append(defaultStreamFields, *hostnameField)
+	}
+
+	sfs := *streamFields
+	if len(sfs) == 0 {
+		sfs = defaultStreamFields
+	}
+
+	logRows := logstorage.GetLogRows(sfs, *ignoreFields, *decolorizeFields, efs, *insertutil.DefaultMsgValue)
+
+	return &processor{
+		storage:            storage,
+		extraFieldsJSONLen: logstorage.EstimatedJSONRowLen(efs),
+		tenantID:           getTenantID(argIdx),
+		logRows:            logRows,
+	}
+}
+
+func (p *processor) TryAddLine(line []byte) bool {
+	if len(line) == 0 {
+		// Skip empty lines to avoid zero-value logs with the content "missing _msg field".
+		return true
+	}
+
+	parser := logstorage.GetJSONParser()
+	defer logstorage.PutJSONParser(parser)
+
+	ok := false
+	if line[0] == '{' {
+		// Automatically parse JSON, since there's no sense to use an unstructured log format.
+		err := parser.ParseLogMessage(line, nil, "")
+		ok = err == nil
+		// Rename the message field to _msg.
+		logstorage.RenameField(parser.Fields, getMsgFields(), "_msg")
+	}
+	if !ok {
+		parser.Fields = append(parser.Fields, logstorage.Field{
+			Name:  "_msg",
+			Value: bytesutil.ToUnsafeString(line),
+		})
+	}
+
+	// Try to parse timestamp from the time fields.
+	timestamp, err := insertutil.ExtractTimestampFromFields(getTimeFields(), parser.Fields)
+	if err != nil {
+		timestamp = time.Now().UnixNano()
+	}
+
+	if len(parser.Fields) > 1000 {
+		line := logstorage.MarshalFieldsToJSON(nil, parser.Fields)
+		logger.Warnf("dropping log line with %d fields; %s", len(parser.Fields), line)
+		rowsDroppedTotalTooManyFields.Inc()
+		return true
+	}
+
+	p.logRows.MustAdd(p.tenantID, timestamp, parser.Fields, -1)
+	p.storage.MustAddRows(p.logRows)
+	p.logRows.ResetKeepSettings()
+
+	p.rowsIngestedLocal++
+	p.bytesIngestedLocal += p.extraFieldsJSONLen + len(line)
+	if p.rowsIngestedLocal > 128 {
+		p.flushMetrics()
+	}
+
+	return true
+}
+
+var rowsDroppedTotalTooManyFields = metrics.GetOrCreateCounter(`vl_rows_dropped_total{reason="too_many_fields"}`)
+
+func (p *processor) Flush() {
+	p.flushMetrics()
+}
+
+func (p *processor) flushMetrics() {
+	if p.rowsIngestedLocal == 0 {
+		return
+	}
+	rowsIngestedTotal.Add(p.rowsIngestedLocal)
+	bytesIngestedTotal.Add(p.bytesIngestedLocal)
+	p.rowsIngestedLocal = 0
+	p.bytesIngestedLocal = 0
+}
+
+var rowsIngestedTotal = metrics.GetOrCreateCounter(fmt.Sprintf("vl_rows_ingested_total{type=%q}", "file_logs"))
+var bytesIngestedTotal = metrics.GetOrCreateCounter(fmt.Sprintf("vl_bytes_ingested_total{type=%q}", "file_logs"))
+
+func (p *processor) MustClose() {
+	p.Flush()
+	logstorage.PutLogRows(p.logRows)
+	p.logRows = nil
+}
+
+var parsedTenantIDs []logstorage.TenantID
+
+func getTenantID(argIdx int) logstorage.TenantID {
+	if argIdx >= len(parsedTenantIDs) {
+		return logstorage.TenantID{}
+	}
+	return parsedTenantIDs[argIdx]
+}
+
+func initTenantIDs() {
+	parsedTenantIDs = make([]logstorage.TenantID, 0, len(*tenantIDs))
+	for i := range len(*glob) {
+		s := tenantIDs.GetOptionalArg(i)
+		if s == "" {
+			parsedTenantIDs = append(parsedTenantIDs, logstorage.TenantID{})
+			continue
+		}
+		v, err := logstorage.ParseTenantID(s)
+		if err != nil {
+			logger.Fatalf("cannot parse -fileCollector.tenantID=%q: %s", s, err)
+		}
+		parsedTenantIDs = append(parsedTenantIDs, v)
+	}
+}
+
+var parsedExtraFields [][]logstorage.Field
+
+func getExtraFields(argIdx int) []logstorage.Field {
+	if argIdx >= len(parsedExtraFields) {
+		return nil
+	}
+	return parsedExtraFields[argIdx]
+}
+
+func initExtraFields() {
+	for i := range *glob {
+		s := extraFields.GetOptionalArg(i)
+		if s == "" {
+			parsedExtraFields = append(parsedExtraFields, nil)
+			continue
+		}
+
+		p := logstorage.GetJSONParser()
+		if err := p.ParseLogMessage([]byte(s), nil, ""); err != nil {
+			logger.Fatalf("cannot parse -fileCollector.extraFields=%q: %s", *extraFields, err)
+		}
+
+		slices.SortFunc(p.Fields, func(a, b logstorage.Field) int {
+			return cmp.Compare(a.Name, b.Name)
+		})
+
+		parsedExtraFields = append(parsedExtraFields, p.Fields)
+	}
+}
+
+var defaultMsgFields = []string{"message", "msg", "log"}
+
+func getMsgFields() []string {
+	if len(*msgField) == 0 {
+		return defaultMsgFields
+	}
+	return *msgField
+}
+
+var defaultTimeFields = []string{"time", "timestamp", "ts"}
+
+func getTimeFields() []string {
+	if len(*timeField) == 0 {
+		return defaultTimeFields
+	}
+	return *timeField
+}
+
+var hostname string
+
+func initHostname() {
+	s, err := os.Hostname()
+	if err != nil {
+		logger.Fatalf("cannot get hostname: %s", err)
+	}
+	hostname = s
+}

--- a/app/vlagent/filecollector/processor_test.go
+++ b/app/vlagent/filecollector/processor_test.go
@@ -1,0 +1,133 @@
+package filecollector
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage"
+)
+
+func TestProcessorParseContent(t *testing.T) {
+	f := func(in []string, resultsExpected []string) {
+		t.Helper()
+
+		storage := newTestLogRowsStorage()
+		proc := newProcessor(0, "test.log", storage)
+		for _, s := range in {
+			proc.TryAddLine([]byte(s))
+		}
+
+		expected := strings.Join(resultsExpected, "\n")
+		got := strings.Join(storage.logRows, "\n")
+		if expected != got {
+			t.Errorf("expected:\n%s\ngot:\n%s", expected, got)
+		}
+	}
+
+	// Empty content
+	in := []string{""}
+	expected := []string{}
+	f(in, expected)
+
+	// Spaces
+	in = []string{"", " ", "  "}
+	expected = []string{`{"_msg":" ","file":"test.log"}`, `{"_msg":"  ","file":"test.log"}`}
+	f(in, expected)
+
+	// JSON content
+	in = []string{`{"_msg":"foo bar","file":"test.log"}`}
+	expected = []string{`{"_msg":"foo bar","file":"test.log"}`}
+	f(in, expected)
+
+	// Started like JSON object, but it is a regular log line
+	in = []string{"{foobar}"}
+	expected = []string{`{"_msg":"{foobar}","file":"test.log"}`}
+	f(in, expected)
+
+	// Non-JSON content
+	in = []string{
+		`foo`,
+		`bar`,
+		`buz`,
+	}
+	expected = []string{
+		`{"_msg":"foo","file":"test.log"}`,
+		`{"_msg":"bar","file":"test.log"}`,
+		`{"_msg":"buz","file":"test.log"}`,
+	}
+	f(in, expected)
+}
+
+func TestProcessorSetTimestamp(t *testing.T) {
+	f := func(in string, timestampsExpected []int64) {
+		t.Helper()
+
+		storage := newTestLogRowsStorage()
+		proc := newProcessor(0, "test.log", storage)
+		proc.TryAddLine([]byte(in))
+		proc.MustClose()
+
+		if !reflect.DeepEqual(storage.timestamps, timestampsExpected) {
+			t.Fatalf("unexpected timestamps; expected:\n%v\ngot:\n%v", timestampsExpected, storage.timestamps)
+		}
+	}
+
+	current := time.Now()
+
+	// RFC3339
+	in := fmt.Sprintf(`{"_msg":"foo","time":%q}`, current.Format(time.RFC3339))
+	expected := []int64{current.Unix() * time.Second.Nanoseconds()}
+	f(in, expected)
+
+	// RFC3339 nano
+	in = fmt.Sprintf(`{"_msg":"foo","time":%q}`, current.Format(time.RFC3339Nano))
+	expected = []int64{current.UnixNano()}
+	f(in, expected)
+
+	// Unix timestamp
+	in = fmt.Sprintf(`{"_msg":"foo","time":%d}`, current.Unix())
+	expected = []int64{current.Unix() * time.Second.Nanoseconds()}
+	f(in, expected)
+
+	// Unix timestamp with milliseconds precision
+	in = fmt.Sprintf(`{"_msg":"foo","time":%d}`, current.UnixMilli())
+	expected = []int64{current.UnixMilli() * time.Millisecond.Nanoseconds()}
+	f(in, expected)
+
+	// Unix timestamp with microseconds precision
+	in = fmt.Sprintf(`{"_msg":"foo","time":%d}`, current.UnixMicro())
+	expected = []int64{current.UnixMicro() * time.Microsecond.Nanoseconds()}
+	f(in, expected)
+
+	// Unix timestamp with nanosecond precision
+	in = fmt.Sprintf(`{"_msg":"foo","time":%d}`, current.UnixNano())
+	expected = []int64{current.UnixNano()}
+	f(in, expected)
+}
+
+// testLogRowsStorage implements insertutil.LogRowsStorage interface.
+type testLogRowsStorage struct {
+	logRows    []string
+	timestamps []int64
+}
+
+func newTestLogRowsStorage() *testLogRowsStorage {
+	return &testLogRowsStorage{}
+}
+
+// MustAddRows implements insertutil.LogRowsStorage interface
+func (s *testLogRowsStorage) MustAddRows(lr *logstorage.LogRows) {
+	lr.ForEachRow(func(_ uint64, r *logstorage.InsertRow) {
+		row := logstorage.MarshalFieldsToJSON(nil, r.Fields)
+		s.logRows = append(s.logRows, string(row))
+		s.timestamps = append(s.timestamps, r.Timestamp)
+	})
+}
+
+// CanWriteData implements insertutil.LogRowsStorage interface
+func (s *testLogRowsStorage) CanWriteData() error {
+	return nil
+}

--- a/app/vlagent/kubernetescollector/processor.go
+++ b/app/vlagent/kubernetescollector/processor.go
@@ -32,7 +32,7 @@ var (
 	timeField = flagutil.NewArrayString("kubernetesCollector.timeField", "Fields that may contain the _time field. "+
 		"Default: time,timestamp,ts. If none of the specified fields is found in the log line, then the write time will be used. "+
 		"See https://docs.victoriametrics.com/victorialogs/keyconcepts/#time-field")
-	extraFields = flag.String("kubernetesCollector.extraFields", "", "Extra fields to add to each log line collected from Kubernetes pods in JSON format. "+
+	extraFields = flag.String("kubernetesCollector.extraFields", "", "Extra fields in JSON format to add to each log line collected from Kubernetes Pods. "+
 		`For example: -kubernetesCollector.extraFields='{"cluster":"cluster-1","env":"production"}'`)
 	streamFields = flagutil.NewArrayString("kubernetesCollector.streamFields", "Comma-separated list of fields to use as log stream fields for logs ingested from Kubernetes Pods. "+
 		"Default: kubernetes.container_name,kubernetes.pod_name,kubernetes.pod_namespace. "+

--- a/app/vlagent/main.go
+++ b/app/vlagent/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/procutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/pushmetrics"
 
+	"github.com/VictoriaMetrics/VictoriaLogs/app/vlagent/filecollector"
 	"github.com/VictoriaMetrics/VictoriaLogs/app/vlagent/kubernetescollector"
 	"github.com/VictoriaMetrics/VictoriaLogs/app/vlagent/remotewrite"
 	"github.com/VictoriaMetrics/VictoriaLogs/app/vlinsert"
@@ -28,7 +29,9 @@ var (
 	useProxyProtocol = flagutil.NewArrayBool("httpListenAddr.useProxyProtocol", "Whether to use proxy protocol for connections accepted at the corresponding -httpListenAddr . "+
 		"See https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt . "+
 		"With enabled proxy protocol http server cannot serve regular /metrics endpoint. Use -pushmetrics.url for metrics pushing")
-	tmpDataPath = flag.String("tmpDataPath", "", "Default path for storing vlagent data; see also -remoteWrite.tmpDataPath and -kubernetesCollector.checkpointsPath")
+	tmpDataPath = flag.String("tmpDataPath", "", "Base directory for storing vlagent data. "+
+		"Used as default for -remoteWrite.tmpDataPath, -kubernetesCollector.checkpointsPath, "+
+		"and -fileCollector.checkpointsPath unless those flags are set explicitly")
 )
 
 func main() {
@@ -50,6 +53,7 @@ func main() {
 	insertutil.SetLogRowsStorage(&remotewrite.Storage{})
 	remotewrite.Init(*tmpDataPath)
 
+	filecollector.Init(*tmpDataPath)
 	kubernetescollector.Init(*tmpDataPath)
 	vlinsert.Init()
 
@@ -70,6 +74,7 @@ func main() {
 	}
 	vlinsert.Stop()
 	kubernetescollector.Stop()
+	filecollector.Stop()
 	remotewrite.Stop()
 	logger.Infof("successfully shut down the webservice in %.3f seconds", time.Since(startTime).Seconds())
 	logger.Infof("successfully stopped vlagent in %.3f seconds", time.Since(startTime).Seconds())

--- a/app/vlagent/tail/logfile.go
+++ b/app/vlagent/tail/logfile.go
@@ -53,20 +53,20 @@ type logFile struct {
 	tailSize int
 }
 
-func newLogFile(symlink string) *logFile {
+func newLogFile(filePath string) *logFile {
 	return &logFile{
-		path: symlink,
+		path: filePath,
 	}
 }
 
-func newLogFileFromFile(f *os.File, fingerprint uint64, symlink string) (*logFile, error) {
+func newLogFileFromFile(f *os.File, fingerprint uint64, filePath string) (*logFile, error) {
 	fi, err := f.Stat()
 	if err != nil {
 		return nil, fmt.Errorf("cannot get file info of %q: %w", f.Name(), err)
 	}
 	inode := getInode(fi)
 
-	lf := newLogFile(symlink)
+	lf := newLogFile(filePath)
 	lf.file = f
 	lf.inode = inode
 	lf.commitInode = inode
@@ -186,11 +186,7 @@ func (lf *logFile) tryCompleteTail(data []byte) ([]byte, []byte, bool) {
 
 	lf.tailSize += len(tailEnd)
 	if lf.tailSize > maxLogLineSize {
-		// Discard the too large log line.
-		//
-		// This is unexpected in default Kubernetes installations since
-		// containerd splits log lines into 16 KiB chunks by default (criLine.partial will be true for such lines).
-		// See: https://github.com/containerd/containerd/blob/f37f951f5601b309e3b31fadf66991625370f7ba/docs/cri/config.md?plain=1#L399-L402
+		tooLongLinesSkipped.Inc()
 		logger.Warnf("log line from file %q with size %d bytes exceeds maximum allowed size of %d MiB",
 			lf.path, lf.tailSize, maxLogLineSize/1024/1024)
 
@@ -293,16 +289,23 @@ func (lf *logFile) status() logFileStatus {
 		return logFileStatusNotRotated
 	}
 
-	newInode := getInode(stat)
-	if lf.inode == newInode {
+	size := stat.Size()
+	if size == 0 {
+		// The new log file has been created, but an application hasn't switched to it yet.
+		// Consider the file is not rotated, as it may be appended to during the rotation process.
 		return logFileStatusNotRotated
 	}
-	if stat.Size() == 0 {
-		// The file has been created, but Container Runtime hasn't switched to it yet.
-		return logFileStatusNotRotated
+	if size < lf.offset {
+		// The file was truncated.
+		return logFileStatusRotated
 	}
 
-	return logFileStatusRotated
+	newInode := getInode(stat)
+	if lf.inode != newInode {
+		return logFileStatusRotated
+	}
+
+	return logFileStatusNotRotated
 }
 
 func (lf *logFile) setOffset(offset int64) {

--- a/app/vlagent/tail/tailer.go
+++ b/app/vlagent/tail/tailer.go
@@ -6,12 +6,14 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/timeutil"
+	"github.com/VictoriaMetrics/metrics"
 )
 
 // Processor processes log lines from a single file.
@@ -67,10 +69,16 @@ func Start(checkpointsPath string) *Tailer {
 	}
 }
 
-func (fc *Tailer) StartRead(filepath string, proc Processor) {
+func (fc *Tailer) StartRead(relPath string, proc Processor) {
+	// Use absolute paths to prevent duplicate logs in case the vlagent working directory changes.
+	absPath, err := filepath.Abs(relPath)
+	if err != nil {
+		logger.Panicf("FATAL: cannot get absolute path of %q: %s", relPath, err)
+	}
+
 	fc.logFilesLock.Lock()
-	_, ok := fc.logFiles[filepath]
-	fc.logFiles[filepath] = struct{}{}
+	_, ok := fc.logFiles[absPath]
+	fc.logFiles[absPath] = struct{}{}
 	fc.logFilesLock.Unlock()
 	if ok {
 		// Already reading from the file.
@@ -79,7 +87,7 @@ func (fc *Tailer) StartRead(filepath string, proc Processor) {
 	}
 
 	fc.wg.Go(func() {
-		lf := fc.openLogFile(filepath)
+		lf := fc.openLogFile(absPath)
 		fc.process(lf, proc)
 	})
 }
@@ -104,14 +112,14 @@ func tryResumeFromCheckpoint(filepath string, cp checkpoint) (*logFile, bool) {
 	if !ok {
 		// The file was deleted just after StartRead was called.
 		logger.Warnf("log file %q was deleted before being fully read; "+
-			"this is expected if the Pod was deleted while vlagent was starting", filepath)
+			"this is expected if the file was deleted while vlagent was starting", filepath)
 		return nil, false
 	}
 
 	if inode != cp.Inode {
 		_ = f.Close()
 
-		// When kubelet rotates log files, it keeps the previous log file uncompressed
+		// When kubelet or logrotate rotates log files, it typically keeps the previous log file uncompressed
 		// in the same directory with a different name (typically with a timestamp suffix).
 		// We attempt to find this renamed file to continue reading from our last offset.
 		// See https://github.com/kubernetes/kubernetes/blob/f794aa12d78f5b1f9579ce8a991a116a99a2c43c/pkg/kubelet/logs/container_log_manager.go#L416
@@ -122,7 +130,7 @@ func tryResumeFromCheckpoint(filepath string, cp checkpoint) (*logFile, bool) {
 			// This means the file was rotated and potentially removed before we could process it.
 			logger.Warnf("skipping log file %q: rotated log file not found (inode=%d); "+
 				"some log lines may have been lost; "+
-				"this typically happens when Pod logs rotate faster than vlagent can process them during startup or downtime; "+
+				"this typically happens when logs rotate faster than vlagent can process them during startup or downtime; "+
 				"consider increasing kubelet's --container-log-max-size to reduce log rotation frequency",
 				filepath, cp.Inode)
 			return nil, false
@@ -134,8 +142,8 @@ func tryResumeFromCheckpoint(filepath string, cp checkpoint) (*logFile, bool) {
 		logger.Warnf("skipping log file %q: file content changed unexpectedly (expected fingerprint=%d, got=%d); "+
 			"log file was likely rotated and truncated before vlagent could finish reading; "+
 			"some log lines may have been lost; "+
-			"this typically happens when Pod logs rotate faster than vlagent can process them during startup or downtime; "+
-			"consider increasing kubelet's --container-log-max-size to reduce log rotation frequency",
+			"this typically happens when logs rotate faster than vlagent can process them during startup or downtime; "+
+			"consider reducing log rotation frequency",
 			filepath, cp.Fingerprint, fp)
 		return nil, false
 	}
@@ -293,7 +301,7 @@ func (fc *Tailer) CleanupCheckpoints() {
 	}
 
 	logger.Warnf("%d log files were deleted before being fully read; "+
-		"this is expected if Pods were deleted while vlagent was restarting; "+
+		"this is expected if files were deleted while vlagent was restarting; "+
 		"an example of such file: %q", len(unusedCheckpoints), unusedCheckpoints[0].Path)
 }
 
@@ -313,11 +321,17 @@ func (fc *Tailer) getUnusedCheckpoints() []checkpoint {
 	return unused
 }
 
-func (fc *Tailer) IsTailing(filepath string) bool {
+func (fc *Tailer) IsTailing(relPath string) bool {
+	// Use absolute paths to prevent duplicate logs in case the vlagent working directory changes.
+	absPath, err := filepath.Abs(relPath)
+	if err != nil {
+		logger.Panicf("FATAL: cannot get absolute path of %q: %s", relPath, err)
+	}
+
 	fc.logFilesLock.Lock()
 	defer fc.logFilesLock.Unlock()
 
-	_, ok := fc.logFiles[filepath]
+	_, ok := fc.logFiles[absPath]
 	return ok
 }
 
@@ -363,3 +377,5 @@ func tryResolveSymlink(symlink string) string {
 	}
 	return resolvedPath
 }
+
+var tooLongLinesSkipped = metrics.GetOrCreateCounter("vl_too_long_lines_skipped_total")

--- a/app/vlagent/tail/tailer_test.go
+++ b/app/vlagent/tail/tailer_test.go
@@ -2,6 +2,7 @@ package tail
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -57,14 +58,109 @@ func TestTailer(t *testing.T) {
 	writeLinesToFile(t, logFilePath, resultExpected)
 	f(resultExpected, linesExpected, inode, offsetExpected)
 
-	// Test that the tailer switches to the next log file after rotation.
+	// Verify 'rename-create' rotation: the tailer should detect the new log file and successfully resume reading after a restart.
 	writeLinesToFile(t, logFilePath, "1", "22")
-	newInode := rotateLogFile(t, logFilePath)
+	rotateRenameCreate(t, logFilePath)
+	inode = updateInode(t, logFilePath, inode)
+
 	writeLinesToFile(t, logFilePath, "333")
 	resultExpected = "1\n22\n333\n"
 	linesExpected = 3
 	offsetExpected = len("333\n")
-	f(resultExpected, linesExpected, newInode, offsetExpected)
+	f(resultExpected, linesExpected, inode, offsetExpected)
+
+	// Verify 'copy-truncate' rotation: the tailer should detect the truncation and start reading the file from the beginning after a restart.
+	writeLinesToFile(t, logFilePath, "foo", "bar")
+	rotateCopyTruncate(t, logFilePath)
+	writeLinesToFile(t, logFilePath, "buz")
+	// It's expected that 'foo' and 'bar' are lost by vlagent due to truncation.
+	resultExpected = "buz\n"
+	linesExpected = 1
+	offsetExpected = len("buz\n")
+	f(resultExpected, linesExpected, inode, offsetExpected)
+}
+
+// TestHandleRotationRenameCreate verifies that vlagent switches to the new log file by tracking inode changes.
+func TestHandleRotationRenameCreate(t *testing.T) {
+	checkpointsPath := filepath.Join(t.TempDir(), "checkpoints.json")
+	logFilePath, _ := createTestLogFile(t)
+
+	tailer := Start(checkpointsPath)
+	defer tailer.Stop()
+
+	proc := newTestProcessor(nil)
+	tailer.StartRead(logFilePath, proc)
+
+	for _, s := range []string{"foo", "bar", "buz"} {
+		proc.expect(1)
+		writeLinesToFile(t, logFilePath, s)
+		proc.wait()
+	}
+
+	oldPath := rotateRenameCreate(t, logFilePath)
+
+	// Simulate a scenario where the log file was rotated, but the old file was still appended to.
+	for _, s := range []string{"1", "2", "3"} {
+		proc.expect(1)
+		writeLinesToFile(t, oldPath, s)
+		proc.wait()
+	}
+
+	for _, s := range []string{"VictoriaMetrics", "VictoriaLogs", "VictoriaTraces"} {
+		proc.expect(1)
+		writeLinesToFile(t, logFilePath, s)
+		proc.wait()
+	}
+
+	expected := `foo
+bar
+buz
+1
+2
+3
+VictoriaMetrics
+VictoriaLogs
+VictoriaTraces
+`
+	if err := proc.verify(expected); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+// TestHandleRotationCopyTruncate verifies that vlagent detects log truncation by tracking file size reduction.
+func TestHandleRotationCopyTruncate(t *testing.T) {
+	checkpointsPath := filepath.Join(t.TempDir(), "checkpoints.json")
+	logFilePath, _ := createTestLogFile(t)
+
+	tailer := Start(checkpointsPath)
+	defer tailer.Stop()
+
+	proc := newTestProcessor(nil)
+	tailer.StartRead(logFilePath, proc)
+
+	for _, s := range []string{"foo", "bar", "buz"} {
+		proc.expect(1)
+		writeLinesToFile(t, logFilePath, s)
+		proc.wait()
+	}
+
+	rotateCopyTruncate(t, logFilePath)
+
+	for _, s := range []string{"ping", "pong"} {
+		proc.expect(1)
+		writeLinesToFile(t, logFilePath, s)
+		proc.wait()
+	}
+
+	expected := `foo
+bar
+buz
+ping
+pong
+`
+	if err := proc.verify(expected); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
 }
 
 func TestCommitPartialLines(t *testing.T) {
@@ -111,7 +207,8 @@ func TestCommitPartialLines(t *testing.T) {
 	f(isFull, readLinesExpected, inode, offsetExpected)
 
 	// Write another partial line to the rotated log file to ensure that the tailer switches to the new file.
-	newInode := rotateLogFile(t, logFilePath)
+	rotateRenameCreate(t, logFilePath)
+	newInode := updateInode(t, logFilePath, inode)
 	writeLinesToFile(t, logFilePath, "2025-10-16T15:37:36.1Z stderr P bar")
 	isFull = []bool{false, false}
 	readLinesExpected = 2
@@ -240,25 +337,63 @@ func (p *testProcessor) verify(expected string) error {
 	return nil
 }
 
-func rotateLogFile(t *testing.T, logFilePath string) uint64 {
+// rotateRenameCreate rotates the currentFile using "rename-create" (aka "create" in logrotate) rotation method,
+// and returns the new name of the rotated log file.
+func rotateRenameCreate(t *testing.T, currentFile string) string {
 	t.Helper()
 
-	oldFileName := tryResolveSymlink(logFilePath)
-	newFileName := fmt.Sprintf("%s-%d", oldFileName, time.Now().UnixNano())
-	if err := os.Rename(oldFileName, newFileName); err != nil {
+	currentFile = tryResolveSymlink(currentFile)
+	rotatedFile := fmt.Sprintf("%s-%d", currentFile, time.Now().UnixNano())
+
+	if err := os.Rename(currentFile, rotatedFile); err != nil {
 		t.Fatalf("failed to rename log file: %s", err)
 	}
-	f, err := os.Create(oldFileName)
+	f, err := os.Create(currentFile)
 	if err != nil {
 		t.Fatalf("failed to create new log file: %s", err)
 	}
 	defer f.Close()
 
-	stat, ok := mustStat(oldFileName)
+	return rotatedFile
+}
+
+func rotateCopyTruncate(t *testing.T, currentFile string) {
+	t.Helper()
+
+	currentFile = tryResolveSymlink(currentFile)
+	rotatedFile := fmt.Sprintf("%s-%d", currentFile, time.Now().UnixNano())
+
+	current, err := os.Open(currentFile)
+	if err != nil {
+		t.Fatalf("failed to create new log file: %s", err)
+	}
+	defer current.Close()
+
+	rotated, err := os.Create(rotatedFile)
+	if err != nil {
+		t.Fatalf("failed to create new log file: %s", err)
+	}
+	defer rotated.Close()
+
+	if _, err := io.Copy(rotated, current); err != nil {
+		t.Fatalf("failed to copy log file: %s", err)
+	}
+
+	if err := os.Truncate(currentFile, 0); err != nil {
+		t.Fatalf("failed to truncate log file: %s", err)
+	}
+}
+
+func updateInode(t *testing.T, filename string, oldInode uint64) uint64 {
+	t.Helper()
+
+	stat, ok := mustStat(filename)
 	if !ok {
-		t.Fatalf("failed to stat log file %q", oldFileName)
+		t.Fatalf("file %q does not exist", filename)
 	}
 	inode := getInode(stat)
-
+	if oldInode == inode {
+		t.Fatalf("file %q already has inode %d", filename, inode)
+	}
 	return inode
 }

--- a/docs/victorialogs/vlagent.md
+++ b/docs/victorialogs/vlagent.md
@@ -346,6 +346,254 @@ The `vlagent-data` volume uses `hostPath` so that the checkpoint file and the on
 
 See also: [How to exclude vlagent's own logs from collection](https://docs.victoriametrics.com/victorialogs/vlagent/#excluding-vlagents-own-logs).
 
+## Collect logs from files
+
+`vlagent` can collect text-based logs directly from files on disk using the `-fileCollector.glob` flag.
+This is useful for collecting logs from applications that write to log files, such as nginx, Redis, ClickHouse.
+
+### Quick start
+
+The following command starts `vlagent` to collect logs from a file
+and sends the collected logs to a VictoriaLogs instance at `victoria-logs:9428`:
+
+```sh
+./vlagent-prod \
+  -fileCollector.glob=/path/to/file \
+  -tmpDataPath=/var/lib/vlagent \
+  -remoteWrite.url=http://victoria-logs:9428/insert/native
+```
+
+By default, `vlagent` uses `hostname` and `file` as [`_stream`](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields) fields.
+
+`vlagent` automatically parses JSON logs and maps well-known fields to
+[`_msg`](https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field) and
+[`_time`](https://docs.victoriametrics.com/victorialogs/keyconcepts/#time-field).
+
+### Glob pattern requirements
+
+The `-fileCollector.glob` flag must point to a file, not a directory:
+
+```sh
+# correct
+-fileCollector.glob=/var/log/nginx/access.log
+-fileCollector.glob=/var/log/nginx/*.log
+
+# incorrect - points to a directory
+-fileCollector.glob=/var/log/nginx/
+```
+
+Multiple glob patterns can be specified by repeating the flag:
+
+```sh
+-fileCollector.glob=/var/log/nginx/access.log \
+-fileCollector.glob=/var/log/nginx/error.log
+```
+
+To exclude specific files from collection, use `-fileCollector.excludeGlob`:
+
+```sh
+-fileCollector.glob=/var/log/*/*.log \
+-fileCollector.excludeGlob=/var/log/com.apple*
+```
+
+Double-star (`**`) glob patterns are not supported:
+
+```sh
+# incorrect
+-fileCollector.glob=/var/log/**/*.log
+```
+
+### Log rotation
+
+`vlagent` fully supports the `create` log rotation strategy (the default in `logrotate`).
+When the active log file is renamed, `vlagent` finishes reading it before switching to the new file.
+Rotated files in the same directory are tracked automatically, even after `vlagent` restart.
+
+Example `logrotate` config:
+
+```
+/var/log/myapp/myapp.log {
+    create
+    postrotate
+        kill -USR1 $(cat /var/run/myapp.pid)
+    endscript
+}
+```
+
+Note that the application must handle the signal specified in `postrotate` and reopen its log file in response.
+
+`vlagent` does not fully support the `copytruncate` rotation strategy and does not read compressed (`.gz`) files.
+
+> **Note:** if you are collecting logs from a well-known application such as nginx, Apache, or PostgreSQL,
+> a `logrotate` config is most likely already preconfigured by the package and located in `/etc/logrotate.d/`.
+
+### Checkpoints
+
+By default, all temporary data such as checkpoints and buffered logs are stored in the directory specified by `-tmpDataPath`:
+
+A custom path for the checkpoint file can be specified via `-fileCollector.checkpointsPath`:
+
+```sh
+-fileCollector.checkpointsPath=/var/lib/vlagent/file-checkpoints.json
+```
+
+### Metadata and fields
+
+By default, `vlagent` attaches the following fields to every log entry collected from files:
+
+- `file` - path to the source file (controlled by `-fileCollector.fileField`)
+- `hostname` - hostname of the machine (controlled by `-fileCollector.hostnameField`)
+
+These fields are also used as [stream fields](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields) by default.
+Setting either flag to an empty string disables the corresponding field:
+
+```sh
+-fileCollector.fileField=""
+-fileCollector.hostnameField=""
+```
+
+To attach additional fields to all collected logs:
+
+```sh
+-fileCollector.extraFields='{"env":"prod","app":"nginx"}'
+```
+
+To drop specific fields before sending:
+
+```sh
+-fileCollector.ignoreFields=field1,field2
+```
+
+To remove ANSI color codes from specific fields:
+
+```sh
+-fileCollector.decolorizeFields=message
+```
+
+`vlagent` automatically parses JSON log lines and maps well-known fields to
+[`_msg`](https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field) and
+[`_time`](https://docs.victoriametrics.com/victorialogs/keyconcepts/#time-field).
+
+Default `_msg` fields (first match wins): `message`, `msg`, `log`.  
+Override with `-fileCollector.msgField=field1,field2`.
+
+Default `_time` fields (first match wins): `time`, `timestamp`, `ts`.  
+Override with `-fileCollector.timeField=field1,field2`.
+
+If none of the `_time` fields are found, `vlagent` uses the time the log line was read from disk.
+
+### Collecting nginx logs
+
+The following command starts `vlagent` to collect nginx access and error logs,
+attaches an `app` field to each log entry, uses `hostname` and `app` as stream fields for fast filtering in VictoriaLogs,
+and sends the collected logs to a VictoriaLogs instance at `victoria-logs:9428`:
+
+```sh
+./vlagent-prod \
+  -fileCollector.glob="/var/log/nginx/access.log" \
+  -fileCollector.extraFields='{"app":"nginx-access"}' \
+  -fileCollector.glob="/var/log/nginx/error.log" \
+  -fileCollector.extraFields='{"app":"nginx-error"}' \
+  -fileCollector.streamFields=hostname,app \
+  -fileCollector.msgField=request \
+  -tmpDataPath=/var/lib/vlagent \
+  -remoteWrite.url=http://victoria-logs:9428/insert/native
+```
+
+To enable JSON format for nginx access logs, add the following `log_format` directive to the http section of `/etc/nginx/nginx.conf`:
+
+```
+http {
+    log_format json_combined escape=json
+        '{'
+            '"time":"$msec",'
+            '"remote_addr":"$remote_addr",'
+            '"request":"$request",'
+            '"status":"$status",'
+            '"body_bytes_sent":"$body_bytes_sent",'
+            '"http_referer":"$http_referer",'
+            '"http_user_agent":"$http_user_agent"'
+        '}';
+
+    access_log /var/log/nginx/access.log json_combined;
+}
+```
+
+After enabling JSON format, `vlagent` will automatically parse the log entries and map the time field to
+[`_time`](https://docs.victoriametrics.com/victorialogs/keyconcepts/#time-field) and the `request` field to [`_msg`](https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field).
+All other fields will be stored as individual log fields, enabling precise filtering in VictoriaLogs.
+To use a different field as `_msg`, override it with the `-fileCollector.msgField` command-line flag.
+
+### Collecting Redis logs
+
+The following command starts `vlagent` to collect Redis logs, attaches an `app` field to each log entry,
+uses `hostname` and `app` as stream fields for fast filtering in VictoriaLogs,
+and sends the collected logs to a VictoriaLogs instance at `victoria-logs:9428`:
+
+```sh
+./vlagent-prod \
+  -fileCollector.glob="/var/log/redis/redis-server.log" \
+  -fileCollector.extraFields='{"app":"redis"}' \
+  -fileCollector.streamFields=hostname,app \
+  -tmpDataPath=/var/lib/vlagent \
+  -remoteWrite.url=http://victoria-logs:9428/insert/native
+```
+
+### Collecting ClickHouse logs
+
+The following command starts `vlagent` to collect ClickHouse server logs,
+attaches an `app` field to each log entry, uses `hostname` and `app` as stream fields for fast filtering in VictoriaLogs,
+and sends the collected logs to a VictoriaLogs instance at `victoria-logs:9428`:
+
+```sh
+./vlagent-prod \
+  -fileCollector.glob="/var/log/clickhouse-server/clickhouse-server.log" \
+  -fileCollector.extraFields='{"app":"clickhouse"}' \
+  -fileCollector.streamFields=hostname,app \
+  -fileCollector.timeField=date_time \
+  -tmpDataPath=/var/lib/vlagent \
+  -remoteWrite.url=http://victoria-logs:9428/insert/native
+```
+
+ClickHouse writes all log levels to `clickhouse-server.log` and errors only to `clickhouse-server.err.log`.
+To collect error logs only, replace the glob pattern with the error log path.
+
+ClickHouse rotates its own log files internally based on the `<size>` and `<count>` settings in its server config, without relying on `logrotate`.
+`vlagent` handles this rotation automatically.
+
+To enable JSON format for ClickHouse server logs, add the following `<formatting>` section to the `<logger>` section of `/etc/clickhouse-server/config.xml`:
+
+```xml
+
+<clickhouse>
+    <logger>
+        <level>information</level>
+        <log>/var/log/clickhouse-server/clickhouse-server.log</log>
+        <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
+        # ...
+        <formatting>
+            <type>json</type>
+            <names>
+                <date_time>date_time</date_time>
+                <thread_name>thread_name</thread_name>
+                <thread_id>thread_id</thread_id>
+                <level>level</level>
+                <query_id>query_id</query_id>
+                <logger_name>logger_name</logger_name>
+                <message>message</message>
+                <source_file>source_file</source_file>
+                <source_line>source_line</source_line>
+            </names>
+        </formatting>
+    </logger>
+    # ...
+</clickhouse>
+```
+
+After enabling JSON format, `vlagent` will automatically parse the log entries and map the `timestamp` field to [`_time`](https://docs.victoriametrics.com/victorialogs/keyconcepts/#time-field)
+and the `message` field to [`_msg`](https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field).
+All other fields such as `level` and `logger_name` will be stored as individual log fields, enabling precise filtering in VictoriaLogs.
+
 ## Security and TLS
 
 By default, `vlagent` communicates with remote storage over plain HTTP.

--- a/docs/victorialogs/vlagent.md
+++ b/docs/victorialogs/vlagent.md
@@ -353,8 +353,8 @@ This is useful for collecting logs from applications that write to log files, su
 
 ### Quick start
 
-The following command starts `vlagent` to collect logs from a file
-and sends the collected logs to a VictoriaLogs instance at `victoria-logs:9428`:
+The following command starts `vlagent` to collect logs from the `/path/to/file` file
+and to send the collected logs to a VictoriaLogs instance at `victoria-logs:9428`:
 
 ```sh
 ./vlagent-prod \
@@ -371,7 +371,7 @@ By default, `vlagent` uses `hostname` and `file` as [`_stream`](https://docs.vic
 
 ### Glob pattern requirements
 
-The `-fileCollector.glob` flag must point to a file, not a directory:
+The `-fileCollector.glob` flag must point to a file or a collection of files with the given suffix (extension), not a directory:
 
 ```sh
 # correct


### PR DESCRIPTION
This PR adds support for collecting logs from regular text files in `vlagent`.

Users can now point `vlagent` to log files with glob patterns such as `/var/log/nginx/*.log`, and `vlagent` will read these files, remember the read positions, and send the logs to VictoriaLogs.

Closes #1195
