### PR TITLE
ci: enable whitespace golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ version: "2"
 linters:
   enable:
     - errorlint
+    - whitespace
   settings:
     errcheck:
       exclude-functions:

--- a/app/vlagent/remotewrite/remotewrite.go
+++ b/app/vlagent/remotewrite/remotewrite.go
@@ -188,7 +188,6 @@ func pushToRemoteStorages(lr *logstorage.LogRows) {
 	for _, rwctx := range rwctxs {
 		wg.Go(func() {
 			rwctx.push(lr)
-
 		})
 	}
 	wg.Wait()

--- a/app/vlinsert/datadog/datadog.go
+++ b/app/vlinsert/datadog/datadog.go
@@ -164,7 +164,6 @@ func appendMsgFields(fields []logstorage.Field, v *fastjson.Value) ([]logstorage
 						Value: bytesutil.ToUnsafeString(val),
 					})
 				})
-
 			}
 		})
 	default:

--- a/app/vlinsert/insertutil/line_reader.go
+++ b/app/vlinsert/insertutil/line_reader.go
@@ -127,7 +127,6 @@ func (lr *LineReader) readMoreData() bool {
 var tooLongLinesSkipped = metrics.GetOrCreateCounter("vl_too_long_lines_skipped_total")
 
 func (lr *LineReader) skipUntilNextLine() (bool, int) {
-
 	// Initialize skipped bytes count with MaxLineSizeBytes because
 	// we've already read that many bytes without encountering a newline,
 	// indicating the line size exceeds the maximum allowed limit.

--- a/app/vlinsert/loki/loki.go
+++ b/app/vlinsert/loki/loki.go
@@ -79,7 +79,6 @@ func getCommonParams(r *http.Request) (*commonParams, error) {
 			}
 			cp.TenantID = tenantID
 		}
-
 	}
 
 	parseMessage := !*disableMessageParsing

--- a/app/vlinsert/loki/loki_json_timing_test.go
+++ b/app/vlinsert/loki/loki_json_timing_test.go
@@ -52,7 +52,6 @@ func getJSONBody(streams, rows, labels int) []byte {
 			if j < labels-1 {
 				body = append(body, ',')
 			}
-
 		}
 		body = append(body, `}, "values":[`...)
 
@@ -69,7 +68,6 @@ func getJSONBody(streams, rows, labels int) []byte {
 		if i < streams-1 {
 			body = append(body, ',')
 		}
-
 	}
 
 	body = append(body, `]}`...)

