### PR TITLE
apptest/tests: fix flaky stats_query and stats_query_range sort/first/last tests

### DIFF
--- a/apptest/tests/stats_query_range_test.go
+++ b/apptest/tests/stats_query_range_test.go
@@ -54,9 +54,9 @@ func TestVlsingleStatsQueryRange_Success(t *testing.T) {
 	f(`* | stats by (x) count() q, max(x) xmax | math q / xmax as y | sort by (y desc) | keep y, x`, `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"y","x":"1"},"values":[[1735689900,"1"]]},{"metric":{"__name__":"y","x":"2"},"values":[[1735689900,"0.5"]]}]}}`)
 
 	// sort
-	f(`* | stats by (x) count() q | sort by (q desc) limit 1`, `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"q","x":"1"},"values":[[1735689600,"1"]]}]}}`)
-	f(`* | stats by (x) count() q | first 1 by (q desc)`, `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"q","x":"1"},"values":[[1735689600,"1"]]}]}}`)
-	f(`* | stats by (x) count() q | last 1 by (q)`, `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"q","x":"1"},"values":[[1735689600,"1"]]}]}}`)
+	f(`* | stats by (x) count() q | sort by (q desc, x) limit 1`, `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"q","x":"1"},"values":[[1735689600,"1"]]}]}}`)
+	f(`* | stats by (x) count() q | first 1 by (q desc, x)`, `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"q","x":"1"},"values":[[1735689600,"1"]]}]}}`)
+	f(`* | stats by (x) count() q | last 1 by (q, x)`, `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"q","x":"2"},"values":[[1735689600,"1"]]}]}}`)
 }
 
 func TestVlsingleStatsQueryRange_Failure(t *testing.T) {

--- a/apptest/tests/stats_query_test.go
+++ b/apptest/tests/stats_query_test.go
@@ -52,9 +52,9 @@ func TestVlsingleStatsQuery_Success(t *testing.T) {
 	f(`* | stats by (x) count() q, max(x) xmax | math q / xmax as y | sort by (y desc) | keep y, x`, `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"y","x":"1"},"value":[1735689900,"1"]},{"metric":{"__name__":"y","x":"5"},"value":[1735689900,"0.2"]}]}}`)
 
 	// sort
-	f(`* | stats by (x) count() q | sort by (q desc) limit 1`, `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"q","x":"5"},"value":[1735689900,"1"]}]}}`)
-	f(`* | stats by (x) count() q | first 1 by (q desc)`, `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"q","x":"5"},"value":[1735689900,"1"]}]}}`)
-	f(`* | stats by (x) count() q | last 1 by (q)`, `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"q","x":"5"},"value":[1735689900,"1"]}]}}`)
+	f(`* | stats by (x) count() q | sort by (q desc, x) limit 1`, `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"q","x":"1"},"value":[1735689900,"1"]}]}}`)
+	f(`* | stats by (x) count() q | first 1 by (q desc, x)`, `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"q","x":"1"},"value":[1735689900,"1"]}]}}`)
+	f(`* | stats by (x) count() q | last 1 by (q, x)`, `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"q","x":"5"},"value":[1735689900,"1"]}]}}`)
 
 	// limit
 	f(`* | stats count() q | limit 10`, `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"q"},"value":[1735689900,"2"]}]}}`)


### PR DESCRIPTION
The `sort | limit 1`, `first 1` and `last 1` assertions select one of two groups that have an equal `count()`, so the tie-break was non-deterministic and [the tests failed](https://github.com/VictoriaMetrics/VictoriaLogs/actions/runs/27215323410/job/80355522512sao#step:5:1466). 

Add `x` as a tie-breaker to the sort/first/last keys so the selected row is deterministic, in both `/select/logsql/stats_query` and `/select/logsql/stats_query_range` tests.