### PR TITLE
app/vlinsert/opentelemetry: replace custom severity with standard severity_text and severity_number

### DIFF
--- a/app/vlinsert/opentelemetry/opentelemetry_test.go
+++ b/app/vlinsert/opentelemetry/opentelemetry_test.go
@@ -51,7 +51,7 @@ func TestPushProtobufRequest(t *testing.T) {
 		}]
 	}]`
 	timestampsExpected := []int64{1234}
-	resultsExpected := `{"_msg":"log-line-message","severity":"Trace"}`
+	resultsExpected := `{"severity_number":"1","_msg":"log-line-message"}`
 	f(data, timestampsExpected, resultsExpected)
 
 	// single line with scope attributes
@@ -75,7 +75,7 @@ func TestPushProtobufRequest(t *testing.T) {
 		}]
 	}]`
 	timestampsExpected = []int64{1234}
-	resultsExpected = `{"scope.name":"foo","scope.version":"v1.234.5","scope.attributes.abc":"de","scope.attributes.x":"aaa","_msg":"log-line-message","severity":"Trace"}`
+	resultsExpected = `{"scope.name":"foo","scope.version":"v1.234.5","scope.attributes.abc":"de","scope.attributes.x":"aaa","severity_number":"1","_msg":"log-line-message"}`
 	f(data, timestampsExpected, resultsExpected)
 
 	// severities mapping
@@ -89,9 +89,9 @@ func TestPushProtobufRequest(t *testing.T) {
 		}]
 	}]`
 	timestampsExpected = []int64{1234, 1235, 1236}
-	resultsExpected = `{"_msg":"log-line-message","severity":"Trace"}
-{"_msg":"log-line-message","severity":"Warn"}
-{"_msg":"log-line-message","severity":"Fatal4"}`
+	resultsExpected = `{"severity_number":"1","_msg":"log-line-message"}
+{"severity_number":"13","_msg":"log-line-message"}
+{"severity_number":"24","_msg":"log-line-message"}`
 	f(data, timestampsExpected, resultsExpected)
 
 	// multi-line with resource attributes
@@ -123,10 +123,10 @@ func TestPushProtobufRequest(t *testing.T) {
 		}]
 	}]`
 	timestampsExpected = []int64{1234, 1235, 1236, 1237}
-	resultsExpected = `{"logger":"context","instance_id":"10","node_taints.role":"dev","node_taints.cluster_load_percent":"0.55","scope.name":"foo","scope.version":"unknown","scope.attributes.x":"aaa","_msg":"833","severity":"Trace"}
-{"logger":"context","instance_id":"10","node_taints.role":"dev","node_taints.cluster_load_percent":"0.55","scope.name":"foo","scope.version":"unknown","scope.attributes.x":"aaa","_msg":"log-line-message-msg-2","severity":"Unspecified"}
-{"logger":"context","instance_id":"10","node_taints.role":"dev","node_taints.cluster_load_percent":"0.55","scope.name":"foo","scope.version":"unknown","scope.attributes.x":"aaa","_msg":"log-line-message-msg-3","severity":"Unspecified"}
-{"logger":"context","instance_id":"10","node_taints.role":"dev","node_taints.cluster_load_percent":"0.55","event_name":"abc","scope.name":"foo","scope.version":"unknown","scope.attributes.x":"aaa","_msg":"10","severity":"Unspecified"}`
+	resultsExpected = `{"logger":"context","instance_id":"10","node_taints.role":"dev","node_taints.cluster_load_percent":"0.55","scope.name":"foo","scope.version":"unknown","scope.attributes.x":"aaa","severity_number":"1","_msg":"833"}
+{"logger":"context","instance_id":"10","node_taints.role":"dev","node_taints.cluster_load_percent":"0.55","scope.name":"foo","scope.version":"unknown","scope.attributes.x":"aaa","severity_number":"25","_msg":"log-line-message-msg-2"}
+{"logger":"context","instance_id":"10","node_taints.role":"dev","node_taints.cluster_load_percent":"0.55","scope.name":"foo","scope.version":"unknown","scope.attributes.x":"aaa","severity_number":"-1","_msg":"log-line-message-msg-3"}
+{"logger":"context","instance_id":"10","node_taints.role":"dev","node_taints.cluster_load_percent":"0.55","event_name":"abc","scope.name":"foo","scope.version":"unknown","scope.attributes.x":"aaa","severity_number":"0","_msg":"10"}`
 	f(data, timestampsExpected, resultsExpected)
 
 	// multi-scope with resource attributes and multi-line
