### PR TITLE
app/vmui: minor ui improvements

### DIFF
--- a/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsOptions/BarHitsOptions.tsx
+++ b/app/vmui/packages/vmui/src/components/Chart/BarHitsChart/BarHitsOptions/BarHitsOptions.tsx
@@ -5,7 +5,7 @@ import "./style.scss";
 import useStateSearchParams from "../../../../hooks/useStateSearchParams";
 import { useSearchParams } from "react-router-dom";
 import Button from "../../../Main/Button/Button";
-import { MoreIcon, TipIcon, VisibilityIcon, VisibilityOffIcon } from "../../../Main/Icons";
+import { KeyboardIcon, MoreIcon, VisibilityIcon, VisibilityOffIcon } from "../../../Main/Icons";
 import Tooltip from "../../../Main/Tooltip/Tooltip";
 import ShortcutKeys from "../../../Main/ShortcutKeys/ShortcutKeys";
 import { useCallback } from "react";
@@ -210,7 +210,7 @@ const BarHitsOptions: FC<Props> = ({ query, isHitsMode, isOverview, onChange }) 
             <Button
               variant="text"
               color="gray"
-              startIcon={<TipIcon/>}
+              startIcon={<KeyboardIcon/>}
             />
           </ShortcutKeys>
         </>
@@ -227,7 +227,7 @@ const BarHitsOptions: FC<Props> = ({ query, isHitsMode, isOverview, onChange }) 
           color="primary"
           startIcon={hideChart ? <VisibilityIcon/> : <VisibilityOffIcon/>}
           onClick={toggleHideChart}
-          ariaLabel="settings"
+          aria-label="settings"
         >
           {hideChart ? "Show chart" : ""}
         </Button>
@@ -240,7 +240,7 @@ const BarHitsOptions: FC<Props> = ({ query, isHitsMode, isOverview, onChange }) 
             color="primary"
             startIcon={<MoreIcon/>}
             onClick={handleToggleList}
-            ariaLabel="settings"
+            aria-label="settings"
           />
           <Modal
             title={"Hits Options"}

--- a/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/GlobalSettings.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/GlobalSettings.tsx
@@ -85,7 +85,7 @@ const GlobalSettings = forwardRef<GlobalSettingsHandle>((_, ref) => {
           color="primary"
           startIcon={<SettingsIcon/>}
           onClick={handleOpen}
-          ariaLabel="settings"
+          aria-label="settings"
         />
       </Tooltip>
     )}

--- a/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/TenantsConfiguration/TenantsFields.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/TenantsConfiguration/TenantsFields.tsx
@@ -54,18 +54,16 @@ const TenantsFields: FC<Props> = ({ accountId, projectId, onChange }) => {
         />
       </div>
       <div className="vm-tenant-input-list__buttons">
-        <a
+        <Button
+          as="a"
           href={`${LOGS_DOCS_URL}/#multitenancy`}
           target="_blank"
           rel="help noreferrer"
+          variant="text"
+          color="primary"
         >
-          <Button
-            variant="text"
-            color="primary"
-          >
-            Multitenancy docs
-          </Button>
-        </a>
+          Multitenancy docs
+        </Button>
         <Button
           variant="contained"
           color="primary"

--- a/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/TenantsConfiguration/TenantsSelect.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/GlobalSettings/TenantsConfiguration/TenantsSelect.tsx
@@ -63,18 +63,16 @@ const TenantsSelect: FC<Props> = ({ accountIds, tenantId, onChange }) => {
         </div>
       ))}
       <div className="vm-tenant-input-list__buttons">
-        <a
+        <Button
+          as="a"
           href={`${LOGS_DOCS_URL}/#multitenancy`}
           target="_blank"
           rel="help noreferrer"
+          variant="text"
+          color="primary"
         >
-          <Button
-            variant="text"
-            color="primary"
-          >
-            Multitenancy docs
-          </Button>
-        </a>
+          Multitenancy docs
+        </Button>
       </div>
     </div>
   );

--- a/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/AutocompleteToggle.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/AutocompleteToggle.tsx
@@ -2,8 +2,10 @@ import { FC } from "preact/compat";
 import { useQueryDispatch, useQueryState } from "../../../state/query/QueryStateContext";
 import Button from "../../Main/Button/Button";
 import { AutocompleteIcon } from "../../Main/Icons";
