### PR TITLE
 fix: handle retention watcher when all partitions are expired

### DIFF
--- a/lib/logstorage/storage.go
+++ b/lib/logstorage/storage.go
@@ -765,39 +765,42 @@ func (s *Storage) watchRetention() {
 	ticker := time.NewTicker(d)
 	defer ticker.Stop()
 	for {
-		now := time.Now().UnixNano()
-		minAllowedDay := s.getMinAllowedDay(now)
-
-		s.partitionsLock.Lock()
-
-		// Delete outdated partitions.
-		// s.partitions are sorted by day, so find the first non-expired partition.
-		n := sort.Search(len(s.partitions), func(i int) bool {
-			return s.partitions[i].day >= minAllowedDay
-		})
-		ptwsToDelete := s.partitions[:n]
-		s.partitions = s.partitions[n:]
-		s.updateDeletedPartitionsLocked(ptwsToDelete)
-
-		// Remove reference to deleted partitions from s.ptwHot
-		if slices.Contains(ptwsToDelete, s.ptwHot) {
-			s.ptwHot = nil
-		}
-
-		s.partitionsLock.Unlock()
-
-		for i, ptw := range ptwsToDelete {
-			logger.Infof("the partition %s is scheduled to be deleted because it is outside the -retentionPeriod=%dd", ptw.pt.path, durationToDays(s.retention))
-			ptw.mustDrop.Store(true)
-			ptw.decRef()
-			ptwsToDelete[i] = nil
-		}
+		s.deleteExpiredPartitions(time.Now().UnixNano())
 
 		select {
 		case <-s.stopCh:
 			return
 		case <-ticker.C:
 		}
+	}
+}
+
+func (s *Storage) deleteExpiredPartitions(nowNsec int64) {
+	minAllowedDay := s.getMinAllowedDay(nowNsec)
+
+	s.partitionsLock.Lock()
+
+	// Delete outdated partitions.
+	// s.partitions are sorted by day, so find the first non-expired partition.
+	n := sort.Search(len(s.partitions), func(i int) bool {
+		return s.partitions[i].day >= minAllowedDay
+	})
+	ptwsToDelete := s.partitions[:n]
+	s.partitions = s.partitions[n:]
+	s.updateDeletedPartitionsLocked(ptwsToDelete)
+
+	// Remove reference to deleted partitions from s.ptwHot
+	if slices.Contains(ptwsToDelete, s.ptwHot) {
+		s.ptwHot = nil
+	}
+
+	s.partitionsLock.Unlock()
+
+	for i, ptw := range ptwsToDelete {
+		logger.Infof("the partition %s is scheduled to be deleted because it is outside the -retentionPeriod=%dd", ptw.pt.path, durationToDays(s.retention))
+		ptw.mustDrop.Store(true)
+		ptw.decRef()
+		ptwsToDelete[i] = nil
 	}
 }
 

--- a/lib/logstorage/storage_test.go
+++ b/lib/logstorage/storage_test.go
@@ -440,3 +440,38 @@ func storeRowsForProcessDeleteTaskTest(s *Storage, tenantIDs []TenantID, now int
 
 	s.DebugFlush()
 }
+
+func TestStorageRetentionAllExpired(t *testing.T) {
+	path := t.Name()
+
+	// Open storage with long retention and write old data.
+	cfg := &StorageConfig{
+		Retention: 365 * 24 * time.Hour,
+	}
+	s := MustOpenStorage(path, cfg)
+
+	lr := newTestLogRows(1, 10, 0)
+	oldTimestamp := time.Now().UTC().UnixNano() - 30*nsecsPerDay
+	for i := range lr.timestamps {
+		lr.timestamps[i] = oldTimestamp
+	}
+	s.MustAddRows(lr)
+	s.DebugFlush()
+	s.MustClose()
+
+	// Reopen with short retention so all partitions are expired.
+	cfg = &StorageConfig{
+		Retention: 24 * time.Hour,
+	}
+	s = MustOpenStorage(path, cfg)
+
+	// Manually trigger expired partition deletion.
+	s.deleteExpiredPartitions(time.Now().UnixNano())
+
+	if ptns := s.PartitionList(); len(ptns) != 0 {
+		t.Fatalf("expected no partitions after retention cleanup; got %v", ptns)
+	}
+
+	s.MustClose()
+	fs.MustRemoveDir(path)
+}


### PR DESCRIPTION
### Describe Your Changes

When all existing partitions are outside -retentionPeriod, the watchRetention loop completes without reaching the break branch, leaving expired partitions in s.partitions. This can cause panics during storage shutdown.

Fixes https://github.com/VictoriaMetrics/VictoriaLogs/issues/1289
