### PR TITLE
vmui: sanitize markdown link/image URLs in logs view

### DIFF
--- a/app/vmui/packages/vmui/src/constants/markedPlugins.ts
+++ b/app/vmui/packages/vmui/src/constants/markedPlugins.ts
@@ -13,7 +13,6 @@ const SAFE_URL_PROTOCOLS = new Set([
 ]);
 
 const decodeHtmlEntities = (value: string): string => {
-  if (typeof document === "undefined") return value;
   const textarea = document.createElement("textarea");
   textarea.innerHTML = value;
   return textarea.value;
@@ -24,13 +23,11 @@ const isSafeUrl = (url: string): boolean => {
   const normalized = Array.from(decoded)
     .filter((ch) => {
       const code = ch.charCodeAt(0);
-      return !((code <= 0x1f) || code === 0x7f || /\s/.test(ch));
+      return code > 0x1f && code !== 0x7f && !/\s/.test(ch);
     })
-    .join("")
-    .trim();
+    .join("");
   const schemeMatch = normalized.match(/^([a-zA-Z][a-zA-Z0-9+.-]*:)/);
-  if (!schemeMatch) return true;
-  return SAFE_URL_PROTOCOLS.has(schemeMatch[1].toLowerCase());
+  return !schemeMatch || SAFE_URL_PROTOCOLS.has(schemeMatch[1].toLowerCase());
 };
 
 marked.use({

--- a/app/vmui/packages/vmui/src/constants/markedPlugins.ts
+++ b/app/vmui/packages/vmui/src/constants/markedPlugins.ts
@@ -5,11 +5,45 @@ import emojis from "./emojis";
 // TODO: Dynamically import the emoji map only if the emoji parser is active
 marked.use(markedEmoji({ emojis, renderer: (token) => token.emoji }));
 
+const SAFE_URL_PROTOCOLS = new Set([
+  "http:",
+  "https:",
+  "mailto:",
+  "tel:",
+]);
+
+const decodeHtmlEntities = (value: string): string => {
+  if (typeof document === "undefined") return value;
+  const textarea = document.createElement("textarea");
+  textarea.innerHTML = value;
+  return textarea.value;
+};
+
+const isSafeUrl = (url: string): boolean => {
+  const decoded = decodeHtmlEntities(url);
+  const normalized = Array.from(decoded)
+    .filter((ch) => {
+      const code = ch.charCodeAt(0);
+      return !((code <= 0x1f) || code === 0x7f || /\s/.test(ch));
+    })
+    .join("")
+    .trim();
+  const schemeMatch = normalized.match(/^([a-zA-Z][a-zA-Z0-9+.-]*:)/);
+  if (!schemeMatch) return true;
+  return SAFE_URL_PROTOCOLS.has(schemeMatch[1].toLowerCase());
+};
+
 marked.use({
   walkTokens(token) {
     if (token.type === "html") {
       token.type = "text";
       token.text = token.raw ?? token.text ?? "";
+      return;
+    }
+    if (token.type === "link" || token.type === "image") {
+      if (!isSafeUrl(token.href)) {
+        token.href = "";
+      }
     }
   },
   tokenizer: {

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -23,6 +23,7 @@ according to the following docs:
 ## tip
 
 * FEATURE: [querying API](https://docs.victoriametrics.com/victorialogs/querying/): allow using [`limit`](https://docs.victoriametrics.com/victorialogs/logsql/#limit-pipe) and [`offset`](https://docs.victoriametrics.com/victorialogs/logsql/#offset-pipe) pipes after the [`stats` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#stats-pipe) in queries to [`/select/logsql/stats_query`](https://docs.victoriametrics.com/victorialogs/querying/#querying-log-stats). This enables the usage for these pipes in [alerting and recording rules for VictoriaLogs](https://docs.victoriametrics.com/victorialogs/vmalert/). See [#1296](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1296).
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): sanitize markdown URLs in logs rendered with `markdown parsing` enabled, allowing only `http`, `https`, `mailto`, and `tel` schemes for active links and images. See [#1313](https://github.com/VictoriaMetrics/VictoriaLogs/pull/1313).
 
 ## [v1.50.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.50.0)
 


### PR DESCRIPTION
Improves safety in the Logs UI markdown rendering by checking URLs in links and images before they are rendered. allows only `http`, `https`, `mailto`, and `tel`, and clears any other scheme. This reduces XSS risk when markdown parsing is enabled.