### PR TITLE
docs: correct vl_streams_created_total monotonicity description

### DIFF
--- a/docs/victorialogs/data-ingestion/README.md
+++ b/docs/victorialogs/data-ingestion/README.md
@@ -379,6 +379,6 @@ VictoriaLogs exposes various [metrics](https://docs.victoriametrics.com/victoria
     The [`vl_rows_dropped_total`](https://docs.victoriametrics.com/victorialogs/metrics/#vl_rows_dropped_total) metric is incremented for each logged row.
   - By passing `-logIngestedRows` command-line flag to VictoriaLogs. In this case it logs all the ingested data, so it can be investigated later.
 - [`vl_streams_created_total`](https://docs.victoriametrics.com/victorialogs/metrics/#vl_streams_created_total) - the number of created [log streams](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields)
-  since the last VictoriaLogs restart. If this metric grows rapidly during extended periods of time, then this may lead
+  in currently retained indexdb partitions since the current VictoriaLogs process initialized them. Existing stream IDs on disk are not recounted after a restart. The metric can decrease when an old indexdb partition is rotated out. If this metric grows rapidly during extended periods of time, then this may lead
   to [high cardinality issues](https://docs.victoriametrics.com/victorialogs/keyconcepts/#high-cardinality).
   The newly created log streams can be inspected in logs - see [these docs](https://docs.victoriametrics.com/victorialogs/#logging-new-streams).

--- a/docs/victorialogs/keyConcepts.md
+++ b/docs/victorialogs/keyConcepts.md
@@ -284,7 +284,7 @@ VictoriaLogs works perfectly with such fields unless they are associated with [l
 - Increased disk read/write I/O
 
 VictoriaLogs exposes `vl_streams_created_total` [metric](https://docs.victoriametrics.com/victorialogs/metrics/#vl_streams_created_total),
-which shows the number of created streams since the last VictoriaLogs restart. If this metric grows at a rapid rate
+which shows the number of created streams in currently retained indexdb partitions since the current VictoriaLogs process initialized them. Existing stream IDs on disk are not recounted after a restart. The metric can decrease when an old indexdb partition is rotated out. If this metric grows at a rapid rate
 over a long period of time, then there is a high chance of high-cardinality issues mentioned above.
 VictoriaLogs can log all the newly registered streams - see [these docs](https://docs.victoriametrics.com/victorialogs/#logging-new-streams).
 This can help narrow down and eliminate high-cardinality fields from [log streams](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields).

--- a/docs/victorialogs/metrics.md
+++ b/docs/victorialogs/metrics.md
@@ -319,7 +319,7 @@ These metrics follow the Prometheus exposition format and can be used for monito
 ### vl_streams_created_total
 **Type:** Counter
 
-**Description:** New unique combinations of stream fields first encountered during log ingestion. Only counts streams not previously seen since startup, shows growth in stream cardinality and high-cardinality detection.
+**Description:** New unique combinations of stream fields first encountered during log ingestion since the current VictoriaLogs process initialized the currently retained indexdb partitions. Existing stream IDs on disk are not recounted after restart. The value can decrease when an old indexdb partition is rotated out, for example around the daily partition boundary. Because of this it is not strictly monotonic, so avoid Prometheus counter functions such as `rate()` and `increase()` on it: they treat the rotation decrease as a counter reset and report false spikes. Read the raw value or compare it over time instead. Rapid growth shows stream cardinality growth and may help detect high-cardinality issues.
 
 ### vl_indexdb_rows
 **Type:** Gauge


### PR DESCRIPTION
## Summary

Corrects the `vl_streams_created_total` metric description so it matches the implementation: the value is per-process and per-indexdb, it is not recounted from retained partitions after a restart, and it can decrease when an old indexdb partition is rotated out. It also warns against applying Prometheus counter functions to it, and carries the same scope note to the shorter descriptions in the data-ingestion and key-concepts docs.

## Why this matters

The docs described `vl_streams_created_total` as a steadily growing counter, but `streamsCreatedTotal` is held in each in-memory indexdb and initialized to zero when partitions are opened, so it drops on partition rotation and resets on restart. Operators reading the old wording would use `rate()`/`increase()` and get false spikes around the daily partition boundary, or expect retained on-disk streams to be counted after a restart. The updated text documents the real, non-monotonic behavior and tells readers to avoid counter functions. Reported in #1461.

## Testing

Documentation-only change; no code paths affected. Verified the wording is consistent across `metrics.md`, the data-ingestion `README.md`, and `keyConcepts.md`.

Closes #1461
