### PR TITLE
docs/victorialogs/vlagent.md: scope the container runtime log-symlink note to the Docker runtime

### DIFF
--- a/docs/victorialogs/vlagent.md
+++ b/docs/victorialogs/vlagent.md
@@ -341,9 +341,9 @@ spec:
 
 The `vlagent-data` volume uses `hostPath` so that the checkpoint file and the on-disk buffer survive Pod restarts on the same node.
 
-> **Note**: for Kubernetes in Docker (`minikube`, `kind`): `/var/log/containers` and `/var/log/pods`
-> may contain symlinks to data under the container runtime directory.
-> Mount the corresponding data path (e.g., `/var/lib/docker/containers/`) as a read-only `hostPath` volume to resolve these symlinks.
+> **Note**: with the Docker container runtime (for example, `minikube` with its default settings), the files under
+> `/var/log/containers` and `/var/log/pods` are symlinks into the runtime data directory such as `/var/lib/docker/containers/`.
+> Mount `/var/lib` as a read-only `hostPath` volume so these symlinks can be resolved.
 > See also [the default mounts](https://github.com/VictoriaMetrics/helm-charts/blob/5fcefca5e8afa9d03375486c11be817f631ef1d1/charts/victoria-logs-collector/values.yaml#L266-L284) for the victoria-logs-collector Helm chart.
 
 See also: [How to exclude vlagent's own logs from collection](https://docs.victoriametrics.com/victorialogs/vlagent/#excluding-vlagents-own-logs).

--- a/docs/victorialogs/vlagent.md
+++ b/docs/victorialogs/vlagent.md
@@ -341,7 +341,7 @@ spec:
 
 The `vlagent-data` volume uses `hostPath` so that the checkpoint file and the on-disk buffer survive Pod restarts on the same node.
 
-> **Note**: with the Docker container runtime (for example, `minikube` with its default settings), the files under
+> **Note**: with the Docker container runtime (for example, `minikube` v1.x with its default settings), the files under
 > `/var/log/containers` and `/var/log/pods` are symlinks into the runtime data directory such as `/var/lib/docker/containers/`.
 > Mount `/var/lib` as a read-only `hostPath` volume so these symlinks can be resolved.
 > See also [the default mounts](https://github.com/VictoriaMetrics/helm-charts/blob/5fcefca5e8afa9d03375486c11be817f631ef1d1/charts/victoria-logs-collector/values.yaml#L266-L284) for the victoria-logs-collector Helm chart.


### PR DESCRIPTION
The note about mounting the container runtime data directory applies to the Docker runtime. `kind` defaults to `containerd`, which stores plain log files under `/var/log/pods` and needs no extra mount. See also https://github.com/kubernetes/minikube/issues/21973

Scope the note to the Docker runtime, and recommend mounting `/var/lib` read-only (matching the default mounts of the `victoria-logs-collector` Helm chart) instead of the narrower `/var/lib/docker/containers/` path.

This is a follow-up for the commit e3a48e19cb3a6c4acfcb14aa055d91507d62453e.

