### PR TITLE
Enhance stats switch validation

### DIFF
--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -24,6 +24,7 @@ according to the following docs:
 
 * SECURITY: upgrade Go builder from Go1.26.1 to Go1.26.2. See [the list of issues addressed in Go1.26.2](https://github.com/golang/go/issues?q=milestone%3AGo1.26.2%20label%3ACherryPickApproved).
 
+* FEATURE: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): improve validation for [`stats switch(...)`](https://docs.victoriametrics.com/victorialogs/logsql/#stats-with-additional-filters) by rejecting empty `switch()` expressions and multiple `default` branches. This helps catch invalid queries earlier and avoids confusing results. See [#1300](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1300).
 * FEATURE: [LogsLQ](https://docs.victoriametrics.com/victorialogs/logsql/): add an ability to search across multiple log fields with the `field_name_prefix*:filter` syntax. See [these docs](https://docs.victoriametrics.com/victorialogs/logsql/#searching-over-multiple-fields) for details. See [#82](https://github.com/VictoriaMetrics/VictoriaLogs/issues/82).
 * FEATURE: [Loki data ingestion](https://docs.victoriametrics.com/victorialogs/data-ingestion/promtail/): Add an ability to add the given prefix to log field names parsed from JSON message. This may be used for avoiding clash between log stream labels and the automatically parsed log field names. See [these docs](https://docs.victoriametrics.com/victorialogs/data-ingestion/promtail/#parsing-log-message) for details. See [#1127](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1127).
 

--- a/lib/logstorage/pipe_stats.go
+++ b/lib/logstorage/pipe_stats.go
@@ -1477,6 +1477,7 @@ func parseStatsSwitch(lex *lexer, sf statsFunc) (*pipeStatsSwitch, error) {
 	lex.nextToken()
 
 	var cases []pipeStatsCase
+	defaultSet := false
 	for !lex.isKeyword(")") {
 		switch {
 		case lex.isKeyword("case", "if"):
@@ -1496,6 +1497,10 @@ func parseStatsSwitch(lex *lexer, sf statsFunc) (*pipeStatsSwitch, error) {
 				resultName: resultName,
 			})
 		case lex.isKeyword("default"):
+			if defaultSet {
+				return nil, fmt.Errorf("switch(...) cannot contain more than one 'default'")
+			}
+			defaultSet = true
 			lex.nextToken()
 			if lex.isKeyword("as") {
 				lex.nextToken()

--- a/lib/logstorage/pipe_stats.go
+++ b/lib/logstorage/pipe_stats.go
@@ -1518,6 +1518,9 @@ func parseStatsSwitch(lex *lexer, sf statsFunc) (*pipeStatsSwitch, error) {
 			lex.nextToken()
 		}
 	}
+	if len(cases) == 0 {
+		return nil, fmt.Errorf("switch(...) must contain at least a single 'case' or 'default'")
+	}
 	lex.nextToken()
 
 	return &pipeStatsSwitch{

--- a/lib/logstorage/pipe_stats_test.go
+++ b/lib/logstorage/pipe_stats_test.go
@@ -20,7 +20,7 @@ func TestParsePipeStatsSuccess(t *testing.T) {
 	f(`stats count(*) switch(case (status:=200) as ok, case (status:>=400 status:<500) as bad, default as other)`)
 
 	// multiple switches with regular funcs
-	f(`stats count(*) if (a) as x, sum(b) switch(case (c) as q), min(x) switch(default as w), max(y) switch(default as qq, case (p) as ww), avg(w) switch()`)
+	f(`stats count(*) if (a) as x, sum(b) switch(case (c) as q), min(x) switch(default as w), max(y) switch(default as qq, case (p) as ww), avg(w) switch(default as avg_w)`)
 
 	// switch with by (...)
 	f(`stats by (host) count(*) switch(case (path:~"^/admin/") as admin_requests, default as other_requests)`)
@@ -61,6 +61,7 @@ func TestParsePipeStatsFailure(t *testing.T) {
 	// zero cases
 	f(`stats count() switch()`)
 	f(`stats by (x) count() switch()`)
+	f(`stats count(), avg() switch()`)
 }
 
 func TestPipeStats(t *testing.T) {

--- a/lib/logstorage/pipe_stats_test.go
+++ b/lib/logstorage/pipe_stats_test.go
@@ -62,6 +62,10 @@ func TestParsePipeStatsFailure(t *testing.T) {
 	f(`stats count() switch()`)
 	f(`stats by (x) count() switch()`)
 	f(`stats count(), avg() switch()`)
+
+	// multiple defaults
+	f(`stats count() switch(default a, default b)`)
+	f(`stats count() as total, avg() switch(case (x) avg_x, default avg_other, default avg_fallback)`)
 }
 
 func TestPipeStats(t *testing.T) {


### PR DESCRIPTION
### Describe Your Changes

This PR makes `stats switch(...)` validation stricter.

It rejects:

- empty `switch()`
- multiple `default` branches in the same `switch(...)`

Why: Currently, these behaviors are a bit confusing:

- empty `switch()` in the first stats function return a generic error
- empty `switch()` in a later stats function make that function silently ignored
- multiple `default` branches are accepted

This PR treat empty switch and multiple defaults as invalid query, and fail early with clear errors.

Fixes #1300 

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