@@ -170,14 +170,14 @@ func TestPushProtobufRequest(t *testing.T) {
 		]
 	}]`
 	timestampsExpected = []int64{1234, 1235, 2345, 2346, 2347, 2348, 3333, 432}
-	resultsExpected = `{"logger":"context","instance_id":"10","node_taints.role":"dev","node_taints.cluster_load_percent":"0.55","scope.name":"unknown","scope.version":"unknown","scope.attributes.abc":"de","_msg":"log-line-message","severity":"Trace"}
-{"logger":"context","instance_id":"10","node_taints.role":"dev","node_taints.cluster_load_percent":"0.55","scope.name":"unknown","scope.version":"unknown","scope.attributes.abc":"de","_msg":"log-line-message-msg-2","severity":"Debug"}
-{"_msg":"log-line-resource-scope-1-0-0","severity":"Info2"}
-{"_msg":"log-line-resource-scope-1-0-1","severity":"Info2"}
-{"_msg":"log-line-resource-scope-1-1-0","severity":"Info4"}
-{"_msg":"log-line-resource-scope-1-1-1","trace_id":"1234","span_id":"45","severity":"Info4"}
-{"_msg":"log-line-resource-scope-1-1-2","trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7","severity":"Unspecified"}
-{"event_name":"foobar","_msg":"abcd","severity":"Unspecified"}`
+	resultsExpected = `{"logger":"context","instance_id":"10","node_taints.role":"dev","node_taints.cluster_load_percent":"0.55","scope.name":"unknown","scope.version":"unknown","scope.attributes.abc":"de","severity_number":"1","_msg":"log-line-message"}
+{"logger":"context","instance_id":"10","node_taints.role":"dev","node_taints.cluster_load_percent":"0.55","scope.name":"unknown","scope.version":"unknown","scope.attributes.abc":"de","severity_number":"5","_msg":"log-line-message-msg-2"}
+{"severity_number":"10","_msg":"log-line-resource-scope-1-0-0"}
+{"severity_number":"10","_msg":"log-line-resource-scope-1-0-1"}
+{"severity_number":"12","_msg":"log-line-resource-scope-1-1-0"}
+{"severity_number":"12","_msg":"log-line-resource-scope-1-1-1","trace_id":"1234","span_id":"45"}
+{"severity_number":"0","_msg":"log-line-resource-scope-1-1-2","trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7"}
+{"event_name":"foobar","severity_number":"0","_msg":"abcd"}`
 	f(data, timestampsExpected, resultsExpected)
 
 	// nested fields
@@ -254,15 +254,15 @@ func TestPushProtobufRequest(t *testing.T) {
 		}]
 	}]`
 	timestampsExpected = []int64{1234}
-	resultsExpected = `{"_msg":"nested fields","error.type":"document_parsing_exception","error.reason":"failed to parse field [_msg] of type [text]",` +
+	resultsExpected = `{"severity_number":"0","_msg":"nested fields","error.type":"document_parsing_exception","error.reason":"failed to parse field [_msg] of type [text]",` +
 		`"error.caused_by.type":"x_content_parse_exception","error.caused_by.reason":"unexpected end-of-input in VALUE_STRING",` +
-		`"error.caused_by.caused_by.type":"json_e_o_f_exception","error.caused_by.caused_by.reason":"eof","severity":"Unspecified"}`
+		`"error.caused_by.caused_by.type":"json_e_o_f_exception","error.caused_by.caused_by.reason":"eof"}`
 	f(data, timestampsExpected, resultsExpected)
 
 	// decode BytesValue
 	data = `[{"scopeLogs":[{"logRecords":[{"timeUnixNano":1234,"body":{"bytesValue":"Zm9vIGJhcg=="}}]}]}]`
 	timestampsExpected = []int64{1234}
-	resultsExpected = `{"_msg":"Zm9vIGJhcg==","severity":"Unspecified"}`
+	resultsExpected = `{"severity_number":"0","_msg":"Zm9vIGJhcg=="}`
 	f(data, timestampsExpected, resultsExpected)
 
 	// decode KeyValueList
