### PR TITLE
app/vlinsert/syslog: refresh the cached year exactly at the year boundary

### DIFF
--- a/app/vlinsert/syslog/syslog.go
+++ b/app/vlinsert/syslog/syslog.go
@@ -154,18 +154,18 @@ func MustInit() {
 		globalTimezone = time.Local
 	}
 
-	currentYear := time.Now().Year()
+	currentYear := nowInGlobalTZ().Year()
 	globalCurrentYear.Store(int64(currentYear))
 	workersWG.Go(func() {
 		for {
-			now := time.Now().In(globalTimezone)
+			now := nowInGlobalTZ()
 			nextYear := time.Date(now.Year()+1, 1, 1, 0, 0, 0, 0, globalTimezone)
 			nextTick := min(time.Minute, nextYear.Sub(now))
 			select {
 			case <-workersStopCh:
 				return
 			case <-time.After(nextTick):
-				currentYear := time.Now().In(globalTimezone).Year()
+				currentYear := nowInGlobalTZ().Year()
 				globalCurrentYear.Store(int64(currentYear))
 			}
 		}
@@ -181,6 +181,10 @@ var (
 	workersWG     sync.WaitGroup
 	workersStopCh chan struct{}
 )
+
+func nowInGlobalTZ() time.Time {
+	return time.Now().In(globalTimezone)
+}
 
 // MustStop stops syslog parser initialized via MustInit()
 func MustStop() {

--- a/app/vlinsert/syslog/syslog.go
+++ b/app/vlinsert/syslog/syslog.go
@@ -177,14 +177,14 @@ var (
 	globalTimezone    *time.Location
 )
 
+func nowInGlobalTZ() time.Time {
+	return time.Now().In(globalTimezone)
+}
+
 var (
 	workersWG     sync.WaitGroup
 	workersStopCh chan struct{}
 )
-
-func nowInGlobalTZ() time.Time {
-	return time.Now().In(globalTimezone)
-}
 
 // MustStop stops syslog parser initialized via MustInit()
 func MustStop() {

--- a/app/vlinsert/syslog/syslog.go
+++ b/app/vlinsert/syslog/syslog.go
@@ -144,22 +144,6 @@ func MustInit() {
 		})
 	}
 
-	currentYear := time.Now().Year()
-	globalCurrentYear.Store(int64(currentYear))
-	workersWG.Go(func() {
-		ticker := time.NewTicker(time.Minute)
-		for {
-			select {
-			case <-workersStopCh:
-				ticker.Stop()
-				return
-			case <-ticker.C:
-				currentYear := time.Now().Year()
-				globalCurrentYear.Store(int64(currentYear))
-			}
-		}
-	})
-
 	if *syslogTimezone != "" {
 		tz, err := time.LoadLocation(*syslogTimezone)
 		if err != nil {
@@ -169,6 +153,23 @@ func MustInit() {
 	} else {
 		globalTimezone = time.Local
 	}
+
+	currentYear := time.Now().Year()
+	globalCurrentYear.Store(int64(currentYear))
+	workersWG.Go(func() {
+		for {
+			now := time.Now().In(globalTimezone)
+			nextYear := time.Date(now.Year()+1, 1, 1, 0, 0, 0, 0, globalTimezone)
+			nextTick := min(time.Minute, nextYear.Sub(now))
+			select {
+			case <-workersStopCh:
+				return
+			case <-time.After(nextTick):
+				currentYear := time.Now().In(globalTimezone).Year()
+				globalCurrentYear.Store(int64(currentYear))
+			}
+		}
+	})
 }
 
 var (


### PR DESCRIPTION
VictoriaLogs fills RFC3164 from a cached current year that was refreshed by an 1 minute ticker, this left a ~1-minute window right after new year and messages could be stamped with the previous year (and dropped under a short `-retentionPeriod`). 

So:

- keep the 1 minute refresh (for latency, changing time on local, etc.).
- shortened to land exactly on the year boundary to avoid log loss.
- also computes the year in `-syslog.timezone` (instead of the server's local zone), this was a bug.

I consider removing the cache but `time.Now().Year()` is expensive, half of the time parsing