### PR TITLE
lib/logstorage: fix typos in error messages and comments

### DIFF
--- a/lib/logstorage/block.go
+++ b/lib/logstorage/block.go
@@ -150,7 +150,7 @@ func (c *column) mustWriteTo(ch *columnHeader, sw *streamWriters) {
 	putValuesEncoder(ve)
 	ch.valuesSize = uint64(len(bb.B))
 	if ch.valuesSize > maxValuesBlockSize {
-		logger.Panicf("BUG: too valuesSize: %d bytes; mustn't exceed %d bytes", ch.valuesSize, maxValuesBlockSize)
+		logger.Panicf("BUG: too big valuesSize: %d bytes; mustn't exceed %d bytes", ch.valuesSize, maxValuesBlockSize)
 	}
 	ch.valuesOffset = bloomValuesWriter.values.bytesWritten
 	bloomValuesWriter.values.MustWrite(bb.B)

--- a/lib/logstorage/filter_string_range.go
+++ b/lib/logstorage/filter_string_range.go
@@ -6,7 +6,7 @@ import (
 
 var maxStringRangeValue = string([]byte{255, 255, 255, 255})
 
-// filterStringRange matches tie given string range [minValue..maxValue)
+// filterStringRange matches the given string range [minValue..maxValue)
 //
 // Note that the minValue is included in the range, while the maxValue isn't included in the range.
 // This simplifies querying distinct log sets with string_range(A, B), string_range(B, C), etc.

--- a/lib/logstorage/parser_test.go
+++ b/lib/logstorage/parser_test.go
@@ -4489,7 +4489,7 @@ func TestTryParseIPv4CIDR_Success(t *testing.T) {
 			t.Fatalf("cannot parse %s as ipv4 CIDR", s)
 		}
 		if minValue != minValueExpected {
-			t.Fatalf("unexpeccted minValue; got %d; want %d", minValue, minValueExpected)
+			t.Fatalf("unexpected minValue; got %d; want %d", minValue, minValueExpected)
 		}
 		if maxValue != maxValueExpected {
 			t.Fatalf("unexpected maxValue; got %d; want %d", maxValue, maxValueExpected)

--- a/lib/logstorage/running_stats_last.go
+++ b/lib/logstorage/running_stats_last.go
@@ -67,7 +67,7 @@ func parseRunningStatsLast(lex *lexer) (runningStatsFunc, error) {
 		return nil, err
 	}
 	if len(args) != 1 {
-		return nil, fmt.Errorf("unexpeccted number of args for the last() function; got %d; want 1; args: %q", len(args), args)
+		return nil, fmt.Errorf("unexpected number of args for the last() function; got %d; want 1; args: %q", len(args), args)
 	}
 
 	fieldName := args[0]


### PR DESCRIPTION
Small typo fixes in 4 files:

- `block.go`: panic message says `BUG: too valuesSize` - missing word "big" (the panic 18 lines below for `bloomFilterSize` says it correctly: `BUG: too big bloomFilterSize`)
- `filter_string_range.go`: comment says `matches tie given string range` (tie -> the)
- `running_stats_last.go`: error returned to user says `unexpeccted` (doubled c)
- `parser_test.go`: same `unexpeccted` in test failure message

How to trigger the `running_stats_last.go` one: pass wrong number of args to `last()` in a running stats query, e.g. `| running_stats last(a, b)` - you get the misspelled error back.

The `block.go` panic only fires when a values block exceeds `maxValuesBlockSize`, which is a hard internal limit - so it's not user-triggerable in normal ops, but the message is still wrong when it does fire.