### PR TITLE
lib/logstorage: fix stream tags verification

### DIFF
--- a/lib/logstorage/log_rows_test.go
+++ b/lib/logstorage/log_rows_test.go
@@ -444,7 +444,7 @@ func TestVerifyStreamTagsCanonical_Failure(t *testing.T) {
 		if err := st.unmarshalStringInplace(streamTags); err != nil {
 			t.Fatalf("cannot unmarshal stream tags: %s", err)
 		}
-		streamTagsCanonical := st.MarshalCanonical(nil)
+		streamTagsCanonical := st.marshalCanonicalInternal(nil)
 		PutStreamTags(st)
 
 		p := getLogfmtParser()
@@ -465,4 +465,7 @@ func TestVerifyStreamTagsCanonical_Failure(t *testing.T) {
 
 	// multiple fields with the same name
 	f(`{a="b"}`, `a=b x=y a=c`)
+
+	// tags are not sorted
+	f(`{b="1",a="1"}`, `a=1 b=1`)
 }

--- a/lib/logstorage/stream_tags.go
+++ b/lib/logstorage/stream_tags.go
@@ -65,6 +65,7 @@ func (st *StreamTags) verifyCanonicalFieldValues(fields []Field) error {
 		if tagName <= prevTagName {
 			return fmt.Errorf("stream tag names must be sorted; got %q after %q; streamTags: %s", tagName, prevTagName, st)
 		}
+		prevTagName = tagName
 
 		tagValue := tag.Value
 		found := false
@@ -136,7 +137,10 @@ func (st *StreamTags) Add(name, value string) {
 // MarshalCanonical marshal st in a canonical way
 func (st *StreamTags) MarshalCanonical(dst []byte) []byte {
 	sort.Sort(st)
+	return st.marshalCanonicalInternal(dst)
+}
 
+func (st *StreamTags) marshalCanonicalInternal(dst []byte) []byte {
 	tags := st.tags
 	dst = encoding.MarshalVarUint64(dst, uint64(len(tags)))
 	for i := range tags {


### PR DESCRIPTION
This commit adds the missing assignment of the previous tag when checking that tags are sorted,
which was introduced in commit 917cfabcde40f88d76a9f3873c7d74ec2eaa8353

Updates #38
