### PR TITLE
app/vlogscli: fallback to stdout when `less` isn't available

### DIFF
--- a/app/vlogscli/less_wrapper.go
+++ b/app/vlogscli/less_wrapper.go
@@ -18,14 +18,13 @@ func isTerminal() bool {
 }
 
 func readWithLess(r io.Reader, disableColors, wrapLongLines bool) error {
-	if !isTerminal() {
-		// Just write everything to stdout if no terminal is available.
+	// Write everything to stdout if there is no terminal or 'less' isn't available in $PATH.
+	// The latter happens e.g. inside the distroless Docker image, which doesn't ship 'less'.
+	path, err := exec.LookPath("less")
+	if !isTerminal() || err != nil {
 		_, err := io.Copy(os.Stdout, r)
 		if err != nil && !isErrPipe(err) {
 			return fmt.Errorf("error when forwarding data to stdout: %w", err)
-		}
-		if err := os.Stdout.Sync(); err != nil {
-			return fmt.Errorf("cannot sync data to stdout: %w", err)
 		}
 		return nil
 	}
@@ -44,10 +43,6 @@ func readWithLess(r io.Reader, disableColors, wrapLongLines bool) error {
 	defer cancel()
 
 	// Start 'less' process
-	path, err := exec.LookPath("less")
-	if err != nil {
-		return fmt.Errorf("cannot find 'less' command: %w", err)
-	}
 	opts := []string{"less", "-F", "-X"}
 	if !disableColors {
 		opts = append(opts, "-R")

--- a/docs/victorialogs/querying/vlogscli.md
+++ b/docs/victorialogs/querying/vlogscli.md
@@ -109,6 +109,10 @@ thanks to the way how `less` interacts with [`/select/logsql/query`](https://doc
   VictoriaLogs stops query processing and frees up all the associated resources
   after the response stream is closed.
 
+If the `less` command isn't available in `$PATH` (for example, when `vlogscli` runs inside the
+[distroless](https://github.com/GoogleContainerTools/distroless/) Docker image, which doesn't ship `less`),
+`vlogscli` prints the query response directly to stdout without paging.
+
 See also [`less` docs](https://man7.org/linux/man-pages/man1/less.1.html) and
 [command-line integration docs for VictoriaLogs](https://docs.victoriametrics.com/victorialogs/querying/#command-line).
 


### PR DESCRIPTION
Fallback to stdout instead of failing with `cannot find 'less' command` when `less` isn't in `$PATH` (e.g. inside the distroless image), since vlogscli pipes interactive output to `less`.

Remove the sync() `stdout` in this edge case as `os.Stdout` is unbuffered, so `io.Copy` has already written all the data.

Update https://github.com/VictoriaMetrics/VictoriaLogs/pull/1494