### PR TITLE
app/vlselect/logsql: return 502 from stats_query APIs when vlstorage is unavailable

### DIFF
--- a/app/vlselect/logsql/logsql.go
+++ b/app/vlselect/logsql/logsql.go
@@ -1008,7 +1008,7 @@ func ProcessStatsQueryRangeRequest(ctx context.Context, w http.ResponseWriter, r
 	// Execute the request.
 	startTime := time.Now()
 	if err := vlstorage.RunQuery(qctx, writeBlock); err != nil {
-		err = fmt.Errorf("cannot execute query [%s]: %s", ca.q, err)
+		err = fmt.Errorf("cannot execute query [%s]: %w", ca.q, err)
 		httpserver.SendPrometheusError(w, r, err)
 		return
 	}
@@ -1144,7 +1144,7 @@ func ProcessStatsQueryRequest(ctx context.Context, w http.ResponseWriter, r *htt
 	// Execute the query
 	startTime := time.Now()
 	if err := vlstorage.RunQuery(qctx, writeBlock); err != nil {
-		err = fmt.Errorf("cannot execute query [%s]: %s", ca.q, err)
+		err = fmt.Errorf("cannot execute query [%s]: %w", ca.q, err)
 		httpserver.SendPrometheusError(w, r, err)
 		return
 	}

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -40,6 +40,7 @@ according to the following docs:
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix browser navigation issues where the UI state didn't update on URL changes. See [#1056](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1056).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): remove extra empty value in `Stream fields` sidebar when selecting all values within a field. See [#1235](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1235).
 * BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix target log rendering in the `Log context` modal. See [#1199](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1199).
+* BUGFIX: [HTTP querying APIs](https://docs.victoriametrics.com/victorialogs/querying/#http-api): return `502 Bad Gateway` from [`/select/logsql/stats_query`](https://docs.victoriametrics.com/victorialogs/querying/#querying-log-stats) and [`/select/logsql/stats_query_range`](https://docs.victoriametrics.com/victorialogs/querying/#querying-log-range-stats) when one of `vlstorage` nodes is unavailable in cluster mode. Previously these endpoints could incorrectly return `422 Unprocessable Entity`, which could break retry and failover handling in high-availability setups. See [#1419](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1419).
 
 ## [v1.50.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.50.0)
 


### PR DESCRIPTION
Closes https://github.com/VictoriaMetrics/VictoriaLogs/issues/1419

Fixes the typo, preserves the original `ErrorWithStatusCode` returned from vlstorage, so `/select/logsql/stats_query` and `/select/logsql/stats_query_range` return `502` instead of `422` when a vlstorage node is unavailable in cluster mode.