+import useDeviceDetect from "../../../hooks/useDeviceDetect";
 
 const AutocompleteToggle: FC = () => {
+  const { isMobile } = useDeviceDetect();
   const { autocomplete } = useQueryState();
   const queryDispatch = useQueryDispatch();
 
@@ -18,7 +20,7 @@ const AutocompleteToggle: FC = () => {
       onClick={onChangeAutocomplete}
       startIcon={<AutocompleteIcon/>}
     >
-      Autocomplete: {autocomplete ? "On" : "Off"}
+      {!isMobile && "Autocomplete: "}{autocomplete ? "On" : "Off"}
     </Button>
   );
 };

--- a/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/QueryExamples/QueryExamplesItem/QueryExamplesItemControls.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/QueryExamples/QueryExamplesItem/QueryExamplesItemControls.tsx
@@ -19,20 +19,18 @@ const QueryExamplesItemControls: FC<Props> = ({ example, onApply }) => {
 
   return (
     <div className="vm-query-examples-content-item-header-controls">
-      <a
+      <Button
+        as={"a"}
         href={url}
         target="_blank"
         rel="noreferrer"
+        startIcon={<OpenNewIcon/>}
+        variant="text"
+        size="small"
+        color="gray"
       >
-        <Button
-          startIcon={<OpenNewIcon/>}
-          variant="text"
-          size="small"
-          color="gray"
-        >
-          Docs
-        </Button>
-      </a>
+        Docs
+      </Button>
 
       <Tooltip
         title={"Replace current query and run search"}

--- a/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/QueryExamples/QueryExamplesModal.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/QueryExamples/QueryExamplesModal.tsx
@@ -2,11 +2,13 @@ import { FC, useMemo, useState } from "preact/compat";
 import { queryExamples } from "./examples";
 import "./style.scss";
 import TextField from "../../../Main/TextField/TextField";
-import { SearchIcon } from "../../../Main/Icons";
+import { SearchIcon, WikiIcon } from "../../../Main/Icons";
 import classNames from "classnames";
 import useDeviceDetect from "../../../../hooks/useDeviceDetect";
 import QueryExamplesSidebar from "./QueryExamplesSidebar";
 import QueryExamplesItem from "./QueryExamplesItem/QueryExamplesItem";
+import { LOGS_DOCS_URL } from "../../../../constants/logs";
+import Button from "../../../Main/Button/Button";
 
 type Props = {
   onApply: (value: string) => void;
@@ -51,7 +53,20 @@ const QueryExamplesModal: FC<Props> = ({ onApply }) => {
     })}
     >
       <div className="vm-query-examples-header">
-        <h2 className="vm-query-examples-header__title">Browse examples or search to find the right query pattern.</h2>
+        <div className="vm-query-examples-header-top">
+          <h2 className="vm-query-examples-header__title">Browse examples or search to find the right query pattern.</h2>
+          <Button
+            as={"a"}
+            target="_blank"
+            href={`${LOGS_DOCS_URL}/logsql/`}
+            rel="help noreferrer"
+            variant="outlined"
+            color="primary"
+            startIcon={<WikiIcon/>}
+          >
+            LogsQL docs
+          </Button>
+        </div>
         <TextField
           autofocus
           placeholder="Filter examples..."

--- a/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/QueryExamples/style.scss
+++ b/app/vmui/packages/vmui/src/components/Configurators/QueryEditor/QueryExamples/style.scss
@@ -26,6 +26,12 @@
   &-header {
     grid-column: span 2;
 
+    &-top {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+    }
+
     &__title {
       font-weight: 500;
       padding-inline: $padding-small;

--- a/app/vmui/packages/vmui/src/components/Configurators/TimeRangeSettings/ExecutionControls/ExecutionControls.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/TimeRangeSettings/ExecutionControls/ExecutionControls.tsx
@@ -93,7 +93,7 @@ export const ExecutionControls: FC = () => {
               color="primary"
               onClick={handleUpdate}
               startIcon={<RefreshIcon/>}
-              ariaLabel="refresh dashboard"
+              aria-label="refresh dashboard"
             />
           </Tooltip>
         )}

--- a/app/vmui/packages/vmui/src/components/Configurators/TimeRangeSettings/TimeSelector/TimeSelector.tsx
+++ b/app/vmui/packages/vmui/src/components/Configurators/TimeRangeSettings/TimeSelector/TimeSelector.tsx
@@ -145,7 +145,7 @@ export const TimeSelector: FC<Props> = ({ onOpenSettings }) => {
             color="primary"
             startIcon={<ClockIcon/>}
             onClick={toggleOpenOptions}
-            ariaLabel="time range controls"
+            aria-label="time range controls"
           >
             {displayFullDate && <span>{dateTitle}</span>}
           </Button>

--- a/app/vmui/packages/vmui/src/components/CopyButton/CopyButton.tsx
+++ b/app/vmui/packages/vmui/src/components/CopyButton/CopyButton.tsx
@@ -23,7 +23,7 @@ export const CopyButton: FC<Props> = ({ title, getData, successfulCopiedMessage 
       variant="text"
       startIcon={<CopyIcon/>}
       onClick={handleClick}
-      ariaLabel={title}
+      aria-label={title}
     />
   </Tooltip>;
 };

--- a/app/vmui/packages/vmui/src/components/FilterSidebar/FilterSidebarField/style.scss
+++ b/app/vmui/packages/vmui/src/components/FilterSidebar/FilterSidebarField/style.scss
@@ -57,6 +57,7 @@ $icon-width: 14px;
 
     &__title {
       line-height: 2;
+      font-weight: 600;
     }
 
     &__hits {

--- a/app/vmui/packages/vmui/src/components/FilterSidebar/FilterSidebarValue/style.scss
+++ b/app/vmui/packages/vmui/src/components/FilterSidebar/FilterSidebarValue/style.scss
@@ -8,7 +8,7 @@ $padding-smaller: calc($padding-small / 2);
   align-items: center;
   justify-content: flex-start;
   padding-block: $padding-smaller;
-  padding-inline: $padding-small;
+  padding-inline: $padding-global $padding-small;
   gap: $padding-small;
   min-height: 28px;
   border-radius: $border-radius-small;

--- a/app/vmui/packages/vmui/src/components/Main/Button/Button.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Button/Button.tsx
@@ -1,60 +1,59 @@
-import { FC, MouseEvent as ReactMouseEvent, ReactNode } from "preact/compat";
+import { ElementType, ComponentPropsWithoutRef, ReactNode } from "preact/compat";
 import classNames from "classnames";
 import "./style.scss";
 
-interface ButtonProps {
-  variant?: "contained" | "outlined" | "text"
-  color?: "primary" | "secondary" | "success" | "error" | "gray"  | "warning" | "white"
-  size?: "small" | "medium" | "large"
-  ariaLabel?: string // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label
-  endIcon?: ReactNode
-  startIcon?: ReactNode
-  fullWidth?: boolean
-  disabled?: boolean
-  children?: ReactNode
-  className?: string
-  "data-id"?: string
-  onClick?: (e: ReactMouseEvent<HTMLButtonElement>) => void
-  onMouseDown?: (e: ReactMouseEvent<HTMLButtonElement>) => void
-}
+type ButtonOwnProps<E extends ElementType = ElementType> = {
+  as?: E;
+  variant?: "contained" | "outlined" | "text";
+  color?: "primary" | "secondary" | "success" | "error" | "gray" | "warning" | "white";
+  size?: "small" | "medium" | "large";
+  endIcon?: ReactNode;
+  startIcon?: ReactNode;
+  fullWidth?: boolean;
+  children?: ReactNode;
+  className?: string;
+};
 
-const Button: FC<ButtonProps> = ({
+type ButtonProps<E extends ElementType> = ButtonOwnProps<E> &
+  Omit<ComponentPropsWithoutRef<E>, keyof ButtonOwnProps<E>>;
+
+const defaultElement = "button";
+
+const Button = <E extends ElementType = typeof defaultElement>({
+  as,
   variant = "contained",
   color = "primary",
   size = "medium",
-  ariaLabel,
   children,
   endIcon,
   startIcon,
   fullWidth = false,
   className,
-  disabled,
-  onClick,
-  onMouseDown,
-  "data-id": dataId
-}) => {
+  ...rest
+}: ButtonProps<E>) => {
+  const Tag = as ?? defaultElement;
 
-  const classesButton = classNames({
-    "vm-button": true,
-    [`vm-button_${variant}_${color}`]: true,
-    [`vm-button_${size}`]: size,
-    "vm-button_icon_only": (startIcon || endIcon) && !children,
-    "vm-button_full-width": fullWidth,
-    "vm-button_with-icons": startIcon || endIcon,
-    [className || ""]: className
-  });
+  const classesButton = classNames(
+    "vm-button",
+    `vm-button_${variant}_${color}`,
+    `vm-button_${size}`,
+    {
+      "vm-button_icon_only": (startIcon || endIcon) && !children,
+      "vm-button_full-width": fullWidth,
+      "vm-button_with-icons": startIcon || endIcon,
+    },
+    className,
+  );
 
   return (
-    <button
+    <Tag
       className={classesButton}
-      disabled={disabled}
-      aria-label={ariaLabel}
-      onClick={onClick}
-      onMouseDown={onMouseDown}
-      data-id={dataId}
+      {...rest}
     >
-      {startIcon}{children}{endIcon}
-    </button>
+      {startIcon}
+      {children}
+      {endIcon}
+    </Tag>
   );
 };
 

--- a/app/vmui/packages/vmui/src/components/Main/CodeExample/CodeExample.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/CodeExample/CodeExample.tsx
@@ -39,7 +39,7 @@ const CodeExample: FC<{code: string}> = ({ code }) => {
             color="gray"
             onClick={handlerCopy}
             startIcon={isCopied ? <DoneIcon/> : <CopyIcon/>}
-            ariaLabel="close"
+            aria-label="close"
           />
         </Tooltip>
       </div>

--- a/app/vmui/packages/vmui/src/components/Main/DatePicker/DateTimeInput/DateTimeInput.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/DatePicker/DateTimeInput/DateTimeInput.tsx
@@ -110,7 +110,7 @@ const DateTimeInput: FC<DateTimeInputProps> = ({
           color="gray"
           size="small"
           startIcon={<CalendarIcon/>}
-          ariaLabel="calendar"
+          aria-label="calendar"
         />
       </div>
       <DatePicker

--- a/app/vmui/packages/vmui/src/components/Main/Icons/index.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Icons/index.tsx
@@ -341,17 +341,6 @@ export const TuneIcon = () => (
   </svg>
 );
 
-export const TipIcon = () => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="currentColor"
-  >
-    <path
-      d="M7 20h4c0 1.1-.9 2-2 2s-2-.9-2-2zm-2-1h8v-2H5v2zm11.5-9.5c0 3.82-2.66 5.86-3.77 6.5H5.27c-1.11-.64-3.77-2.68-3.77-6.5C1.5 5.36 4.86 2 9 2s7.5 3.36 7.5 7.5zm4.87-2.13L20 8l1.37.63L22 10l.63-1.37L24 8l-1.37-.63L22 6l-.63 1.37zM19 6l.94-2.06L22 3l-2.06-.94L19 0l-.94 2.06L16 3l2.06.94L19 6z"
-    ></path>
-  </svg>
-);
-
 export const ListIcon = () => (
   <svg
     viewBox="0 0 24 24"
@@ -642,17 +631,6 @@ export const MinusIcon = () => (
   </svg>
 );
 
-export const BoltIcon = () => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="currentColor"
-  >
-    <path
-      d="M11 21h-1l1-7H7.5c-.58 0-.57-.32-.38-.66s.05-.08.07-.12C8.48 10.94 10.42 7.54 13 3h1l-1 7h3.5c.49 0 .56.33.47.51l-.07.15C12.96 17.55 11 21 11 21"
-    ></path>
-  </svg>
-);
-
 export const DisabledIcon = () => (
   <svg
     viewBox="0 0 24 24"
@@ -670,7 +648,7 @@ export const ListAllIcon = () => (
     fill="currentColor"
   >
     <path
-      d="M19 5v14H5V5zm1.1-2H3.9c-.5 0-.9.4-.9.9v16.2c0 .4.4.9.9.9h16.2c.4 0 .9-.5.9-.9V3.9c0-.5-.5-.9-.9-.9M11 7h6v2h-6zm0 4h6v2h-6zm0 4h6v2h-6zM7 7h2v2H7zm0 4h2v2H7zm0 4h2v2H7z"
+      d="M4 10.5c-.83 0-1.5.67-1.5 1.5s.67 1.5 1.5 1.5 1.5-.67 1.5-1.5-.67-1.5-1.5-1.5m0-6c-.83 0-1.5.67-1.5 1.5S3.17 7.5 4 7.5 5.5 6.83 5.5 6 4.83 4.5 4 4.5m0 12c-.83 0-1.5.68-1.5 1.5s.68 1.5 1.5 1.5 1.5-.68 1.5-1.5-.67-1.5-1.5-1.5M7 19h14v-2H7zm0-6h14v-2H7zm0-8v2h14V5z"
     ></path>
   </svg>
 );

--- a/app/vmui/packages/vmui/src/components/Main/Modal/Modal.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Modal/Modal.tsx
@@ -81,7 +81,7 @@ const Modal: FC<ModalProps> = ({
               color="gray"
               size="small"
               onClick={onClose}
-              ariaLabel="close"
+              aria-label="close"
             >
               <CloseIcon/>
             </Button>

--- a/app/vmui/packages/vmui/src/components/Main/Popper/PopperContent.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Popper/PopperContent.tsx
@@ -165,7 +165,7 @@ const PopperContent: FC<PopperContentProps> = ({
             color={variant === "dark" ? "white" : "primary"}
             size="small"
             onClick={handleClickClose}
-            ariaLabel="close"
+            aria-label="close"
           >
             <CloseIcon />
           </Button>

--- a/app/vmui/packages/vmui/src/components/QueryHistory/QueryHistory.tsx
+++ b/app/vmui/packages/vmui/src/components/QueryHistory/QueryHistory.tsx
@@ -111,7 +111,7 @@ const QueryHistory: FC<Props> = ({ handleSelectQuery, historyKey }) => {
         variant="outlined"
         onClick={handleOpenModal}
         startIcon={<ClockIcon/>}
-        ariaLabel={"Query history"}
+        aria-label={"Query history"}
       >
         {!isMobile && "History"}
       </Button>

--- a/app/vmui/packages/vmui/src/components/ScrollToTopButton/ScrollToTopButton.tsx
+++ b/app/vmui/packages/vmui/src/components/ScrollToTopButton/ScrollToTopButton.tsx
@@ -47,7 +47,7 @@ const ScrollToTopButton: FC<ScrollToTopButtonProps> = ({ className }) => {
           variant="contained"
           color="primary"
           onClick={scrollToTop}
-          ariaLabel="Scroll to top"
+          aria-label="Scroll to top"
           startIcon={<ScrollToTopIcon />}
         />
       </Tooltip>

--- a/app/vmui/packages/vmui/src/components/Table/TableCopyButton/TableCopyButton.tsx
+++ b/app/vmui/packages/vmui/src/components/Table/TableCopyButton/TableCopyButton.tsx
@@ -35,7 +35,7 @@ const TableCopyButton: FC<Props> = ({ getData }) => {
       color="gray"
       size="small"
       onClick={handleCopyLog}
-      ariaLabel="Copy log"
+      aria-label="Copy log"
     />
   );
 };

--- a/app/vmui/packages/vmui/src/components/Table/TableSettings/TableSettings.tsx
+++ b/app/vmui/packages/vmui/src/components/Table/TableSettings/TableSettings.tsx
@@ -31,7 +31,7 @@ const TableSettings: FC<TableSettingsProps> = (props) => {
           variant="text"
           startIcon={<TuneIcon/>}
           onClick={toggleOpenSettings}
-          ariaLabel={title}
+          aria-label={title}
         />
       </Tooltip>
 

--- a/app/vmui/packages/vmui/src/components/Views/GroupView/GroupLogs.tsx
+++ b/app/vmui/packages/vmui/src/components/Views/GroupView/GroupLogs.tsx
@@ -158,7 +158,7 @@ const GroupLogs: FC<Props> = ({ logs, settingsRef }) => {
               variant="text"
               startIcon={expandAll ? <CollapseIcon/> : <ExpandIcon/>}
               onClick={handleToggleExpandAll}
-              ariaLabel={expandAll ? "Collapse All" : "Expand All"}
+              aria-label={expandAll ? "Collapse All" : "Expand All"}
             />
           </Tooltip>
           <GroupLogsConfigurators logs={logs}/>

--- a/app/vmui/packages/vmui/src/components/Views/GroupView/GroupLogsConfigurators/GroupLogsConfigurators.tsx
+++ b/app/vmui/packages/vmui/src/components/Views/GroupView/GroupLogsConfigurators/GroupLogsConfigurators.tsx
@@ -113,7 +113,7 @@ const GroupLogsConfigurators: FC<Props> = ({ logs }) => {
             variant="text"
             startIcon={<TuneIcon/>}
             onClick={toggleOpen}
-            ariaLabel={title}
+            aria-label={title}
           />
         </Tooltip>
         {hasChanges && <span className="vm-group-logs-configurator-button__marker"/>}

--- a/app/vmui/packages/vmui/src/components/Views/GroupView/GroupLogsItem.tsx
+++ b/app/vmui/packages/vmui/src/components/Views/GroupView/GroupLogsItem.tsx
@@ -181,7 +181,7 @@ const GroupLogsItem: FC<Props> = ({ log, displayFields = [], isContextView, hide
               color="gray"
               startIcon={<CopyIcon/>}
               onClick={handleCopy}
-              ariaLabel="Copy log"
+              aria-label="Copy log"
             />
           </Tooltip>
         </div>

--- a/app/vmui/packages/vmui/src/components/Views/LiveTailingView/LiveTailingSettings.tsx
+++ b/app/vmui/packages/vmui/src/components/Views/LiveTailingView/LiveTailingSettings.tsx
@@ -1,4 +1,4 @@
-import { FC, RefObject, useRef, createPortal } from "preact/compat";
+import { FC, RefObject, createPortal } from "preact/compat";
 import Button from "../../Main/Button/Button";
 import SelectLimit from "../../Main/Pagination/SelectLimit/SelectLimit";
 import { DeleteIcon, PauseIcon, PlayCircleOutlineIcon, TuneIcon } from "../../Main/Icons";
@@ -36,7 +36,6 @@ const LiveTailingSettings: FC<LiveTailingSettingsProps> = ({
   offset,
   handleSetOffset
 }) => {
-  const settingButtonRef = useRef<HTMLDivElement>(null);
   const { value: isSettingsOpen, setFalse: closeSettings, setTrue: openSettings } = useBoolean(false);
 
   if (!settingsRef.current) return null;
@@ -65,7 +64,7 @@ const LiveTailingSettings: FC<LiveTailingSettingsProps> = ({
             color="primary"
             onClick={isPaused ? handleResumeLiveTailing : pauseLiveTailing}
             startIcon={isPaused ? <PlayCircleOutlineIcon/> : <PauseIcon/>}
-            ariaLabel={`${isPaused ? "Resume" : "Pause"} live tailing`}
+            aria-label={`${isPaused ? "Resume" : "Pause"} live tailing`}
           />
         </Tooltip>
         <Tooltip title={"Clear logs"}>
@@ -74,16 +73,15 @@ const LiveTailingSettings: FC<LiveTailingSettingsProps> = ({
             color="secondary"
             onClick={clearLogs}
             startIcon={<DeleteIcon/>}
-            ariaLabel={"Clear logs"}
+            aria-label={"Clear logs"}
           />
         </Tooltip>
         <Tooltip title={"Settings"}>
           <Button
-            ref={settingButtonRef}
             variant="text"
             onClick={openSettings}
             startIcon={<TuneIcon/>}
-            ariaLabel={"Settings"}
+            aria-label={"Settings"}
           />
         </Tooltip>
         {isSettingsOpen && <Modal

--- a/app/vmui/packages/vmui/src/layouts/Header/HeaderControls/HeaderControls.tsx
+++ b/app/vmui/packages/vmui/src/layouts/Header/HeaderControls/HeaderControls.tsx
@@ -56,7 +56,7 @@ const HeaderControls: FC<ControlsProps & HeaderProps> = ({
             })}
             startIcon={<MoreIcon/>}
             onClick={handleToggleList}
-            ariaLabel={"controls"}
+            aria-label={"controls"}
           />
         </div>
         <Modal

--- a/app/vmui/packages/vmui/src/pages/QueryPage/QueryPageBody/QueryPageBody.tsx
+++ b/app/vmui/packages/vmui/src/pages/QueryPage/QueryPageBody/QueryPageBody.tsx
@@ -111,7 +111,7 @@ const QueryPageBody: FC<Props> = ({ data, queryParams, isLoading, isPreview }) =
               <Button
                 variant="text"
                 startIcon={<DownloadIcon/>}
-                ariaLabel="Download Logs"
+                aria-label="Download Logs"
               />
             </Tooltip>
           </DownloadLogsModal>
@@ -121,7 +121,7 @@ const QueryPageBody: FC<Props> = ({ data, queryParams, isLoading, isPreview }) =
               color="primary"
               startIcon={hideLogs ? <VisibilityIcon/> : <VisibilityOffIcon/>}
               onClick={toggleHideLogs}
-              ariaLabel="settings"
+              aria-label="settings"
             >
               {hideLogs ? "Show Logs" : ""}
             </Button>

--- a/app/vmui/packages/vmui/src/pages/QueryPage/QueryPageHeader/QueryPageHeader.tsx
+++ b/app/vmui/packages/vmui/src/pages/QueryPage/QueryPageHeader/QueryPageHeader.tsx
@@ -1,7 +1,6 @@
 import { FC, useEffect } from "preact/compat";
-import { CodeIcon, PlayIcon, SpinnerIcon, WikiIcon } from "../../../components/Main/Icons";
+import { PlayIcon, SpinnerIcon } from "../../../components/Main/Icons";
 import "./style.scss";
-import useDeviceDetect from "../../../hooks/useDeviceDetect";
 import Button from "../../../components/Main/Button/Button";
 import QueryEditor from "../../../components/Configurators/QueryEditor/QueryEditor";
 import LogsLimitInput from "../LimitController/LogsLimitInput";
@@ -16,7 +15,6 @@ import AutocompleteToggle from "../../../components/Configurators/QueryEditor/Au
 import ExtraFiltersReset from "../../../components/ExtraFilters/ExtraFiltersPanel/ExtraFiltersReset";
 import ExtraFiltersCopy from "../../../components/ExtraFilters/ExtraFiltersPanel/ExtraFiltersCopy";
 import QueryExamplesButton from "../../../components/Configurators/QueryEditor/QueryExamples/QueryExamplesButton";
-import { LOGS_DOCS_URL } from "../../../constants/logs";
 
 interface Props {
   query: string;
@@ -39,7 +37,6 @@ const QueryPageHeader: FC<Props> = ({
   onChangeLimit,
   onRun,
 }) => {
-  const { isMobile } = useDeviceDetect();
   const { autocomplete, queryHistory, autocompleteQuick } = useQueryState();
   const queryDispatch = useQueryDispatch();
   const setQuickAutocomplete = useQuickAutocomplete();
@@ -107,36 +104,6 @@ const QueryPageHeader: FC<Props> = ({
           <ExtraFiltersReset/>
           <ExtraFiltersCopy/>
         </div>
-        {!isMobile && (
-          <div className="vm-query-page-header-bottom-helpful">
-            <a
-              target="_blank"
-              href={`${LOGS_DOCS_URL}/logsql/`}
-              rel="help noreferrer"
-            >
-              <Button
-                variant="text"
-                color="gray"
-                startIcon={<CodeIcon/>}
-              >
-                LogsQL
-              </Button>
-            </a>
-            <a
-              target="_blank"
-              href={`${LOGS_DOCS_URL}`}
-              rel="help noreferrer"
-            >
-              <Button
-                variant="text"
-                color="gray"
-                startIcon={<WikiIcon/>}
-              >
-                Docs
-              </Button>
-            </a>
-          </div>
-        )}
         <QueryExamplesButton onApply={handleChangeAndRun}/>
         <AutocompleteToggle/>
         <QueryHistory

--- a/app/vmui/packages/vmui/src/pages/QueryPage/QueryPageHeader/style.scss
+++ b/app/vmui/packages/vmui/src/pages/QueryPage/QueryPageHeader/style.scss
@@ -1,6 +1,6 @@
 @use "src/styles/variables" as *;
 
-$input-limit-width: 200px;
+$input-limit-width: 197px;
 
 .vm-query-page-header {
   display: flex;
@@ -9,11 +9,15 @@ $input-limit-width: 200px;
 
   &-top {
     display: grid;
-    grid-template-columns: minmax(200px, 1fr) minmax(auto, $input-limit-width);
+    grid-template-columns: minmax(200px, 1fr) minmax(100px, $input-limit-width);
     align-items: flex-start;
     justify-content: center;
     gap: $padding-small;
     margin-bottom: -6px;
+
+    @media (max-width: 768px) {
+      grid-template-columns: 8fr 2fr;
+    }
   }
 
   &-bottom {

--- a/app/vmui/packages/vmui/src/pages/StreamContext/StreamContextButton.tsx
+++ b/app/vmui/packages/vmui/src/pages/StreamContext/StreamContextButton.tsx
@@ -44,7 +44,7 @@ const StreamContextButton: FC<Props> = ({ log, displayFields }) => {
           color="gray"
           startIcon={<ContextIcon/>}
           onClick={handleClickButton}
-          ariaLabel="show context"
+          aria-label="show context"
         />
       </Tooltip>
       {isOpenContext && (

--- a/app/vmui/packages/vmui/src/pages/StreamContext/StreamContextList.tsx
+++ b/app/vmui/packages/vmui/src/pages/StreamContext/StreamContextList.tsx
@@ -75,6 +75,7 @@ const StreamContextList: FC<Props> = ({ log, displayFields, isModal }) => {
 
   const streamPairs = (
     <div className="vm-steam-context-header-streams">
+      <b>Stream labels:</b>
       {streamFields.map(streamPair => (
         <GroupLogsHeaderItem
           key={streamPair}


### PR DESCRIPTION
### Describe Your Changes

This PR includes several small UI improvements in VMUI

### Changes

1. Improve distinction between fields and values in the `Stream fields `sidebar
2. Remove documentation links near the `Execute` button and move the `LogsQL` link to `Query examples`
3. Add the `Stream labels` caption in the Log context modal
4. Adjust mobile layout
5. Replace the chart header icon for shortcuts/help
6. Update the Query examples icon
7. Remove unused icons
8. Improve `Button` component: add support for custom elements (as prop) to enhance semantics and accessibility

| # | Before | After |
|---|---|---|
| 1 | <img width="404" height="261" alt="image" src="https://github.com/user-attachments/assets/0fde1bb1-75c8-48d5-8e05-3a7979f9a895" /> | <img width="404" height="261" alt="image" src="https://github.com/user-attachments/assets/c1e97c24-6fa8-4479-9294-78220f7f4cc7" /> |
| 2 | <img width="730" height="124" alt="image" src="https://github.com/user-attachments/assets/8fcf45df-7777-4d1e-ad5b-d36ebc79a2ed" />| <img width="730" height="124" alt="image" src="https://github.com/user-attachments/assets/487747de-c857-47e1-a89a-cb04544919be" /> |
| 3 | <img width="1068" height="483" alt="image" src="https://github.com/user-attachments/assets/259507d0-9eb1-4ea2-a9c7-b68565a158f8" /> | <img width="1068" height="483" alt="image" src="https://github.com/user-attachments/assets/13144f8b-38f3-4e6a-ab01-03bc5852420a" /> |
| 4 | <img width="389" height="214" alt="image" src="https://github.com/user-attachments/assets/ab1a7c57-55b5-4ca7-b37f-6c482c607285" /> | <img width="389" height="214" alt="image" src="https://github.com/user-attachments/assets/4e35af60-06d7-4969-abf3-92af6b707bac" /> |
| 5 | <img width="435" height="274" alt="image" src="https://github.com/user-attachments/assets/beaca812-a1cc-4f6a-bdd7-1bee492de24f" /> | <img width="435" height="274" alt="image" src="https://github.com/user-attachments/assets/a24ae6ce-d323-4327-832c-cff8cbbfdd06" /> |
| 6 | <img width="160" height="52" alt="image" src="https://github.com/user-attachments/assets/3e54ebf9-7516-4041-bc5c-cec3f282a6bb" /> | <img width="160" height="52" alt="image" src="https://github.com/user-attachments/assets/591a3965-c72e-4049-83f5-da67975cb4d9" /> |