--- a/app/vlinsert/loki/loki_protobuf_test.go
+++ b/app/vlinsert/loki/loki_protobuf_test.go
@@ -210,5 +210,4 @@ func TestParseProtobufRequest_ParseMessage(t *testing.T) {
 		}
 	]
 }`, []string{"a", "trace_id"}, []string{"x"}, "", []int64{1577836800000000001}, `{"x":"y","_msg":"432","parent_id":"qwerty","x":"{\"a\":123}"}`)
-
 }

--- a/app/vlinsert/syslog/syslog.go
+++ b/app/vlinsert/syslog/syslog.go
@@ -679,8 +679,8 @@ type configs struct {
 }
 
 func getConfigs(typ string, argIdx int, streamFieldsArg, ignoreFieldsArg, decolorizeFieldsArg, extraFieldsArg, tenantIDArg, compressMethodArg *flagutil.ArrayString,
-	useLocalTimestampArg, useRemoteIPArg *flagutil.ArrayBool) (*configs, error) {
-
+	useLocalTimestampArg, useRemoteIPArg *flagutil.ArrayBool,
+) (*configs, error) {
 	streamFieldsStr := streamFieldsArg.GetOptionalArg(argIdx)
 	streamFields, err := parseFieldsList(streamFieldsStr)
 	if err != nil {

--- a/app/vlogscli/main.go
+++ b/app/vlogscli/main.go
@@ -92,7 +92,6 @@ func main() {
 	if err := rl.Close(); err != nil {
 		fatalf("cannot close readline: %s", err)
 	}
-
 }
 
 func runReadlineLoop(rl *readline.Instance, incompleteLine *string) {

--- a/app/vlstorage/netselect/netselect.go
+++ b/app/vlstorage/netselect/netselect.go
@@ -667,8 +667,8 @@ func (s *Storage) getTenantIDs(ctx context.Context, start, end int64) ([]logstor
 }
 
 func (s *Storage) getValuesWithHits(qctx *logstorage.QueryContext, limit uint64, resetHitsOnLimitExceeded bool,
-	callback func(ctx context.Context, sn *storageNode) ([]logstorage.ValueWithHits, error)) ([]logstorage.ValueWithHits, error) {
-
+	callback func(ctx context.Context, sn *storageNode) ([]logstorage.ValueWithHits, error),
+) ([]logstorage.ValueWithHits, error) {
 	ctxWithCancel, cancel := context.WithCancel(qctx.Context)
 	defer cancel()
 

--- a/apptest/tests/ingest_protocols_test.go
+++ b/apptest/tests/ingest_protocols_test.go
@@ -79,7 +79,6 @@ func TestVlsingleIngestionProtocols(t *testing.T) {
 			`{"_msg":"ingest native","_time":"2025-06-05T16:41:37.409Z", "_stream":"{foo=\"bar\"}", "foo": "bar", "qwe": "rty"}`,
 		},
 	})
-
 }
 
 func canonicalStreamTagsFromSet(set map[string]string) string {

--- a/apptest/vlagent.go
+++ b/apptest/vlagent.go
@@ -92,7 +92,6 @@ func (app *Vlagent) WaitQueueEmptyAfter(t *testing.T, cb func()) {
 		time.Sleep(period)
 	}
 	t.Fatalf("timed out while waiting for inserted logs to be flushed to remote storage")
-
 }
 
 // sendBlocking sends the data to remote write url by executing `send` function and

--- a/deployment/logs-benchmark/generator/main.go
+++ b/deployment/logs-benchmark/generator/main.go
@@ -94,7 +94,6 @@ func main() {
 		logger.Close()
 		logger2.Close()
 	}
-
 }
 
 func randomString() string {

--- a/lib/logstorage/color_sequence_test.go
+++ b/lib/logstorage/color_sequence_test.go
@@ -60,5 +60,4 @@ func TestDropColorSequences(t *testing.T) {
 
 	// valid device control string sequence. It is left as is.
 	f("a\x1bP 1;2;3 qabc\x1b\\", "a\x1bP 1;2;3 qabc\x1b\\")
-
 }

--- a/lib/logstorage/filter_range_test.go
+++ b/lib/logstorage/filter_range_test.go
@@ -86,7 +86,6 @@ func TestFilterRange(t *testing.T) {
 
 		fr = newFilterRange("foo", 20, 10, "")
 		testFilterMatchForColumns(t, columns, fr, "foo", nil)
-
 	})
 
 	t.Run("strings", func(t *testing.T) {
@@ -168,7 +167,6 @@ func TestFilterRange(t *testing.T) {
 
 		fr = newFilterRange("foo", 2.9, 0.1, "")
 		testFilterMatchForColumns(t, columns, fr, "foo", nil)
-
 	})
 
 	t.Run("uint16", func(t *testing.T) {

--- a/lib/logstorage/indexdb_test.go
+++ b/lib/logstorage/indexdb_test.go
@@ -308,7 +308,6 @@ func TestGetTenantsIDs(t *testing.T) {
 			for _, sid := range sids {
 				idb.mustRegisterStream(&sid, streamTagsCanonical)
 			}
-
 		}
 	}
 	idb.debugFlush()

--- a/lib/logstorage/parser_test.go
+++ b/lib/logstorage/parser_test.go
@@ -4933,7 +4933,6 @@ func TestQueryGetFixedFields_Success(t *testing.T) {
 	f("* | stats by (a, b) count(), sum(x) as y | limit 10 | offset 5", []string{"a", "b", "count(*)", "y"})
 
 	f("* | fields a, b | sort (a) | sort (c,b)", []string{"c", "b", "a"})
-
 }
 
 func TestQueryGetFixedFields_Failure(t *testing.T) {

--- a/lib/logstorage/pattern_test.go
+++ b/lib/logstorage/pattern_test.go
@@ -224,7 +224,6 @@ func TestParsePatternStepsSuccess(t *testing.T) {
 			field:  "foo:bar:baz",
 		},
 	})
-
 }
 
 func TestParsePatternStepsFailure(t *testing.T) {

--- a/lib/logstorage/pipe_join.go
+++ b/lib/logstorage/pipe_join.go
@@ -192,7 +192,6 @@ func (pjp *pipeJoinProcessor) writeBlock(workerID uint, br *blockResult) {
 	for i := range cs {
 		name := cs[i].name
 		byValuesIdxs[i] = slices.Index(pj.byFields, name)
-
 	}
 
 	for rowIdx := range br.rowsLen {

--- a/lib/logstorage/pipe_query_stats_test.go
+++ b/lib/logstorage/pipe_query_stats_test.go
@@ -80,7 +80,6 @@ func TestPipeQueryStats(t *testing.T) {
 			{"QueryDurationNsecs", "0"},
 		},
 	})
-
 }
 
 func TestPipeQueryStatsUpdateNeededFields(t *testing.T) {

--- a/lib/logstorage/pipe_replace_regexp.go
+++ b/lib/logstorage/pipe_replace_regexp.go
@@ -92,7 +92,6 @@ func (pr *pipeReplaceRegexp) newPipeProcessor(_ int, _ <-chan struct{}, _ func()
 	}
 
 	return newPipeUpdateProcessor(updateFunc, ppNext, pr.field, pr.iff)
-
 }
 
 func parsePipeReplaceRegexp(lex *lexer) (pipe, error) {

--- a/lib/logstorage/pipe_unpack.go
+++ b/lib/logstorage/pipe_unpack.go
@@ -83,7 +83,6 @@ func (uctx *fieldsUnpackerContext) addField(name, value string) {
 
 func newPipeUnpackProcessor(unpackFunc func(uctx *fieldsUnpackerContext, s string), ppNext pipeProcessor,
 	fromField string, fieldPrefix string, keepOriginalFields, skipEmptyResults bool, iff *ifFilter) *pipeUnpackProcessor {
-
 	return &pipeUnpackProcessor{
 		unpackFunc: unpackFunc,
 		ppNext:     ppNext,

--- a/lib/logstorage/pipe_unpack_logfmt_test.go
+++ b/lib/logstorage/pipe_unpack_logfmt_test.go
@@ -300,7 +300,6 @@ func TestPipeUnpackLogfmt(t *testing.T) {
 			{"a", "b"},
 		},
 	})
-
 }
 
 func TestPipeUnpackLogfmtUpdateNeededFields(t *testing.T) {

--- a/lib/logstorage/pipe_unroll_test.go
+++ b/lib/logstorage/pipe_unroll_test.go
@@ -220,7 +220,6 @@ func TestPipeUnroll(t *testing.T) {
 			{"q", "abc"},
 		},
 	})
-
 }
 
 func TestPipeUnrollUpdateNeededFields(t *testing.T) {

--- a/lib/logstorage/storage_search.go
+++ b/lib/logstorage/storage_search.go
@@ -1347,7 +1347,6 @@ func (s *Storage) searchParallel(workersCount int, sso *storageSearchOptions, qs
 			putBlockSearch(bs)
 			putBitmap(bm)
 			qs.UpdateAtomic(qsLocal)
-
 		})
 	}
 
@@ -1601,7 +1600,6 @@ func (p *part) hasMatchingRows(pso *partitionSearchOptions, stopCh <-chan struct
 
 			putBlockSearch(bs)
 			putBitmap(bm)
-
 		})
 	}
 

--- a/lib/logstorage/storage_test.go
+++ b/lib/logstorage/storage_test.go
@@ -187,7 +187,6 @@ func TestStoragePartitionDetachRecreateSameDayStreamFilterQuery(t *testing.T) {
 	partitionName := getPartitionNameFromDay(ts / nsecsPerDay)
 
 	addRow := func(stream, marker, msg string) {
-
 		lr := GetLogRows([]string{"stream"}, nil, nil, nil, "")
 		lr.mustAdd(TenantID{}, ts, []Field{
 			{

--- a/lib/logstorage/syslog_parser.go
+++ b/lib/logstorage/syslog_parser.go
@@ -655,7 +655,6 @@ func (p *SyslogParser) parseCEFExtension(s string) bool {
 		p.AddField(keyName, unescapeCEFValue(s[:n]))
 		s = s[n+1:]
 	}
-
 }
 
 func (p *SyslogParser) tryParseTimestampRFC3164(s string) bool {


### PR DESCRIPTION
The `whitespace` linter checks for redundant newline characters to keep the code consistent and helps eliminate typos, such as: https://github.com/VictoriaMetrics/VictoriaLogs/blob/c07adb768b7cb998414eddd5d4a3690cc2c3d28a/app/vlagent/remotewrite/remotewrite.go#L189-L192