### PR TITLE
Docs: fix broken links in the documentation.

### DIFF
--- a/docs/victorialogs/FAQ.md
+++ b/docs/victorialogs/FAQ.md
@@ -363,7 +363,7 @@ The `hits` field in the returned results contains an estimated number of logs wi
 
 ## How to get the number of unique log streams on the given time range?
 
-Use [`count_uniq` pipe](https://docs.victoriametrics.com/victorialogs/logsql/#count_uniq-pipe)
+Use [`count_uniq(...)` stats function](https://docs.victoriametrics.com/victorialogs/logsql/#count_uniq-stats)
 over [`_stream`](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields) field.
 For example, the following [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/) query
 returns the number of unique [log streams](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields)

--- a/docs/victorialogs/victorialogs-datasource.md
+++ b/docs/victorialogs/victorialogs-datasource.md
@@ -8,7 +8,7 @@ aliases:
 ---
 ###### VictoriaLogs datasource for Grafana
 
-Moved to [victorialogs/integrations/grafana](https://docs.victoriametrics.com/victorialogs/integrations/grafana/#victorialogs-datasource-for-grafana).
+Moved to [victorialogs/integrations/grafana](https://docs.victoriametrics.com/victorialogs/integrations/grafana/).
 
 ###### Capabilities
 

--- a/docs/victorialogs/vlagent.md
+++ b/docs/victorialogs/vlagent.md
@@ -714,13 +714,13 @@ according to [these docs](https://docs.victoriametrics.com/victoriametrics/vmaut
 `vlagent` supports DNS SRV resolution in `-remoteWrite.url` when the hostname starts with `srv+`. For example, if DNS contains SRV records for `victoria-logs`, then:
 
 ```
-`-remoteWrite.url=http://srv+victoria-logs/insert/native`
+-remoteWrite.url=http://srv+victoria-logs/insert/native
 ```
 
-is resolved to one of the returned `target:port` addresses, for example:
+When vlagent creates a new TCP connection to the remote endpoint, it resolves the SRV record and uses one of the returned `target:port` addresses, for example:
 
 ```
-`-remoteWrite.url=http://victoria-logs-host:9428/insert/native`
+-remoteWrite.url=http://victoria-logs-host:9428/insert/native
 ```
 
 If SRV lookup returns multiple targets, `vlagent` randomly chooses a target per connection.

--- a/docs/victorialogs/vlagent.md
+++ b/docs/victorialogs/vlagent.md
@@ -48,7 +48,7 @@ Please download and unpack the `vlutils` archive from [releases page](https://gi
 and [Quay](https://quay.io/repository/victoriametrics/vlagent?tab=tags)), then pass the following command-line flags to the `vlagent-prod` binary:
 
 - `-remoteWrite.url` - the VictoriaLogs endpoint for sending the accepted logs to. It must end with `/insert/native`.
-  The `-remoteWrite.url` may refer to [DNS SRV](https://en.wikipedia.org/wiki/SRV_record) address. See [these docs](https://docs.victoriametrics.com/victorialogs/vlagent/#srv-urls) for details.
+  The `-remoteWrite.url` may refer to [DNS SRV](https://en.wikipedia.org/wiki/SRV_record) address. See [these docs](https://docs.victoriametrics.com/victoriametrics/vmagent/#srv-urls) for details.
 
 Example command, which starts `vlagent` for accepting logs over HTTP-based [supported protocols](https://docs.victoriametrics.com/victorialogs/data-ingestion/)
 at the port `9429` and sends the collected logs to VictoriaLogs instance at `victoria-logs-host:9428`:

--- a/docs/victorialogs/vlagent.md
+++ b/docs/victorialogs/vlagent.md
@@ -707,6 +707,19 @@ according to [these docs](https://docs.victoriametrics.com/victoriametrics/vmaut
 - Use `-remoteWrite.showURL=false` (the default) to prevent sensitive URL parameters such as tokens or passwords
   from appearing in logs and on the debug endpoints like `/metrics` and `/debug/pprof/*`
 
+## SRV URLs
+
+If `vlagent` encounters URLs with `srv+` prefix in hostname (such as `http://srv+some-addr/some/path`), then it resolves `some-addr` [DNS SRV](https://en.wikipedia.org/wiki/SRV_record) record into TCP address with hostname and TCP port, and then use the resulting URL when it needs to connect to it.
+
+SRV URLs are supported in the following places:
+
+* In `-remoteWrite.url` command-line flag. For example, if `victoria-logs` [DNS SRV](https://en.wikipedia.org/wiki/SRV_record) record contains
+  `victoria-logs-host:9428` TCP address, then `-remoteWrite.url=http://srv+victoria-logs/insert/native` is automatically resolved into
+  `-remoteWrite.url=http://victoria-logs-host:9428/api/v1/write`. If the DNS SRV record is resolved into multiple TCP addresses, then `vlagent`
+  uses a randomly chosen address for each connection it establishes to the remote storage.
+
+SRV URLs are useful when HTTP services run on different TCP ports or when their TCP ports can change over time (for instance, after a restart).
+
 ## remote write format
 
 By default, `vlagent` sends logs to the `-remoteWrite.url` with `native` protocol, which is supported by all VictoriaLogs components.

--- a/docs/victorialogs/vlagent.md
+++ b/docs/victorialogs/vlagent.md
@@ -709,16 +709,21 @@ according to [these docs](https://docs.victoriametrics.com/victoriametrics/vmaut
 
 ## SRV URLs
 
-If `vlagent` encounters URLs with `srv+` prefix in hostname (such as `http://srv+some-addr/some/path`), then it resolves `some-addr` [DNS SRV](https://en.wikipedia.org/wiki/SRV_record) record into TCP address with hostname and TCP port, and then use the resulting URL when it needs to connect to it.
+[DNS SRVs](https://en.wikipedia.org/wiki/SRV_record) are useful when HTTP services run on different TCP ports or when their TCP ports can change over time (for instance, after a restart).
 
-SRV URLs are supported in the following places:
+`vlagent` supports DNS SRV resolution in `-remoteWrite.url` when the hostname starts with `srv+`. For example, if DNS contains SRV records for `victoria-logs`, then:
 
-* In `-remoteWrite.url` command-line flag. For example, if `victoria-logs` [DNS SRV](https://en.wikipedia.org/wiki/SRV_record) record contains
-  `victoria-logs-host:9428` TCP address, then `-remoteWrite.url=http://srv+victoria-logs/insert/native` is automatically resolved into
-  `-remoteWrite.url=http://victoria-logs-host:9428/api/v1/write`. If the DNS SRV record is resolved into multiple TCP addresses, then `vlagent`
-  uses a randomly chosen address for each connection it establishes to the remote storage.
+```
+`-remoteWrite.url=http://srv+victoria-logs/insert/native`
+```
 
-SRV URLs are useful when HTTP services run on different TCP ports or when their TCP ports can change over time (for instance, after a restart).
+is resolved to one of the returned `target:port` addresses, for example:
+
+```
+`-remoteWrite.url=http://victoria-logs-host:9428/insert/native`
+```
+
+If SRV lookup returns multiple targets, `vlagent` randomly chooses a target per connection.
 
 ## remote write format
 


### PR DESCRIPTION
This PR is linked to the [effort to fix broken links and anchors in the documentation](https://github.com/VictoriaMetrics/vmdocs/issues/221).

The PR fixes two broken anchors. The first one needs review to ensure the fix is valid:

Fix 1) The anchor `victorialogs/vlagent/#srv-urls` is broken. There is no heading "SRV URLs" in vlagent.md in this repository. I couldn't find in the commit history if the heading existed before. Looking at the whole documentation site, I see there is a "SRV URLs" in vmagent. I'm guessing the original intention was to link to [vmagent#srv-urls](https://docs.victoriametrics.com/victoriametrics/vmagent/#srv-urls) since the mechanisms for SRV URLs is likely the same for vmagent and vlagent. Tentatively, I've linked to that page+anchor on vmagent.

This fixes the broken link but we need to check if it's what was originally intended. 

Alternatively, we can either:
- add a SRV URLs section in vlagent.md
- remove the broken link from the `vlagent.md` page altogether
- change the anchor in vlagent.md to a different place heading or page

Fix 2) Remove the anchor in `docs/victorialogs/victorialogs-datasource.md` pointing to the Grafana integration

The original integration page is here: https://github.com/VictoriaMetrics/victorialogs-datasource/blob/main/src/README.md

The anchor is not needed since the page already starts with "VictoriaLogs datasource for Grafana". Removing the anchor maintains the behavior without generating a broken link.
