### PR TITLE
vlagent: honor -defaultMsgValue in kubernetesCollector

### DIFF
--- a/app/vlagent/kubernetescollector/processor.go
+++ b/app/vlagent/kubernetescollector/processor.go
@@ -89,7 +89,7 @@ func newLogFileProcessor(storage insertutil.LogRowsStorage, commonFields []logst
 
 	sfs := getStreamFields()
 	efs := getExtraFields()
-	lr := insertutil.GetLogRows(sfs, *ignoreFields, *decolorizeFields, efs)
+	lr := logstorage.GetLogRows(sfs, *ignoreFields, *decolorizeFields, efs, *insertutil.DefaultMsgValue)
 
 	return &logFileProcessor{
 		storage:             storage,

--- a/app/vlagent/kubernetescollector/processor.go
+++ b/app/vlagent/kubernetescollector/processor.go
@@ -89,8 +89,7 @@ func newLogFileProcessor(storage insertutil.LogRowsStorage, commonFields []logst
 
 	sfs := getStreamFields()
 	efs := getExtraFields()
-	const defaultMsgValue = "missing _msg field; see https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field"
-	lr := logstorage.GetLogRows(sfs, *ignoreFields, *decolorizeFields, efs, defaultMsgValue)
+	lr := insertutil.GetLogRows(sfs, *ignoreFields, *decolorizeFields, efs)
 
 	return &logFileProcessor{
 		storage:             storage,

--- a/app/vlagent/kubernetescollector/processor_test.go
+++ b/app/vlagent/kubernetescollector/processor_test.go
@@ -1,6 +1,7 @@
 package kubernetescollector
 
 import (
+	"flag"
 	"fmt"
 	"strings"
 	"testing"
@@ -120,6 +121,39 @@ func TestProcessor(t *testing.T) {
 	}
 	expectedContents = []string{`{"_msg":"foo\tbar","_stream":"{}","_time":"2025-10-16T15:37:36.330062387Z"}`}
 	f(in, expectedContents)
+}
+
+func TestProcessorUsesDefaultMsgValueFlag(t *testing.T) {
+	flagValue := flag.Lookup("defaultMsgValue")
+	if flagValue == nil {
+		t.Fatal("missing defaultMsgValue flag")
+	}
+	originalValue := flagValue.Value.String()
+	if err := flagValue.Value.Set("-"); err != nil {
+		t.Fatalf("cannot set defaultMsgValue flag: %s", err)
+	}
+	t.Cleanup(func() {
+		if err := flagValue.Value.Set(originalValue); err != nil {
+			t.Fatalf("cannot restore defaultMsgValue flag: %s", err)
+		}
+	})
+
+	storage := newTestLogRowsStorage()
+	commonFields := getCommonFields(node{}, namespace{}, pod{}, containerStatus{})
+	proc := newLogFileProcessor(storage, commonFields)
+
+	proc.TryAddLine([]byte(`2025-10-16T15:37:36.330062387Z stderr F {"service":"demo","status":"ok"}`))
+
+	if len(storage.logRows) != 1 {
+		t.Fatalf("unexpected rows count; got %d; want %d", len(storage.logRows), 1)
+	}
+	logRow := storage.logRows[0]
+	if !strings.Contains(logRow, `"_msg":"-"`) {
+		t.Fatalf("expected overridden default message in row %q", logRow)
+	}
+	if strings.Contains(logRow, `missing _msg field`) {
+		t.Fatalf("unexpected built-in default message in row %q", logRow)
+	}
 }
 
 func TestParseKlog(t *testing.T) {

--- a/app/vlagent/kubernetescollector/processor_test.go
+++ b/app/vlagent/kubernetescollector/processor_test.go
@@ -1,7 +1,6 @@
 package kubernetescollector
 
 import (
-	"flag"
 	"fmt"
 	"strings"
 	"testing"
@@ -121,39 +120,6 @@ func TestProcessor(t *testing.T) {
 	}
 	expectedContents = []string{`{"_msg":"foo\tbar","_stream":"{}","_time":"2025-10-16T15:37:36.330062387Z"}`}
 	f(in, expectedContents)
-}
-
-func TestProcessorUsesDefaultMsgValueFlag(t *testing.T) {
-	flagValue := flag.Lookup("defaultMsgValue")
-	if flagValue == nil {
-		t.Fatal("missing defaultMsgValue flag")
-	}
-	originalValue := flagValue.Value.String()
-	if err := flagValue.Value.Set("-"); err != nil {
-		t.Fatalf("cannot set defaultMsgValue flag: %s", err)
-	}
-	t.Cleanup(func() {
-		if err := flagValue.Value.Set(originalValue); err != nil {
-			t.Fatalf("cannot restore defaultMsgValue flag: %s", err)
-		}
-	})
-
-	storage := newTestLogRowsStorage()
-	commonFields := getCommonFields(node{}, namespace{}, pod{}, containerStatus{})
-	proc := newLogFileProcessor(storage, commonFields)
-
-	proc.TryAddLine([]byte(`2025-10-16T15:37:36.330062387Z stderr F {"service":"demo","status":"ok"}`))
-
-	if len(storage.logRows) != 1 {
-		t.Fatalf("unexpected rows count; got %d; want %d", len(storage.logRows), 1)
-	}
-	logRow := storage.logRows[0]
-	if !strings.Contains(logRow, `"_msg":"-"`) {
-		t.Fatalf("expected overridden default message in row %q", logRow)
-	}
-	if strings.Contains(logRow, `missing _msg field`) {
-		t.Fatalf("unexpected built-in default message in row %q", logRow)
-	}
 }
 
 func TestParseKlog(t *testing.T) {

--- a/app/vlinsert/insertutil/common_params.go
+++ b/app/vlinsert/insertutil/common_params.go
@@ -24,6 +24,11 @@ var (
 		"Default value for _msg field if the ingested log entry doesn't contain it; see https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field")
 )
 
+// GetLogRows returns LogRows configured with the current insertutil defaults.
+func GetLogRows(streamFields, ignoreFields, decolorizeFields []string, extraFields []logstorage.Field) *logstorage.LogRows {
+	return logstorage.GetLogRows(streamFields, ignoreFields, decolorizeFields, extraFields, *defaultMsgValue)
+}
+
 // CommonParams contains common HTTP parameters used by log ingestion APIs.
 //
 // See https://docs.victoriametrics.com/victorialogs/data-ingestion/#http-parameters
@@ -351,7 +356,7 @@ func (lmp *logMessageProcessor) MustClose() {
 //
 // MustClose() must be called on the returned LogMessageProcessor when it is no longer needed.
 func (cp *CommonParams) NewLogMessageProcessor(protocolName string, isStreamMode bool) LogMessageProcessor {
-	lr := logstorage.GetLogRows(cp.StreamFields, cp.IgnoreFields, cp.DecolorizeFields, cp.ExtraFields, *defaultMsgValue)
+	lr := GetLogRows(cp.StreamFields, cp.IgnoreFields, cp.DecolorizeFields, cp.ExtraFields)
 
 	rowsIngestedTotal := metrics.GetOrCreateCounter(fmt.Sprintf("vl_rows_ingested_total{type=%q}", protocolName))
 	bytesIngestedTotal := metrics.GetOrCreateCounter(fmt.Sprintf("vl_bytes_ingested_total{type=%q}", protocolName))

--- a/app/vlinsert/insertutil/common_params.go
+++ b/app/vlinsert/insertutil/common_params.go
@@ -1,7 +1,6 @@
 package insertutil
 
 import (
-	"flag"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -18,16 +17,6 @@ import (
 
 	"github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage"
 )
-
-var (
-	defaultMsgValue = flag.String("defaultMsgValue", "missing _msg field; see https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field",
-		"Default value for _msg field if the ingested log entry doesn't contain it; see https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field")
-)
-
-// GetLogRows returns LogRows configured with the current insertutil defaults.
-func GetLogRows(streamFields, ignoreFields, decolorizeFields []string, extraFields []logstorage.Field) *logstorage.LogRows {
-	return logstorage.GetLogRows(streamFields, ignoreFields, decolorizeFields, extraFields, *defaultMsgValue)
-}
 
 // CommonParams contains common HTTP parameters used by log ingestion APIs.
 //
@@ -356,7 +345,7 @@ func (lmp *logMessageProcessor) MustClose() {
 //
 // MustClose() must be called on the returned LogMessageProcessor when it is no longer needed.
 func (cp *CommonParams) NewLogMessageProcessor(protocolName string, isStreamMode bool) LogMessageProcessor {
-	lr := GetLogRows(cp.StreamFields, cp.IgnoreFields, cp.DecolorizeFields, cp.ExtraFields)
+	lr := logstorage.GetLogRows(cp.StreamFields, cp.IgnoreFields, cp.DecolorizeFields, cp.ExtraFields, *DefaultMsgValue)
 
 	rowsIngestedTotal := metrics.GetOrCreateCounter(fmt.Sprintf("vl_rows_ingested_total{type=%q}", protocolName))
 	bytesIngestedTotal := metrics.GetOrCreateCounter(fmt.Sprintf("vl_bytes_ingested_total{type=%q}", protocolName))

--- a/app/vlinsert/insertutil/flags.go
+++ b/app/vlinsert/insertutil/flags.go
@@ -14,4 +14,8 @@ var (
 	// MaxFieldsPerLine is the maximum number of fields per line for /insert/* handlers
 	MaxFieldsPerLine = flag.Int("insert.maxFieldsPerLine", 1000, "The maximum number of log fields per line, which can be read by /insert/* handlers; "+
 		"see https://docs.victoriametrics.com/victorialogs/faq/#how-many-fields-a-single-log-entry-may-contain")
+
+	// DefaultMsgValue is the default value for _msg field if the ingested log entry doesn't contain it.
+	DefaultMsgValue = flag.String("defaultMsgValue", "missing _msg field; see https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field",
+		"Default value for _msg field if the ingested log entry doesn't contain it; see https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field")
 )

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -24,6 +24,7 @@ according to the following docs:
 
 * SECURITY: upgrade Go builder from Go1.26.1 to Go1.26.2. See [the list of issues addressed in Go1.26.2](https://github.com/golang/go/issues?q=milestone%3AGo1.26.2%20label%3ACherryPickApproved).
 
+* BUGFIX: [Kubernetes Collector](https://docs.victoriametrics.com/victorialogs/vlagent/#collect-kubernetes-pod-logs): honor [`-defaultMsgValue`](https://docs.victoriametrics.com/victorialogs/vlagent/#common-flags) for logs without message fields. Previously `vlagent` stored the hard-coded `missing _msg field; ...` text instead of the configured value when logs were collected via `kubernetesCollector`. See [#1283](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1283).
 * BUGFIX: [/select/logsql/hits](https://docs.victoriametrics.com/victorialogs/querying/#querying-hits-stats): fix `invalid memory address or nil pointer dereference` panic when the `query` passed to `/select/logsql/hits` contains [`union rows(...)`](https://docs.victoriametrics.com/victorialogs/logsql/#adding-static-logs). The panic has been introduced in [v1.49.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.49.0).
 
 ## [v1.49.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.49.0)


### PR DESCRIPTION
### Describe Your Changes

`vlagent` don't honor the flag `-defaultMsgValue` when the message fields are missing, it uses a hardcoded string instead.

This change will export `-defaultMsgValue` from `insertutil`, and have `kubernetescollector` uses it.

Fixes #1283 

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
