### PR TITLE
ci: enable errorlint golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,15 @@
 version: "2"
 linters:
+  enable:
+    - errorlint
   settings:
     errcheck:
       exclude-functions:
         - (net/http.ResponseWriter).Write
+    errorlint:
+      errorf: true
+      comparison: false
+      asserts: false
   exclusions:
     generated: lax
     presets:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,9 @@ linters:
         - (net/http.ResponseWriter).Write
     errorlint:
       errorf: true
+      # Do not enable `comparison` and `asserts`: they produce false positives,
+      # since many call sites intentionally compare sentinel errors directly (e.g. err == io.EOF)
+      # when the producer is documented to return them unwrapped. See https://github.com/VictoriaMetrics/VictoriaLogs/pull/1490
       comparison: false
       asserts: false
   exclusions:


### PR DESCRIPTION
The `%s` -> `%w` error wrapping cleanups had to be repeated several times by hand and still leaked (https://github.com/VictoriaMetrics/VictoriaLogs/commit/8beb0da6ad5db660a110d65d6585444c0e17a0c5, https://github.com/VictoriaMetrics/VictoriaLogs/commit/42dd71bb63535c6bc850e1c4a737c00f64c3b760, https://github.com/VictoriaMetrics/VictoriaLogs/commit/1730ed5fa76bb99bf16c29de4a12ef71624cc1e2, https://github.com/VictoriaMetrics/VictoriaLogs/commit/81d0c7127b7f4f53fbac5ffb7a62d40549fba605,...), so this enables the `errorlint` linter in golangci-lint to catch this class of issues.