### PR TITLE
ci: remove automatic Codecov reporting from test workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,8 +61,8 @@ jobs:
     strategy:
       matrix:
         scenario:
-          - 'test-full'
-          - 'test-full-386'
+          - 'test'
+          - 'test-386'
           - 'test-pure'
 
     steps:
@@ -88,11 +88,6 @@ jobs:
 
       - name: Run tests
         run: GOGC=10 make ${{ matrix.scenario}}
-
-      - name: Publish coverage
-        uses: codecov/codecov-action@v6
-        with:
-          files: ./coverage.txt
 
   integration-test:
     name: integration-test

--- a/Makefile
+++ b/Makefile
@@ -290,6 +290,9 @@ clean-checkers: remove-golangci-lint remove-govulncheck
 test:
 	go test -tags 'synctest' ./lib/... ./app/...
 
+test-386:
+	GOARCH=386 go test -tags 'synctest' ./lib/... ./app/...
+
 test-race:
 	go test -tags 'synctest' -race ./lib/... ./app/...
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,0 @@
-# see https://docs.codecov.com/docs/common-recipe-list#set-non-blocking-status-checks
-coverage:
-  status:
-    project:
-      default:
-        informational: true
-    patch:
-      default:
-        informational: true


### PR DESCRIPTION
This removes automatic Codecov reporting from VictoriaLogs CI. This change keeps local coverage generation available, but removes automatic PR noise and unnecessary CI overhead.