### PR TITLE
app/vlselect/logsql: do not duplicate the query in the parse error

### DIFF
--- a/app/vlselect/logsql/logsql.go
+++ b/app/vlselect/logsql/logsql.go
@@ -114,7 +114,7 @@ func parseQueryFromRequest(r *http.Request, timestamp int64) (*logstorage.Query,
 	}
 	q, err := logstorage.ParseQueryAtTimestamp(qStr, timestamp)
 	if err != nil {
-		return nil, fmt.Errorf("cannot parse `query` arg: %w; query=%s", err, qStr)
+		return nil, fmt.Errorf("cannot parse `query` arg: %w", err)
 	}
 	return q, nil
 }


### PR DESCRIPTION
TL;DR: on a query parse error, `vlselect` duplicates the query in the error message, and pushes the parse reason into the middle of the log line where `-loggerMaxArgLen` may truncate it, so long invalid queries get logged with no explanation of why they failed.

Fix this by dropping the `query` field from the error message, so the error message is placed at the end.

--- 

On a query parse error, `parseQueryFromRequest` appends the query to the error a second time:

```go
// app/vlselect/logsql/logsql.go
return nil, fmt.Errorf("cannot parse `query` arg: %w; query=%s", err, qStr)
```

But the query is already logged as part of `requestURI` by `httpserver`:

```go
// lib/httpserver: logHTTPError
errStr = fmt.Sprintf("remoteAddr: %s; requestURI: %s; %s", remoteAddr, requestURI, errStr)
```

So the log line contains the query twice with the parse reason **in the middle**:

```
remoteAddr: ...; requestURI: <query>; cannot parse `query` arg: <reason>; query=<query>
```

For long queries the line exceeds `-loggerMaxArgLen` (default 5000), and the logger keeps only the head and tail, replacing the middle with `..` and unfortunately dropping exactly the reason:

```
[head: requestURI=<query>] .. [tail: query=<query>]     ← reason gone
```

Result is a warn log with the query twice and no explanation of why parsing failed.