### PR TITLE
lib/logstorage: move pipe stop tokens to a separate variable

### DIFF
--- a/lib/logstorage/parser.go
+++ b/lib/logstorage/parser.go
@@ -2089,7 +2089,7 @@ func parseQueryOptions(dstOpts *queryOptions, lex *lexer) error {
 }
 
 func parseFilter(lex *lexer, allowPipeKeywords bool) (filter, error) {
-	if lex.isKeyword("|", ")", "") {
+	if lex.isKeywordAny(pipeStopTokens) {
 		return nil, fmt.Errorf("missing query")
 	}
 
@@ -2118,7 +2118,7 @@ func parseFilterOr(lex *lexer, fieldName string) (filter, error) {
 		}
 		filters = append(filters, f)
 		switch {
-		case lex.isKeyword("|", ")", ""):
+		case lex.isKeywordAny(pipeStopTokens):
 			if len(filters) == 1 {
 				return filters[0], nil
 			}
@@ -2139,7 +2139,7 @@ func parseFilterAnd(lex *lexer, fieldName string) (filter, error) {
 		}
 		filters = append(filters, f)
 		switch {
-		case lex.isKeyword("or", "|", ")", ""):
+		case lex.isKeyword("or") || lex.isKeywordAny(pipeStopTokens):
 			if len(filters) == 1 {
 				return filters[0], nil
 			}
@@ -2684,7 +2684,7 @@ func parseFilterStar(lex *lexer, fieldName string) (filter, error) {
 		return parseFilterGeneric(lex, "*")
 	}
 
-	if lex.isSkippedSpace || lex.isKeyword("", ")", "|") {
+	if lex.isSkippedSpace || lex.isKeywordAny(pipeStopTokens) {
 		// '*' or 'fieldName:*' filter
 		return newFilterPrefix(fieldName, ""), nil
 	}
@@ -2699,7 +2699,7 @@ func parseFilterStar(lex *lexer, fieldName string) (filter, error) {
 	}
 	lex.nextToken()
 
-	if !lex.isSkippedSpace && !lex.isKeyword("", ")", "|") {
+	if !lex.isSkippedSpace && !lex.isKeywordAny(pipeStopTokens) {
 		return nil, fmt.Errorf("missing whitespace between *%q* and %q", phrase, lex.token)
 	}
 	return newFilterSubstring(fieldName, phrase), nil

--- a/lib/logstorage/pipe.go
+++ b/lib/logstorage/pipe.go
@@ -112,6 +112,8 @@ func (npp *noopPipeProcessor) flush() error {
 	return nil
 }
 
+var pipeStopTokens = []string{"|", ")", ""}
+
 func parsePipes(lex *lexer) ([]pipe, error) {
 	var pipes []pipe
 	for {

--- a/lib/logstorage/pipe_blocks_count.go
+++ b/lib/logstorage/pipe_blocks_count.go
@@ -133,7 +133,7 @@ func parsePipeBlocksCount(lex *lexer) (pipe, error) {
 			return nil, fmt.Errorf("cannot parse result name for 'blocks_count': %w", err)
 		}
 		resultName = name
-	} else if !lex.isKeyword("", "|") {
+	} else if !lex.isKeywordAny(pipeStopTokens) {
 		name, err := parseFieldName(lex)
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse result name for 'blocks_count': %w", err)

--- a/lib/logstorage/pipe_copy.go
+++ b/lib/logstorage/pipe_copy.go
@@ -126,7 +126,7 @@ func parsePipeCopy(lex *lexer) (pipe, error) {
 		dstFieldFilters = append(dstFieldFilters, dstFieldFilter)
 
 		switch {
-		case lex.isKeyword("|", ")", ""):
+		case lex.isKeywordAny(pipeStopTokens):
 			pc := &pipeCopy{
 				srcFieldFilters: srcFieldFilters,
 				dstFieldFilters: dstFieldFilters,

--- a/lib/logstorage/pipe_decolorize.go
+++ b/lib/logstorage/pipe_decolorize.go
@@ -72,7 +72,7 @@ func parsePipeDecolorize(lex *lexer) (pipe, error) {
 	lex.nextToken()
 
 	field := "_msg"
-	if !lex.isKeyword("|", ")", "") {
+	if !lex.isKeywordAny(pipeStopTokens) {
 		f, err := parseFieldName(lex)
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse field name after 'decolorize': %w", err)

--- a/lib/logstorage/pipe_field_names.go
+++ b/lib/logstorage/pipe_field_names.go
@@ -264,7 +264,7 @@ func parsePipeFieldNames(lex *lexer) (pipe, error) {
 			return nil, fmt.Errorf("cannot parse result name for 'field_names': %w", err)
 		}
 		resultName = name
-	} else if !lex.isKeyword("", "|") {
+	} else if !lex.isKeywordAny(pipeStopTokens) {
 		name, err := parseFieldName(lex)
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse result name for 'field_names': %w", err)

--- a/lib/logstorage/pipe_hash.go
+++ b/lib/logstorage/pipe_hash.go
@@ -173,7 +173,7 @@ func parsePipeHash(lex *lexer) (pipe, error) {
 	if lex.isKeyword("as") {
 		lex.nextToken()
 	}
-	if !lex.isKeyword("|", ")", "") {
+	if !lex.isKeywordAny(pipeStopTokens) {
 		field, err := parseFieldName(lex)
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse result field after 'hash(%s)': %w", quoteTokenIfNeeded(fieldName), err)

--- a/lib/logstorage/pipe_json_array_len.go
+++ b/lib/logstorage/pipe_json_array_len.go
@@ -182,7 +182,7 @@ func parsePipeJSONArrayLen(lex *lexer) (pipe, error) {
 	if lex.isKeyword("as") {
 		lex.nextToken()
 	}
-	if !lex.isKeyword("|", ")", "") {
+	if !lex.isKeywordAny(pipeStopTokens) {
 		field, err := parseFieldName(lex)
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse result field after 'len(%s)': %w", quoteTokenIfNeeded(fieldName), err)

--- a/lib/logstorage/pipe_last.go
+++ b/lib/logstorage/pipe_last.go
@@ -102,7 +102,7 @@ func parsePipeLast(lex *lexer) (pipe, error) {
 func parsePipeLastFirst(lex *lexer) (*pipeSort, error) {
 	var ps pipeSort
 	ps.limit = 1
-	if !lex.isKeyword("by", "partition", "rank", "(", "|", ")", "") {
+	if !lex.isKeyword("by", "partition", "rank", "(") && !lex.isKeywordAny(pipeStopTokens) {
 		s, err := lex.nextCompoundToken()
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse number: %w", err)

--- a/lib/logstorage/pipe_len.go
+++ b/lib/logstorage/pipe_len.go
@@ -165,7 +165,7 @@ func parsePipeLen(lex *lexer) (pipe, error) {
 	if lex.isKeyword("as") {
 		lex.nextToken()
 	}
-	if !lex.isKeyword("|", ")", "") {
+	if !lex.isKeywordAny(pipeStopTokens) {
 		field, err := parseFieldName(lex)
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse result field after 'len(%s)': %w", quoteTokenIfNeeded(fieldName), err)

--- a/lib/logstorage/pipe_limit.go
+++ b/lib/logstorage/pipe_limit.go
@@ -113,7 +113,7 @@ func parsePipeLimit(lex *lexer) (pipe, error) {
 	lex.nextToken()
 
 	limit := uint64(10)
-	if !lex.isKeyword("|", ")", "") {
+	if !lex.isKeywordAny(pipeStopTokens) {
 		limitStr, err := lex.nextCompoundToken()
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse rows limit: %w", err)

--- a/lib/logstorage/pipe_math.go
+++ b/lib/logstorage/pipe_math.go
@@ -460,7 +460,7 @@ func parsePipeMath(lex *lexer) (pipe, error) {
 		switch {
 		case lex.isKeyword(","):
 			lex.nextToken()
-		case lex.isKeyword("|", ")", ""):
+		case lex.isKeywordAny(pipeStopTokens):
 			if len(mes) == 0 {
 				return nil, fmt.Errorf("missing 'math' expressions")
 			}
@@ -481,7 +481,7 @@ func parseMathEntry(lex *lexer) (*mathEntry, error) {
 	}
 
 	resultField := ""
-	if lex.isKeyword(",", "|", ")", "") {
+	if lex.isKeyword(",") || lex.isKeywordAny(pipeStopTokens) {
 		resultField = me.String()
 	} else {
 		if lex.isKeyword("as") {

--- a/lib/logstorage/pipe_pack_json.go
+++ b/lib/logstorage/pipe_pack_json.go
@@ -88,7 +88,7 @@ func parsePipePackJSON(lex *lexer) (pipe, error) {
 	if lex.isKeyword("as") {
 		lex.nextToken()
 	}
-	if !lex.isKeyword("|", ")", "") {
+	if !lex.isKeywordAny(pipeStopTokens) {
 		field, err := parseFieldName(lex)
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse result field for 'pack_json': %w", err)

--- a/lib/logstorage/pipe_pack_logfmt.go
+++ b/lib/logstorage/pipe_pack_logfmt.go
@@ -88,7 +88,7 @@ func parsePipePackLogfmt(lex *lexer) (pipe, error) {
 	if lex.isKeyword("as") {
 		lex.nextToken()
 	}
-	if !lex.isKeyword("|", ")", "") {
+	if !lex.isKeywordAny(pipeStopTokens) {
 		field, err := parseFieldName(lex)
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse result field for 'pack_logfmt': %w", err)

--- a/lib/logstorage/pipe_rename.go
+++ b/lib/logstorage/pipe_rename.go
@@ -135,7 +135,7 @@ func parsePipeRename(lex *lexer) (pipe, error) {
 		dstFieldFilters = append(dstFieldFilters, dstFieldFilter)
 
 		switch {
-		case lex.isKeyword("|", ")", ""):
+		case lex.isKeywordAny(pipeStopTokens):
 			pr := &pipeRename{
 				srcFieldFilters: srcFieldFilters,
 				dstFieldFilters: dstFieldFilters,

--- a/lib/logstorage/pipe_running_stats.go
+++ b/lib/logstorage/pipe_running_stats.go
@@ -415,7 +415,7 @@ func parsePipeRunningStatsExt(lex *lexer, pipeName string) (pipe, error) {
 		f.f = sf
 
 		resultName := ""
-		if lex.isKeyword(",", "|", ")", "") {
+		if lex.isKeyword(",") || lex.isKeywordAny(pipeStopTokens) {
 			resultName = sf.String()
 		} else {
 			if lex.isKeyword("as") {
@@ -435,7 +435,7 @@ func parsePipeRunningStatsExt(lex *lexer, pipeName string) (pipe, error) {
 
 		funcs = append(funcs, f)
 
-		if lex.isKeyword("|", ")", "") {
+		if lex.isKeywordAny(pipeStopTokens) {
 			ps.funcs = funcs
 			return &ps, nil
 		}

--- a/lib/logstorage/pipe_split.go
+++ b/lib/logstorage/pipe_split.go
@@ -142,7 +142,7 @@ func parsePipeSplit(lex *lexer) (pipe, error) {
 	}
 
 	srcField := "_msg"
-	if !lex.isKeyword("as", ")", "|", "") {
+	if !lex.isKeyword("as") && !lex.isKeywordAny(pipeStopTokens) {
 		if lex.isKeyword("from") {
 			lex.nextToken()
 		}
@@ -154,7 +154,7 @@ func parsePipeSplit(lex *lexer) (pipe, error) {
 	}
 
 	dstField := srcField
-	if !lex.isKeyword(")", "|", "") {
+	if !lex.isKeywordAny(pipeStopTokens) {
 		if lex.isKeyword("as") {
 			lex.nextToken()
 		}

--- a/lib/logstorage/pipe_stats.go
+++ b/lib/logstorage/pipe_stats.go
@@ -1389,7 +1389,7 @@ func parsePipeStatsExt(lex *lexer, needStatsKeyword bool) (pipe, error) {
 		}
 		ps.entries = append(ps.entries, e)
 
-		if lex.isKeyword("|", ")", "") {
+		if lex.isKeywordAny(pipeStopTokens) {
 			break
 		}
 		if !lex.isKeyword(",") {
@@ -1442,7 +1442,7 @@ func parseStatsEntry(lex *lexer) (pipeStatsEntry, error) {
 	}
 
 	resultName := ""
-	if lex.isKeyword(",", "|", ")", "") {
+	if lex.isKeyword(",") || lex.isKeywordAny(pipeStopTokens) {
 		resultName = sf.String()
 		if iff != nil {
 			resultName += " " + iff.String()

--- a/lib/logstorage/pipe_top.go
+++ b/lib/logstorage/pipe_top.go
@@ -620,7 +620,7 @@ func parsePipeTop(lex *lexer) (pipe, error) {
 			return nil, fmt.Errorf("cannot parse 'by(...)': %w", err)
 		}
 		byFields = bfs
-	} else if !lex.isKeyword("hits", "rank", ")", "|", "") {
+	} else if !lex.isKeyword("hits", "rank") && !lex.isKeywordAny(pipeStopTokens) {
 		bfs, err := parseCommaSeparatedFields(lex)
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse 'by ...': %w", err)
@@ -674,11 +674,11 @@ func parseRankFieldName(lex *lexer) (string, error) {
 	rankFieldName := "rank"
 	if lex.isKeyword("as") {
 		lex.nextToken()
-		if lex.isKeyword("", "|", ")", "(") {
+		if lex.isKeyword("(") || lex.isKeywordAny(pipeStopTokens) {
 			return "", fmt.Errorf("missing rank name")
 		}
 	}
-	if !lex.isKeyword("", "|", ")", "limit") {
+	if !lex.isKeyword("limit") && !lex.isKeywordAny(pipeStopTokens) {
 		s, err := parseFieldName(lex)
 		if err != nil {
 			return "", err

--- a/lib/logstorage/pipe_uniq.go
+++ b/lib/logstorage/pipe_uniq.go
@@ -550,7 +550,7 @@ func parsePipeUniq(lex *lexer) (pipe, error) {
 			return nil, fmt.Errorf("cannot parse 'by(...)': %w", err)
 		}
 		byFields = bfs
-	} else if !lex.isKeyword("filter", "with", "hits", "limit", ")", "|", "") {
+	} else if !lex.isKeyword("filter", "with", "hits", "limit") && !lex.isKeywordAny(pipeStopTokens) {
 		bfs, err := parseCommaSeparatedFields(lex)
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse 'by ...': %w", err)

--- a/lib/logstorage/pipe_unpack_json.go
+++ b/lib/logstorage/pipe_unpack_json.go
@@ -160,7 +160,7 @@ func parsePipeUnpackJSON(lex *lexer) (pipe, error) {
 	}
 
 	fromField := "_msg"
-	if !lex.isKeyword("fields", "preserve_keys", "result_prefix", "keep_original_fields", "skip_empty_results", ")", "|", "") {
+	if !lex.isKeyword("fields", "preserve_keys", "result_prefix", "keep_original_fields", "skip_empty_results") && !lex.isKeywordAny(pipeStopTokens) {
 		if lex.isKeyword("from") {
 			lex.nextToken()
 		}

--- a/lib/logstorage/pipe_unpack_logfmt.go
+++ b/lib/logstorage/pipe_unpack_logfmt.go
@@ -142,7 +142,7 @@ func parsePipeUnpackLogfmt(lex *lexer) (pipe, error) {
 	}
 
 	fromField := "_msg"
-	if !lex.isKeyword("fields", "result_prefix", "keep_original_fields", "skip_empty_results", ")", "|", "") {
+	if !lex.isKeyword("fields", "result_prefix", "keep_original_fields", "skip_empty_results") && !lex.isKeywordAny(pipeStopTokens) {
 		if lex.isKeyword("from") {
 			lex.nextToken()
 		}

--- a/lib/logstorage/pipe_unpack_syslog.go
+++ b/lib/logstorage/pipe_unpack_syslog.go
@@ -135,7 +135,7 @@ func parsePipeUnpackSyslog(lex *lexer) (pipe, error) {
 	}
 
 	fromField := "_msg"
-	if !lex.isKeyword("offset", "result_prefix", "keep_original_fields", ")", "|", "") {
+	if !lex.isKeyword("offset", "result_prefix", "keep_original_fields") && !lex.isKeywordAny(pipeStopTokens) {
 		if lex.isKeyword("from") {
 			lex.nextToken()
 		}

--- a/lib/logstorage/pipe_unpack_words.go
+++ b/lib/logstorage/pipe_unpack_words.go
@@ -139,7 +139,7 @@ func parsePipeUnpackWords(lex *lexer) (pipe, error) {
 	lex.nextToken()
 
 	srcField := "_msg"
-	if !lex.isKeyword("drop_duplicates", "as", ")", "|", "") {
+	if !lex.isKeyword("drop_duplicates", "as") && !lex.isKeywordAny(pipeStopTokens) {
 		if lex.isKeyword("from") {
 			lex.nextToken()
 		}
@@ -151,7 +151,7 @@ func parsePipeUnpackWords(lex *lexer) (pipe, error) {
 	}
 
 	dstField := srcField
-	if !lex.isKeyword("drop_duplicates", ")", "|", "") {
+	if !lex.isKeyword("drop_duplicates") && !lex.isKeywordAny(pipeStopTokens) {
 		if lex.isKeyword("as") {
 			lex.nextToken()
 		}


### PR DESCRIPTION
This will simplify adding new stop tokens. Specifically, this is needed to add a new ';' stop token for the log transformations feature: #858

These changes were tested by adding the ';' stop token in the log transformations branch.
See the test here: https://github.com/VictoriaMetrics/VictoriaLogs/blob/2119657327857659b2c643a272b1dcdb9747df50/lib/logstorage/transforms_test.go#L223-L257