### PR TITLE
lib/logstorage: fix topk partition memory accounting

### DIFF
--- a/lib/logstorage/pipe_sort_topk.go
+++ b/lib/logstorage/pipe_sort_topk.go
@@ -334,7 +334,7 @@ func (shard *pipeTopkProcessorShard) getRowsByPartition(partition string) *pipeT
 		}
 		partition = strings.Clone(partition)
 		shard.rowsByPartition[partition] = rs
-		shard.stateSizeBudget += int(unsafe.Sizeof(*rs)+unsafe.Sizeof(rs)) + len(partition)
+		shard.stateSizeBudget -= int(unsafe.Sizeof(*rs)+unsafe.Sizeof(rs)) + len(partition)
 	}
 	return rs
 }


### PR DESCRIPTION
This PR fixes memory accounting for `sort ... limit ... partition by (...)`.

When a new partition is created in the top-k path, the memory budget of the shard is added instead of deducting.

The impact is very little as the size of the `pointer` + `partition key` + `pipeTopkRows struct` is small. I still fix it because it's wrong logic.

I don't add a changelog entry because this is an internal fix with no user-visible impact.