### PR TITLE
lib/prefixfilter: fix nil wildcard filter matching

### DIFF
--- a/lib/prefixfilter/filter.go
+++ b/lib/prefixfilter/filter.go
@@ -84,6 +84,9 @@ func (f *Filter) MatchAll() bool {
 // s may be either a regular string or a wildcard ending with '*'.
 // If s is a wildcard, then true is returned if at least a single string matching this wildcard matches f.
 func (f *Filter) MatchStringOrWildcard(s string) bool {
+	if f == nil {
+		return false
+	}
 	if !IsWildcardFilter(s) {
 		return f.MatchString(s)
 	}

--- a/lib/prefixfilter/filter_test.go
+++ b/lib/prefixfilter/filter_test.go
@@ -212,6 +212,22 @@ func TestFilter_MatchString_NilFilter(t *testing.T) {
 	f("foo")
 }
 
+func TestFilter_MatchStringOrWildcard_NilFilter(t *testing.T) {
+	f := func(s string) {
+		t.Helper()
+
+		var f *Filter
+		if f.MatchStringOrWildcard(s) {
+			t.Fatalf("unexpected MatchStringOrWildcard(%q) for nil Filter; got true; want false", s)
+		}
+	}
+
+	f("")
+	f("foo")
+	f("*")
+	f("foo*")
+}
+
 func TestFilter_Clone(t *testing.T) {
 	f := func(allow, deny []string) {
 		t.Helper()


### PR DESCRIPTION
Small papercut fix, no biggie.

`MatchString` already returns false for nil receivers, but `MatchStringOrWildcard` missed that guard. So a nil `*Filter` + wildcard input could still blow up.

Repro on old master:

```sh
go test ./lib/prefixfilter -run TestFilter_MatchStringOrWildcard_NilFilter -count=1
```

It panics at `filter.go:92` with a nil pointer deref.

This adds the same nil guard and keeps wildcard matching behavior as-is.

Tests:

```sh
go test ./lib/prefixfilter ./lib/logstorage -count=1
```

Also tried `go test ./... -count=1`; it gets to `apptest/tests` and fails because `../../bin/victoria-logs-race` is not built locally.
