### PR TITLE
github/ci: use dedicated runners for critical pipelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,8 @@ jobs:
     name: Build
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    # Runs on dedicated runner with extra resources to increase build speed.
+    runs-on: 'vm-runner'
     steps:
       - name: Code checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,8 @@ jobs:
     name: lint
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    # Runs on dedicated runner with extra resources since golangci-lint requires extra memory
+    runs-on: 'vm-runner'
     steps:
       - name: Code checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -59,7 +60,8 @@ jobs:
     needs: lint
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    # Runs on dedicated runner with extra resources to increase tests speed.
+    runs-on: 'vm-runner'
 
     strategy:
       matrix:
@@ -97,7 +99,8 @@ jobs:
     needs: [lint, test]
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    # Runs on dedicated runner to isolate app tests from other tests.
+    runs-on: apptest
 
     steps:
       - name: Code checkout


### PR DESCRIPTION
`ubuntu-latest` runner was a dedicated runner with extra compute resources and its name collided with tag of the same name. In result, the dedciated runner could have been used for all the tasks and repos in organization.

Now, the dedicated runner name was changed to `vm-runner` and it is expected that only critical pipleines or pipelines with high mem requirements (like golangci-lint) will use it.

We also have another dedicated runner `apptest` for integration tests only. So updating that too.

This change syncs it with https://github.com/VictoriaMetrics/VictoriaMetrics/commit/66672f216b2496c6c246ce4de5b37e6cb0dfdfee