@@ -289,19 +289,19 @@ func TestPushProtobufRequest(t *testing.T) {
 		}]
 	}]`
 	timestampsExpected = []int64{1234}
-	resultsExpected = `{"foo":"bar","bar":"buz","severity":"Unspecified"}`
+	resultsExpected = `{"severity_number":"0","foo":"bar","bar":"buz"}`
 	f(data, timestampsExpected, resultsExpected)
 
 	// decode BoolValue
 	data = `[{"scopeLogs":[{"logRecords":[{"timeUnixNano":1234,"body":{"boolValue":true}}]}]}]`
 	timestampsExpected = []int64{1234}
-	resultsExpected = `{"_msg":"true","severity":"Unspecified"}`
+	resultsExpected = `{"severity_number":"0","_msg":"true"}`
 	f(data, timestampsExpected, resultsExpected)
 
 	// decode StringValue of ArrayValue
 	data = `[{"scopeLogs":[{"logRecords":[{"timeUnixNano":1234,"body":{"arrayValue":{"values":[{"stringValue":"foo bar"}]}}}]}]}]`
 	timestampsExpected = []int64{1234}
-	resultsExpected = `{"_msg":"[\"foo bar\"]","severity":"Unspecified"}`
+	resultsExpected = `{"severity_number":"0","_msg":"[\"foo bar\"]"}`
 	f(data, timestampsExpected, resultsExpected)
 
 	// decode ArrayValue of ArrayValue
@@ -336,43 +336,43 @@ func TestPushProtobufRequest(t *testing.T) {
 		}]
 	}]`
 	timestampsExpected = []int64{1234}
-	resultsExpected = `{"_msg":"[[\"foo\"],[\"bar\"],[\"buz\"]]","severity":"Unspecified"}`
+	resultsExpected = `{"severity_number":"0","_msg":"[[\"foo\"],[\"bar\"],[\"buz\"]]"}`
 	f(data, timestampsExpected, resultsExpected)
 
 	// decode BoolValue of ArrayValue
 	data = `[{"scopeLogs":[{"logRecords":[{"timeUnixNano":1234,"body":{"arrayValue":{"values":[{"boolValue":true}]}}}]}]}]`
 	timestampsExpected = []int64{1234}
-	resultsExpected = `{"_msg":"[true]","severity":"Unspecified"}`
+	resultsExpected = `{"severity_number":"0","_msg":"[true]"}`
 	f(data, timestampsExpected, resultsExpected)
 
 	// decode IntValue of ArrayValue
 	data = `[{"scopeLogs":[{"logRecords":[{"timeUnixNano":1234,"body":{"arrayValue":{"values":[{"intValue":123}]}}}]}]}]`
 	timestampsExpected = []int64{1234}
-	resultsExpected = `{"_msg":"[123]","severity":"Unspecified"}`
+	resultsExpected = `{"severity_number":"0","_msg":"[123]"}`
 	f(data, timestampsExpected, resultsExpected)
 
 	// decode DoubleValue of ArrayValue
 	data = `[{"scopeLogs":[{"logRecords":[{"timeUnixNano":1234,"body":{"arrayValue":{"values":[{"doubleValue":123.45}]}}}]}]}]`
 	timestampsExpected = []int64{1234}
-	resultsExpected = `{"_msg":"[123.45]","severity":"Unspecified"}`
+	resultsExpected = `{"severity_number":"0","_msg":"[123.45]"}`
 	f(data, timestampsExpected, resultsExpected)
 
 	// decode KeyValueList of ArrayValue
 	data = `[{"scopeLogs":[{"logRecords":[{"timeUnixNano":1234,"body":{"arrayValue":{"values":[{"keyValueList":{"values":[{"key":"foo","value":{"stringValue":"bar"}}]}}]}}}]}]}]`
 	timestampsExpected = []int64{1234}
-	resultsExpected = `{"_msg":"[{\"foo\":\"bar\"}]","severity":"Unspecified"}`
+	resultsExpected = `{"severity_number":"0","_msg":"[{\"foo\":\"bar\"}]"}`
 	f(data, timestampsExpected, resultsExpected)
 
 	// decode bytes of ArrayValue
 	data = `[{"scopeLogs":[{"logRecords":[{"timeUnixNano":1234,"body":{"arrayValue":{"values":[{"bytesValue":"Zm9vIGJhcg=="}]}}}]}]}]`
 	timestampsExpected = []int64{1234}
-	resultsExpected = `{"_msg":"[\"Zm9vIGJhcg==\"]","severity":"Unspecified"}`
+	resultsExpected = `{"severity_number":"0","_msg":"[\"Zm9vIGJhcg==\"]"}`
 	f(data, timestampsExpected, resultsExpected)
 
 	// decode null in ArrayValue
 	data = `[{"scopeLogs":[{"logRecords":[{"timeUnixNano":1234,"body":{"arrayValue":{"values":[null,{}]}}}]}]}]`
 	timestampsExpected = []int64{1234}
