### PR TITLE
stats by() lines()

### DIFF
--- a/lib/logstorage/chunked_allocator.go
+++ b/lib/logstorage/chunked_allocator.go
@@ -35,6 +35,7 @@ type chunkedAllocator struct {
 	rowMinProcessors           []statsRowMinProcessor
 	sumProcessors              []statsSumProcessor
 	stddevProcessors           []statsStddevProcessor
+	linesProcessors            []statsLinesProcessor
 	sumLenProcessors           []statsSumLenProcessor
 	uniqValuesProcessors       []statsUniqValuesProcessor
 	valuesProcessors           []statsValuesProcessor
@@ -146,6 +147,10 @@ func (a *chunkedAllocator) newStatsStddevProcessor() (p *statsStddevProcessor) {
 
 func (a *chunkedAllocator) newStatsSumProcessor() (p *statsSumProcessor) {
 	return addNewItem(&a.sumProcessors, a)
+}
+
+func (a *chunkedAllocator) newStatsLinesProcessor() (p *statsLinesProcessor) {
+	return addNewItem(&a.linesProcessors, a)
 }
 
 func (a *chunkedAllocator) newStatsSumLenProcessor() (p *statsSumLenProcessor) {

--- a/lib/logstorage/pipe_stats.go
+++ b/lib/logstorage/pipe_stats.go
@@ -1595,6 +1595,7 @@ func initStatsFuncParsers() {
 		"sum_len":         parseStatsSumLen,
 		"uniq_values":     parseStatsUniqValues,
 		"values":          parseStatsValues,
+		"lines": 				 parseStatsLines,
 	}
 }
 


### PR DESCRIPTION
Hi,

this pull request is **not** intended to be merged as is, it's more of a question to understand if that makes sense at all ?
Did I miss something and it's already possible to do that using other filters ?
This is meant to allow grouping lines together when logs happen at the same second (or more):

```
| stats by (_time:1s, _HOSTNAME, _PID, unit, level, _CMDLINE) lines(_msg) as msgs
| format "<time:_time> [<_HOSTNAME>] <unit> (pid: <_PID>)<msgs>"
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/VictoriaMetrics/VictoriaLogs/pull/1517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

