### PR TITLE
Fix _time:duration boundary handling

### DIFF
--- a/app/vlselect/logsql/logsql.go
+++ b/app/vlselect/logsql/logsql.go
@@ -1489,9 +1489,6 @@ func parseCommonArgsWithConfig(r *http.Request, skipMaxRangeCheck bool) (*common
 	if err != nil {
 		return nil, err
 	}
-	// decrease timestamp by one nanosecond in order to avoid capturing logs belonging
-	// to the first nanosecond at the next period of time (month, week, day, hour, etc.)
-	timestamp--
 
 	currTimestamp := time.Now().UnixNano()
 	if !timeOK {

--- a/lib/logstorage/parser.go
+++ b/lib/logstorage/parser.go
@@ -3465,10 +3465,10 @@ func parseFilterTimeLt(lex *lexer) (*filterTime, error) {
 	if d < 0 {
 		d = -d
 	}
-	if prefix == "<" {
-		d--
-	}
 	minTimestamp := SubInt64NoOverflow(lex.currentTimestamp, d)
+	if prefix == "<" {
+		minTimestamp++
+	}
 	stringRepr := prefix + s
 	return newFilterTime(minTimestamp, lex.currentTimestamp, stringRepr), nil
 }
@@ -3502,7 +3502,7 @@ func parseFilterTimeEq(lex *lexer) (*filterTime, error) {
 	if d < 0 {
 		d = -d
 	}
-	minTimestamp := SubInt64NoOverflow(lex.currentTimestamp, d)
+	minTimestamp := SubInt64NoOverflow(lex.currentTimestamp, d) + 1
 	stringRepr := prefix + s
 	return newFilterTime(minTimestamp, lex.currentTimestamp, stringRepr), nil
 }

--- a/lib/logstorage/parser_test.go
+++ b/lib/logstorage/parser_test.go
@@ -77,9 +77,9 @@ func TestApplyOptionTimeOffset(t *testing.T) {
 	f("options(time_offset=1h) *", math.MinInt64, math.MaxInt64)
 
 	// relative time filter
-	f("_time:1h", -nsecsPerHour*1, 0)
-	f("options(time_offset=1h) _time:1h", -nsecsPerHour*2, -nsecsPerHour*1)
-	f("options(time_offset=-1h) _time:1h", 0, nsecsPerHour*1)
+	f("_time:1h", -nsecsPerHour+1, 0)
+	f("options(time_offset=1h) _time:1h", -nsecsPerHour*2+1, -nsecsPerHour)
+	f("options(time_offset=-1h) _time:1h", 1, nsecsPerHour)
 	f("options(time_offset=1h) _time:offset 1h", math.MinInt64, -nsecsPerHour*2)
 	f("options(time_offset=-1h) _time:offset 1h", math.MinInt64, 0)
 
@@ -123,10 +123,10 @@ func TestApplyOptionTimeOffsetToSubqueries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	assertQueryRange(q, -nsecsPerHour*3, -nsecsPerHour*2)
+	assertQueryRange(q, -nsecsPerHour*3+1, -nsecsPerHour*2)
 	ff := q.getFinalFilter()
 	visitSubqueriesInFilter(ff, func(q *Query) {
-		assertQueryRange(q, -nsecsPerHour*8, -nsecsPerHour*2)
+		assertQueryRange(q, -nsecsPerHour*8+1, -nsecsPerHour*2)
 	})
 
 	// subquery has its own time_offset
@@ -134,10 +134,10 @@ func TestApplyOptionTimeOffsetToSubqueries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	assertQueryRange(q, -nsecsPerHour*3, -nsecsPerHour*2)
+	assertQueryRange(q, -nsecsPerHour*3+1, -nsecsPerHour*2)
 	ff = q.getFinalFilter()
 	visitSubqueriesInFilter(ff, func(q *Query) {
-		assertQueryRange(q, -nsecsPerHour*7, -nsecsPerHour*1)
+		assertQueryRange(q, -nsecsPerHour*7+1, -nsecsPerHour)
 	})
 }
 
@@ -616,13 +616,13 @@ func TestParseTimeDuration(t *testing.T) {
 			t.Fatalf("unexpected duration; got %s; want %s", duration, durationExpected)
 		}
 	}
-	f("5m", 5*time.Minute)
-	f("5m offset 1h", 5*time.Minute)
-	f("5m offset -3.5h5m45s", 5*time.Minute)
-	f("-5.5m", 5*time.Minute+30*time.Second)
-	f("-5.5m offset 1d5m", 5*time.Minute+30*time.Second)
-	f("3d2h12m34s45ms", 3*24*time.Hour+2*time.Hour+12*time.Minute+34*time.Second+45*time.Millisecond)
-	f("3d2h12m34s45ms offset 10ms", 3*24*time.Hour+2*time.Hour+12*time.Minute+34*time.Second+45*time.Millisecond)
+	f("5m", 5*time.Minute-1)
+	f("5m offset 1h", 5*time.Minute-1)
+	f("5m offset -3.5h5m45s", 5*time.Minute-1)
+	f("-5.5m", 5*time.Minute+30*time.Second-1)
+	f("-5.5m offset 1d5m", 5*time.Minute+30*time.Second-1)
+	f("3d2h12m34s45ms", 3*24*time.Hour+2*time.Hour+12*time.Minute+34*time.Second+45*time.Millisecond-1)
+	f("3d2h12m34s45ms offset 10ms", 3*24*time.Hour+2*time.Hour+12*time.Minute+34*time.Second+45*time.Millisecond-1)
 }
 
 func TestParseTimeRange(t *testing.T) {


### PR DESCRIPTION
### Describe Your Changes

Fixes #1226

The boundary logic for duration filters was split between logsql.go and the parser. logsql.go had a simple timestamp decrement while the parser had its own boundary logic, causing inconsistencies.

Moved the adjustment into the parser where minTimestamp is calculated. Now we increment minTimestamp by 1ns instead of decrementing the duration. Cleaner and matches the documented behavior.

Removed the timestamp decrement from logsql.go and updated test expectations.

### Checklist

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).