-	resultsExpected = `{"_msg":"[null,null]","severity":"Unspecified"}`
+	resultsExpected = `{"severity_number":"0","_msg":"[null,null]"}`
 	f(data, timestampsExpected, resultsExpected)
 }
 

--- a/app/vlinsert/opentelemetry/pb.go
+++ b/app/vlinsert/opentelemetry/pb.go
@@ -259,8 +259,6 @@ func decodeLogRecord(src []byte, fs *logstorage.Fields, fb *fmtBuffer) (string, 
 	var (
 		timeUnixNano         uint64
 		observedTimeUnixNano uint64
-		severityText         string
-		severityNumber       int32
 		eventName            string
 	)
 
@@ -284,15 +282,18 @@ func decodeLogRecord(src []byte, fs *logstorage.Fields, fb *fmtBuffer) (string, 
 				return "", 0, fmt.Errorf("cannot read log record observed timestamp")
 			}
 		case 2:
-			severityNumber, ok = fc.Int32()
+			severityNumber, ok := fc.Int32()
 			if !ok {
 				return "", 0, fmt.Errorf("cannot read severity number")
 			}
+			severityNumberStr := fb.formatInt(int64(severityNumber))
+			fs.Add("severity_number", severityNumberStr)
 		case 3:
-			severityText, ok = fc.String()
+			severityText, ok := fc.String()
 			if !ok {
 				return "", 0, fmt.Errorf("cannot read severity string")
 			}
+			fs.Add("severity_text", severityText)
 		case 5:
 			body, ok := fc.MessageData()
 			if !ok {
@@ -330,11 +331,6 @@ func decodeLogRecord(src []byte, fs *logstorage.Fields, fb *fmtBuffer) (string, 
 			}
 		}
 	}
-
-	if severityText == "" {
-		severityText = formatSeverity(severityNumber)
-	}
-	fs.Add("severity", severityText)
 
 	var timestamp int64
 	switch {
@@ -491,40 +487,4 @@ func decodeKeyValueList(src []byte, fs *logstorage.Fields, fb *fmtBuffer, fieldN
 		}
 	}
 	return nil
-}
-
-func formatSeverity(severity int32) string {
-	if severity < 0 || severity >= int32(len(logSeverities)) {
-		return logSeverities[0]
-	}
-	return logSeverities[severity]
-}
-
-// See https://github.com/open-telemetry/opentelemetry-collector/blob/a0cbea73c189551d751d09659e306f48f594fd62/pdata/plog/severity_number.go#L41
-var logSeverities = []string{
-	"Unspecified",
-	"Trace",
-	"Trace2",
-	"Trace3",
-	"Trace4",
-	"Debug",
-	"Debug2",
-	"Debug3",
-	"Debug4",
-	"Info",
-	"Info2",
-	"Info3",
-	"Info4",
-	"Warn",
-	"Warn2",
-	"Warn3",
-	"Warn4",
-	"Error",
-	"Error2",
-	"Error3",
-	"Error4",
-	"Fatal",
-	"Fatal2",
-	"Fatal3",
-	"Fatal4",
 }

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -25,6 +25,7 @@ according to the following docs:
 * SECURITY: upgrade Go builder from Go1.26.1 to Go1.26.2. See [the list of issues addressed in Go1.26.2](https://github.com/golang/go/issues?q=milestone%3AGo1.26.2%20label%3ACherryPickApproved).
 
 * BUGFIX: [/select/logsql/hits](https://docs.victoriametrics.com/victorialogs/querying/#querying-hits-stats): fix `invalid memory address or nil pointer dereference` panic when the `query` passed to `/select/logsql/hits` contains [`union rows(...)`](https://docs.victoriametrics.com/victorialogs/logsql/#adding-static-logs). The panic has been introduced in [v1.49.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.49.0).
+* BUGFIX: [OpenTelemetry data ingestion](https://docs.victoriametrics.com/victorialogs/data-ingestion/opentelemetry/): replace custom `severity` field with `severity_number` and `severity_text` to be compatible with other solutions. See [#1246](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1246).
 
 ## [v1.49.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.49.0)
 


### PR DESCRIPTION
### Describe Your Changes

fixes https://github.com/VictoriaMetrics/VictoriaLogs/issues/1246

by replaced custom `severity` field with standard `severity_text` and `severity_number` fields

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
