### PR TITLE
.github: enforce least permissions for github action jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,16 +20,17 @@ on:
       - '!app/vmui/Makefile'
       - '.github/workflows/build.yml'
 
-permissions:
-  contents: read
-
 concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
+permissions: {}
+
 jobs:
   build:
     name: Build
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Code checkout

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -6,12 +6,14 @@ on:
   pull_request:
     paths:
       - 'vendor'
-permissions:
-  contents: read
+
+permissions: {}
 
 jobs:
   build:
     name: Build
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Code checkout

--- a/.github/workflows/codeql-analysis-go.yml
+++ b/.github/workflows/codeql-analysis-go.yml
@@ -16,6 +16,8 @@ concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,12 +7,14 @@ on:
       - 'docs/**'
       - '.github/workflows/docs.yaml'
   workflow_dispatch: {}
-permissions:
-  contents: read  # This is required for actions/checkout and to commit back image update
-  deployments: write
+
+permissions: {}
+
 jobs:
   build:
     name: Build
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Code checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,16 +16,17 @@ on:
       - 'go.*'
       - '.github/workflows/main.yml'
 
-permissions:
-  contents: read
-
 concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
+permissions: {}
+
 jobs:
   lint:
     name: lint
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Code checkout
@@ -56,6 +57,8 @@ jobs:
   test:
     name: test
     needs: lint
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     strategy:
@@ -92,6 +95,8 @@ jobs:
   integration-test:
     name: integration-test
     needs: [lint, test]
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/vmui.yml
+++ b/.github/workflows/vmui.yml
@@ -14,19 +14,19 @@ on:
       - 'app/vmui/packages/vmui/**'
       - '.github/workflows/vmui.yml'
 
-permissions:
-  contents: read
-  packages: read
-  pull-requests: read
-  checks: write
-
 concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
+permissions: {}
+
 jobs:
   vmui-checks:
     name: VMUI Checks (lint, test, typecheck)
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: Code checkout


### PR DESCRIPTION
Set permissions at the job level instead of workflow level. Set `permissions: {}` at workflow level.
I removed some unnecessary permissions in the following files, please check:
- `docs.yaml`
- `vmui.yml`