### PR TITLE
app/vmui: remove _msg filter from stream_context query

### DIFF
--- a/app/vmui/packages/vmui/src/constants/logs.ts
+++ b/app/vmui/packages/vmui/src/constants/logs.ts
@@ -1,7 +1,7 @@
 import { DATE_TIME_FORMAT } from "./date";
 import { getIsMobile } from "../hooks/useDeviceDetect";
 
-export const LOGS_STREAM_CONTEXT_KEYS = ["_stream_id", "_time", "_msg"];
+export const LOGS_STREAM_CONTEXT_KEYS = ["_stream_id", "_time"];
 export const LOGS_DOCS_URL = "https://docs.victoriametrics.com/victorialogs";
 
 export const LOGS_DEFAULT_LIMIT = 50;

--- a/app/vmui/packages/vmui/src/pages/StreamContext/hooks/useFetchStreamContext.ts
+++ b/app/vmui/packages/vmui/src/pages/StreamContext/hooks/useFetchStreamContext.ts
@@ -25,8 +25,8 @@ const buildContextQuery = (
   const { _stream_id, _time } = log;
 
   if (!_stream_id || !_time) {
-    throw new Error("Log must contain _stream_id, _time and _msg fields.");
-  }
+    throw new Error("Log must contain _stream_id and _time fields.");
+}
 
   return `_stream_id:${_stream_id} 
 _time:${toNanoPrecision(_time)} 

--- a/app/vmui/packages/vmui/src/pages/StreamContext/hooks/useFetchStreamContext.ts
+++ b/app/vmui/packages/vmui/src/pages/StreamContext/hooks/useFetchStreamContext.ts
@@ -26,7 +26,7 @@ const buildContextQuery = (
 
   if (!_stream_id || !_time) {
     throw new Error("Log must contain _stream_id and _time fields.");
-}
+  }
 
   return `_stream_id:${_stream_id} 
 _time:${toNanoPrecision(_time)} 

--- a/app/vmui/packages/vmui/src/pages/StreamContext/hooks/useFetchStreamContext.ts
+++ b/app/vmui/packages/vmui/src/pages/StreamContext/hooks/useFetchStreamContext.ts
@@ -6,7 +6,6 @@ import {
 import { Logs } from "../../../api/types";
 import { useFetchLogs } from "../../QueryPage/hooks/useFetchLogs";
 import { toNanoPrecision } from "../../../utils/time";
-import { escapeForLogsQLString } from "../../../utils/regexp";
 import { removeExactLog } from "../../../utils/logs";
 import { LOGS_STREAM_CONTEXT_KEYS } from "../../../constants/logs";
 
@@ -23,15 +22,14 @@ const buildContextQuery = (
   dir: Direction,
   lines: number
 ): string => {
-  const { _stream_id, _time, _msg } = log;
+  const { _stream_id, _time } = log;
 
-  if (!_stream_id || !_time || !_msg) {
+  if (!_stream_id || !_time) {
     throw new Error("Log must contain _stream_id, _time and _msg fields.");
   }
 
   return `_stream_id:${_stream_id} 
 _time:${toNanoPrecision(_time)} 
-_msg:="${escapeForLogsQLString(_msg)}" 
 | stream_context ${dir} ${lines}
 | sort by (_time) desc`;
 };

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -38,7 +38,7 @@ according to the following docs:
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix stream context view where the selected log overlapped transparently with content below when scrolling. See [#1185](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1185).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix browser navigation issues where the UI state didn't update on URL changes. See [#1056](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1056).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): remove extra empty value in `Stream fields` sidebar when selecting all values within a field. See [#1235](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1235).
-* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix incorrect stream_context selection for logs with identical timestamps. See [#1199](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1199).
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix target log rendering in the `Log context` modal. See [#1199](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1199).
 
 ## [v1.50.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.50.0)
 


### PR DESCRIPTION
### Describe Your Changes

This PR removes redundant `_msg` filtering from `stream_context` queries introduced in #1396.

PR #1396 already fixed the original issue by correcting target log rendering logic in the Log context modal. The additional `_msg` filter is unnecessary.