### PR TITLE
lib/logstorage: allow stream tags with the same name

### DIFF
--- a/lib/logstorage/stream_tags.go
+++ b/lib/logstorage/stream_tags.go
@@ -210,8 +210,8 @@ func (st *StreamTags) checkCorrectness() error {
 		if err := CheckStreamFieldName(tagName); err != nil {
 			return fmt.Errorf("invalid stream tag name: %w", err)
 		}
-		if tagName <= prevTagName {
-			return fmt.Errorf("stream tags must be sorted in alphabetical order; got %q which is less or equal than %q; streamTags=%s", tagName, prevTagName, st)
+		if tagName < prevTagName {
+			return fmt.Errorf("stream tags must be sorted in alphabetical order; got %q which is less than %q; streamTags=%s", tagName, prevTagName, st)
 		}
 		prevTagName = tagName
 	}


### PR DESCRIPTION
A more correct solution would be not to duplicate fields in the log, but the already inserted invalid data can cause a panic after commit da7a2464e8e987be833c6db2c800153fc731339a

Fixes https://github.com/VictoriaMetrics/VictoriaLogs/issues/1603
