### PR TITLE
deployment/docker/victorialogs: fix broken example endpoints

### DIFF
--- a/deployment/docker/victorialogs/fluentd/datadog/fluent.conf
+++ b/deployment/docker/victorialogs/fluentd/datadog/fluent.conf
@@ -17,7 +17,7 @@
   # Optional
   port 8427
   use_ssl false
-  host dd-logs
+  host vmauth
   include_tag_key true
   tag_key 'tag'
   # Optional parameters

--- a/deployment/docker/victorialogs/fluentd/datadog/fluent.conf
+++ b/deployment/docker/victorialogs/fluentd/datadog/fluent.conf
@@ -15,9 +15,9 @@
   @type datadog
   api_key test
   # Optional
-  port 8427
+  port 9429
   use_ssl false
-  host vmauth
+  host vlagent
   include_tag_key true
   tag_key 'tag'
   # Optional parameters

--- a/deployment/docker/victorialogs/fluentd/elasticsearch/fluent.conf
+++ b/deployment/docker/victorialogs/fluentd/elasticsearch/fluent.conf
@@ -6,8 +6,8 @@
 
 <match **>
   @type elasticsearch
-  host victorialogs
+  host vlagent
   path /insert/elasticsearch
   custom_headers {"VL-Msg-Field": "log", "VL-Stream-Fields": "com.docker.compose.service"}
-  port 9428
+  port 9429
 </match>

--- a/deployment/docker/victorialogs/fluentd/syslog/fluent.conf
+++ b/deployment/docker/victorialogs/fluentd/syslog/fluent.conf
@@ -7,7 +7,7 @@
 
 <match **>
   @type remote_syslog
-  host victorialogs
+  host vlagent
   port 8094
   severity debug
   program fluentd

--- a/deployment/docker/victorialogs/opentelemetry-collector/syslog/config.yml
+++ b/deployment/docker/victorialogs/opentelemetry-collector/syslog/config.yml
@@ -1,8 +1,8 @@
 exporters:
   syslog:
     network: tcp
-    endpoint: victorialogs
-    port: 5410
+    endpoint: vlagent
+    port: 8094
     tls:
       insecure: true
   debug:

--- a/deployment/docker/victorialogs/vector/datadog/vector.yml
+++ b/deployment/docker/victorialogs/vector/datadog/vector.yml
@@ -25,7 +25,7 @@ sinks:
     type: datadog_logs
     inputs: [parser]
     default_api_key: test
-    endpoint: http://vmauth:8427
+    endpoint: http://vlagent:9429
     compression: gzip
     request:
       headers:

--- a/deployment/docker/victorialogs/vector/datadog/vector.yml
+++ b/deployment/docker/victorialogs/vector/datadog/vector.yml
@@ -25,7 +25,7 @@ sinks:
     type: datadog_logs
     inputs: [parser]
     default_api_key: test
-    endpoint: http://dd-logs:8427
+    endpoint: http://vmauth:8427
     compression: gzip
     request:
       headers:


### PR DESCRIPTION
Some docker examples under `deployment/docker/victorialogs` used wrong endpoints. This updates them to match the provided compose stack.