### PR TITLE
lib/logstorage: fix handling leading whitespaces in `unpack_json`

### DIFF
--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -41,6 +41,7 @@ according to the following docs:
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): remove extra empty value in `Stream fields` sidebar when selecting all values within a field. See [#1235](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1235).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix target log rendering in the `Log context` modal. See [#1199](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1199).
 * BUGFIX: [HTTP querying APIs](https://docs.victoriametrics.com/victorialogs/querying/#http-api): return `502 Bad Gateway` from [`/select/logsql/stats_query`](https://docs.victoriametrics.com/victorialogs/querying/#querying-log-stats) and [`/select/logsql/stats_query_range`](https://docs.victoriametrics.com/victorialogs/querying/#querying-log-range-stats) when one of `vlstorage` nodes is unavailable in cluster mode. Previously these endpoints could incorrectly return `422 Unprocessable Entity`, which could break retry and failover handling in high-availability setups. See [#1419](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1419).
+* BUGFIX: [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/): fix the `unpack_json` pipe which fails to parse JSON when it starts with whitespace characters.
 
 ## [v1.50.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.50.0)
 

--- a/lib/logstorage/pipe_unpack_json.go
+++ b/lib/logstorage/pipe_unpack_json.go
@@ -3,6 +3,7 @@ package logstorage
 import (
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
 
@@ -100,6 +101,7 @@ func (pu *pipeUnpackJSON) visitSubqueries(visitFunc func(q *Query)) {
 
 func (pu *pipeUnpackJSON) newPipeProcessor(_ int, _ <-chan struct{}, _ func(), ppNext pipeProcessor) pipeProcessor {
 	unpackJSON := func(uctx *fieldsUnpackerContext, s string) {
+		s = strings.TrimSpace(s)
 		if len(s) == 0 || s[0] != '{' {
 			// This isn't a JSON object
 			return

--- a/lib/logstorage/pipe_unpack_json_test.go
+++ b/lib/logstorage/pipe_unpack_json_test.go
@@ -334,6 +334,18 @@ func TestPipeUnpackJSON(t *testing.T) {
 			{"x", `{"z":["bar",123]}`},
 		},
 	})
+
+	// JSON wrapped with spaces
+	f("unpack_json", [][]Field{
+		{
+			{"_msg", `  {  "foo" : "bar"  }  `},
+		},
+	}, [][]Field{
+		{
+			{"_msg", `  {  "foo" : "bar"  }  `},
+			{"foo", "bar"},
+		},
+	})
 }
 
 func TestPipeUnpackJSONUpdateNeededFields(t *testing.T) {


### PR DESCRIPTION
To reproduce the issue, insert a JSON log with leading whitespace:

```sh
curl -X POST http://localhost:9428/insert/jsonline -H "Content-Type: application/json" \
    --data-binary '{"_msg":"    {\"foo\":123} "}'
```

And try to run `unpack_json` on it:

```sh
curl -X POST 'http://localhost:9428/select/logsql/query' -d 'query=foo 123 | unpack_json'
```

I expected it to return:

```json
{"_msg":"    {\"foo\":123} ", ..., "foo":"123"}
```

but it returns:

```json
{"_msg":"    {\"foo\":123} ", ...}
```
