### PR TITLE
lib/logstorage: fix running_stats chronological sorting for fractional seconds

### DIFF
--- a/lib/logstorage/pipe_running_stats.go
+++ b/lib/logstorage/pipe_running_stats.go
@@ -234,7 +234,9 @@ func (psp *pipeRunningStatsProcessor) flush() error {
 	}
 
 	type rowWithTimestamp struct {
-		timestamp string
+		timestamp string // raw string for fallback sorting
+		unixNano  int64  // parsed nanoseconds for fast integer comparison
+		isValid   bool   // true if timestamp parsing succeeded
 		fields    []Field
 	}
 
@@ -248,8 +250,11 @@ func (psp *pipeRunningStatsProcessor) flush() error {
 
 			key := getKeyForRow(row)
 			timestamp := getFieldValueByName(row, "_time")
+			unixNano, isValid := TryParseTimestampRFC3339Nano(timestamp)
 			m[key] = append(m[key], rowWithTimestamp{
 				timestamp: timestamp,
+				unixNano:  unixNano,
+				isValid:   isValid,
 				fields:    row,
 			})
 		}
@@ -271,6 +276,21 @@ func (psp *pipeRunningStatsProcessor) flush() error {
 	for _, key := range keys {
 		rows := m[key]
 		sort.Slice(rows, func(i, j int) bool {
+			if rows[i].isValid && rows[j].isValid {
+				if rows[i].unixNano == rows[j].unixNano {
+					return rows[i].timestamp < rows[j].timestamp
+				}
+				return rows[i].unixNano < rows[j].unixNano
+			}
+
+			if rows[i].isValid && !rows[j].isValid {
+				return true
+			}
+
+			if !rows[i].isValid && rows[j].isValid {
+				return false
+			}
+
 			return rows[i].timestamp < rows[j].timestamp
 		})
 

--- a/lib/logstorage/pipe_running_stats_test.go
+++ b/lib/logstorage/pipe_running_stats_test.go
@@ -266,6 +266,38 @@ func TestPipeRunningStats(t *testing.T) {
 			{"min_c", ""},
 		},
 	})
+
+	// fractional seconds timestamp sorting bug
+	f("running_stats last(sequence) offset 1 as prev_sequence", [][]Field{
+		{
+			{"_time", "2026-03-31T12:00:45.990844Z"},
+			{"sequence", "2"},
+		},
+		{
+			{"_time", "2026-03-31T12:00:45.99Z"},
+			{"sequence", "1"},
+		},
+		{
+			{"_time", "2026-03-31T12:00:45.999324Z"},
+			{"sequence", "3"},
+		},
+	}, [][]Field{
+		{
+			{"_time", "2026-03-31T12:00:45.99Z"},
+			{"sequence", "1"},
+			{"prev_sequence", ""},
+		},
+		{
+			{"_time", "2026-03-31T12:00:45.990844Z"},
+			{"sequence", "2"},
+			{"prev_sequence", "1"},
+		},
+		{
+			{"_time", "2026-03-31T12:00:45.999324Z"},
+			{"sequence", "3"},
+			{"prev_sequence", "2"},
+		},
+	})
 }
 
 func TestPipeRunningStatsUpdateNeededFields(t *testing.T) {


### PR DESCRIPTION
### Summary
Fixes a bug where running_stats incorrectly sorted high-precision timestamps using raw string comparison, causing varying fractional second lengths (e.g., .99Z vs .990844Z) to evaluate out of chronological order.

### Changes
Partitioned Sorting: Groups and sorts all valid timestamps first chronologically, pushing invalid or unparseable string timestamps to the bottom to be sorted alphabetically. This eliminates strict weak ordering violations.

Chronological Sorting: Pre-parses valid `_time` strings into nanosecond integers using `logstorage.TryParseTimestampRFC3339Nano` for high-precision evaluation, using raw string comparison as a deterministic tie-breaker for identical time instants.

### Fixes
Fixes #1581

### Tests
Added a dedicated test case to pipe_running_stats_test.go replicating the fractional second mismatch to prevent future regressions.