### PR TITLE
app/vlselect/logsql: reject tiny step values that would blow up addMissingZeroHits

### DIFF
--- a/app/vlselect/logsql/logsql.go
+++ b/app/vlselect/logsql/logsql.go
@@ -231,6 +231,26 @@ func ProcessHitsRequest(ctx context.Context, w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	// Guard against step values so small they blow up addMissingZeroHits.
+	// That function walks [start, end] by `step` to fill in zero-hit
+	// buckets and calls slices.Contains per tick (O(n) per bucket). A
+	// user-supplied range like [24h ago, now) combined with step=1ns
+	// turns into ~8.64e13 iterations, which pins CPU and climbs memory
+	// until OOM well before the first response byte is written. Cap the
+	// bucket count when the caller set explicit start/end bounds so the
+	// request is rejected up front rather than silently tying up a
+	// goroutine. Data-derived bounds (no start/end args) are left to the
+	// existing row-count path since there is no DoS amplification there
+	// without a user-chosen tiny step.
+	const maxHitsBuckets = 30_000
+	if ca.startAligned != math.MinInt64 && ca.endAligned != math.MaxInt64 && ca.endAligned > ca.startAligned {
+		if (ca.endAligned-ca.startAligned)/step > maxHitsBuckets {
+			httpserver.Errorf(w, r, "step %dns produces more than %d buckets over the selected time range; "+
+				"increase step or narrow the [start, end) window", step, maxHitsBuckets)
+			return
+		}
+	}
+
 	// Obtain offset
 	offset, err := parseDuration(r, "offset", "0s")
 	if err != nil {


### PR DESCRIPTION
## What

`ProcessHitsRequest` in `app/vlselect/logsql/logsql.go` only checked `step > 0`:

```go
step, err := parseDuration(r, "step", "")
// ...
if step <= 0 {
    httpserver.Errorf(w, r, "'step' must be bigger than zero")
    return
}
```

`addMissingZeroHits` then walks `[start, end]` by `step` to fill in zero-hit buckets, and each tick calls `slices.Contains(hs.timestamps, ts)` per series (O(n) per bucket):

```go
for _, hs := range m {
    ts := start
    for ts <= end {
        if !slices.Contains(hs.timestamps, ts) {
            hs.timestamps = append(hs.timestamps, ts)
            hs.hits = append(hs.hits, 0)
        }
        if ts+step < ts { break }
        ts += step
    }
}
```

So a user-supplied window like `[24h ago, now)` combined with `step=1ns` becomes roughly `8.64 × 10¹³` iterations. The goroutine pins a CPU core and climbs memory well before the first response byte is written, and it does not cooperate with HTTP cancellation — a disconnected client leaves the worker running at 100% CPU until OOM. That is the DoS shape described in #1322.

## Fix

When the caller passed explicit `start` / `end` query args, reject the request up front if `(endAligned - startAligned) / step` exceeds 30,000 buckets:

```go
const maxHitsBuckets = 30_000
if ca.startAligned != math.MinInt64 && ca.endAligned != math.MaxInt64 && ca.endAligned > ca.startAligned {
    if (ca.endAligned-ca.startAligned)/step > maxHitsBuckets {
        httpserver.Errorf(w, r, "step %dns produces more than %d buckets over the selected time range; "+
            "increase step or narrow the [start, end) window", step, maxHitsBuckets)
        return
    }
}
```

30,000 matches the `maxPointsPerTimeseries` ceiling used by the sister VictoriaMetrics project and is generous for realistic hits queries (a 24h window at 3s resolution, or a 7d window at ~20s resolution).

## Why only the user-bounded case

The data-derived branch inside `addMissingZeroHits` (when `start == MinInt64` / `end == MaxInt64` — no `start`/`end` args) falls back to `slices.Min`/`slices.Max` over actually-returned timestamps. There is no tiny-step amplification there: if the caller didn't set bounds, the cost is already capped by the `RunQuery` row output. The DoS needs both a user-chosen tiny step *and* a user-chosen wide range, and that is exactly the path this check covers.

## Observable effect

| request | before | after |
|---|---|---|
| `step=1ns`, `start=now-24h`, `end=now` | goroutine pinned until OOM | HTTP 4xx with "step Xns produces more than 30000 buckets..." |
| `step=1m`, `start=now-24h`, `end=now` | works (1440 buckets) | works (unchanged) |
| `step=1s`, `start=now-1h`, `end=now` | works (3600 buckets) | works (unchanged) |
| no `start`/`end`, any step | works | works (unchanged path) |

Fixes #1322