### PR TITLE
apptest: fix flaky vlagent replication test

### DIFF
--- a/apptest/client.go
+++ b/apptest/client.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -198,6 +199,36 @@ func (app *ServesMetrics) GetMetricsByPrefix(t *testing.T, prefix string) []floa
 	}
 	for _, metric := range strings.Split(metrics, "\n") {
 		if !strings.HasPrefix(metric, prefix) {
+			continue
+		}
+
+		parts := strings.Split(metric, " ")
+		if len(parts) < 2 {
+			t.Fatalf("unexpected record format: got %q, want metric name and value separated by a space", metric)
+		}
+
+		value, err := strconv.ParseFloat(parts[len(parts)-1], 64)
+		if err != nil {
+			t.Fatalf("could not parse metric value %s: %v", metric, err)
+		}
+
+		values = append(values, value)
+	}
+	return values
+}
+
+// GetMetricsByRegexp retrieves the values of all metrics that match re.
+func (app *ServesMetrics) GetMetricsByRegexp(t *testing.T, re *regexp.Regexp) []float64 {
+	t.Helper()
+
+	values := []float64{}
+
+	metrics, statusCode := app.cli.Get(t, app.metricsURL)
+	if statusCode != http.StatusOK {
+		t.Fatalf("unexpected status code: got %d, want %d", statusCode, http.StatusOK)
+	}
+	for _, metric := range strings.Split(metrics, "\n") {
+		if !re.MatchString(metric) {
 			continue
 		}
 

--- a/apptest/client.go
+++ b/apptest/client.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -199,36 +198,6 @@ func (app *ServesMetrics) GetMetricsByPrefix(t *testing.T, prefix string) []floa
 	}
 	for _, metric := range strings.Split(metrics, "\n") {
 		if !strings.HasPrefix(metric, prefix) {
-			continue
-		}
-
-		parts := strings.Split(metric, " ")
-		if len(parts) < 2 {
-			t.Fatalf("unexpected record format: got %q, want metric name and value separated by a space", metric)
-		}
-
-		value, err := strconv.ParseFloat(parts[len(parts)-1], 64)
-		if err != nil {
-			t.Fatalf("could not parse metric value %s: %v", metric, err)
-		}
-
-		values = append(values, value)
-	}
-	return values
-}
-
-// GetMetricsByRegexp retrieves the values of all metrics that match re.
-func (app *ServesMetrics) GetMetricsByRegexp(t *testing.T, re *regexp.Regexp) []float64 {
-	t.Helper()
-
-	values := []float64{}
-
-	metrics, statusCode := app.cli.Get(t, app.metricsURL)
-	if statusCode != http.StatusOK {
-		t.Fatalf("unexpected status code: got %d, want %d", statusCode, http.StatusOK)
-	}
-	for _, metric := range strings.Split(metrics, "\n") {
-		if !re.MatchString(metric) {
 			continue
 		}
 

--- a/apptest/tests/vlagent_remotewrite_test.go
+++ b/apptest/tests/vlagent_remotewrite_test.go
@@ -157,7 +157,8 @@ func TestVlagentRemoteWriteReplication(t *testing.T) {
 		`{"_msg":"ingest jsonline","_time": "2025-06-05T14:30:19.088007Z", "foo":"bar"}`,
 		`{"_msg":"ingest jsonline","_time": "2025-06-05T14:30:19.088007Z", "bar":"foo"}`,
 	}, apptest.IngestOpts{})
-	vlagent.WaitRemoteWriteRequests(t, vlagentRemoteWriteMetricURLs, []int{1, 1})
+	vlagent.WaitRemoteWriteRequests(t, vlagentRemoteWriteMetricURLs[0], 1)
+	vlagent.WaitRemoteWriteRequests(t, vlagentRemoteWriteMetricURLs[1], 1)
 
 	wantLogLines := []string{
 		`{"_msg":"ingest jsonline","_stream":"{}","_time":"2025-06-05T14:30:19.088007Z","bar":"foo"}`,
@@ -180,7 +181,7 @@ func TestVlagentRemoteWriteReplication(t *testing.T) {
 		`{"_msg":"ingest jsonline2","_time":"2025-06-05T14:30:19.088007Z","bar":"foo"}`,
 		`{"_msg":"ingest jsonline2","_time":"2025-06-05T14:30:19.088007Z","foo":"bar"}`,
 	}, apptest.IngestOpts{})
-	vlagent.WaitRemoteWriteRequests(t, vlagentRemoteWriteMetricURLs[1:], []int{2})
+	vlagent.WaitRemoteWriteRequests(t, vlagentRemoteWriteMetricURLs[1], 2)
 
 	// check alive storage received data
 	wantLogLines = []string{

--- a/apptest/tests/vlagent_remotewrite_test.go
+++ b/apptest/tests/vlagent_remotewrite_test.go
@@ -32,6 +32,7 @@ func TestVlagentRemoteWriteSingleTenant(t *testing.T) {
 		`{"_msg":"ingest jsonline","_time": "2025-06-05T14:30:19.088007Z", "foo":"bar"}`,
 		`{"_msg":"ingest jsonline","_time": "2025-06-05T14:30:19.088007Z", "bar":"foo"}`,
 	}, apptest.IngestOpts{})
+	vlagent.WaitRemoteWriteRequests(t, "1:"+remoteWriteURL, 1)
 
 	sut.ForceFlush(t)
 	got := sut.LogsQLQuery(t, "ingest jsonline", apptest.QueryOpts{})

--- a/apptest/tests/vlagent_remotewrite_test.go
+++ b/apptest/tests/vlagent_remotewrite_test.go
@@ -147,12 +147,17 @@ func TestVlagentRemoteWriteReplication(t *testing.T) {
 		"-remoteWrite.tmpDataPath=" + fmt.Sprintf("%s/%s-%d", os.TempDir(), vlagentInstance, time.Now().UnixNano()),
 	}
 	vlagent := tc.MustStartVlagent(vlagentInstance, vlagentRemoteWriteURLs, vlagentFlags)
+	vlagentRemoteWriteMetricURLs := []string{
+		"1:" + vlagentRemoteWriteURLs[0],
+		"2:" + vlagentRemoteWriteURLs[1],
+	}
 
 	// ingest data and check if it properly replicated to the vlsingles
 	vlagent.JSONLineWrite(t, []string{
 		`{"_msg":"ingest jsonline","_time": "2025-06-05T14:30:19.088007Z", "foo":"bar"}`,
 		`{"_msg":"ingest jsonline","_time": "2025-06-05T14:30:19.088007Z", "bar":"foo"}`,
 	}, apptest.IngestOpts{})
+	vlagent.WaitRemoteWriteRequests(t, vlagentRemoteWriteMetricURLs, []int{1, 1})
 
 	wantLogLines := []string{
 		`{"_msg":"ingest jsonline","_stream":"{}","_time":"2025-06-05T14:30:19.088007Z","bar":"foo"}`,
@@ -175,6 +180,7 @@ func TestVlagentRemoteWriteReplication(t *testing.T) {
 		`{"_msg":"ingest jsonline2","_time":"2025-06-05T14:30:19.088007Z","bar":"foo"}`,
 		`{"_msg":"ingest jsonline2","_time":"2025-06-05T14:30:19.088007Z","foo":"bar"}`,
 	}, apptest.IngestOpts{})
+	vlagent.WaitRemoteWriteRequests(t, vlagentRemoteWriteMetricURLs[1:], []int{2})
 
 	// check alive storage received data
 	wantLogLines = []string{

--- a/apptest/vlagent.go
+++ b/apptest/vlagent.go
@@ -159,9 +159,10 @@ func (app *Vlagent) sendBlocking(t *testing.T, numRecordsToSend int, send func()
 	t.Fatalf("timed out while waiting for inserted rows to be sent to remote storage")
 }
 
-// RemoteWriteRequests sums up the total number of remote write requests for the given remote write URL.
+// RemoteWriteRequests returns the number of successful remote write requests for the given URL.
 func (app *Vlagent) RemoteWriteRequests(t *testing.T, url string) int {
-	re := regexp.MustCompile(fmt.Sprintf("vlagent_remotewrite_requests_total{.*url=%q.*}", url))
+	metricName := fmt.Sprintf(`vlagent_remotewrite_requests_total{url=%q, status_code="2XX"}`, url)
+	re := regexp.MustCompile(`^` + regexp.QuoteMeta(metricName) + ` `)
 	total := 0.0
 	for _, v := range app.GetMetricsByRegexp(t, re) {
 		total += v

--- a/apptest/vlagent.go
+++ b/apptest/vlagent.go
@@ -94,16 +94,44 @@ func (app *Vlagent) WaitQueueEmptyAfter(t *testing.T, cb func()) {
 	t.Fatalf("timed out while waiting for inserted logs to be flushed to remote storage")
 }
 
-// sendBlocking sends the data to remote write url by executing `send` function and
-// waits until the data is actually sent.
+// WaitRemoteWriteRequests waits until each remote write URL reaches the corresponding requests count.
+func (app *Vlagent) WaitRemoteWriteRequests(t *testing.T, remoteWriteURLs []string, requests []int) {
+	t.Helper()
+
+	if len(remoteWriteURLs) != len(requests) {
+		t.Fatalf("unexpected arguments: got %d remote write URLs and %d request counts", len(remoteWriteURLs), len(requests))
+	}
+
+	const (
+		retries = 50
+		period  = 100 * time.Millisecond
+	)
+	for range retries {
+		ok := true
+		for i, remoteWriteURL := range remoteWriteURLs {
+			if app.RemoteWriteRequests(t, remoteWriteURL) != requests[i] {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return
+		}
+		time.Sleep(period)
+	}
+	t.Fatalf("timed out while waiting for remote write requests for %q to reach %v", remoteWriteURLs, requests)
+}
+
+// sendBlocking executes send and waits until the data is added to every remote
+// write queue.
 //
 // vlagent does not send the data immediately. It first puts the data into a
-// buffer. Then a background goroutine takes the data from the buffer sends it
+// buffer. Then a background goroutine takes the data from the buffer and sends it
 // to the vmstorage. This happens every 1s by default.
 //
-// Waiting is implemented a retrieving the value of `vlagent_remotewrite_block_size_rows_sum`
+// Waiting is implemented by retrieving the value of `vlagent_remotewrite_block_size_rows_sum`
 // metric and checking whether it is equal or greater than the wanted value.
-// If it is, then the data has been sent to remote storage.
+// This doesn't guarantee that remote storage has received the data.
 //
 // Unreliable if the records are inserted concurrently.
 func (app *Vlagent) sendBlocking(t *testing.T, numRecordsToSend int, send func()) {
@@ -129,6 +157,16 @@ func (app *Vlagent) sendBlocking(t *testing.T, numRecordsToSend int, send func()
 		time.Sleep(period)
 	}
 	t.Fatalf("timed out while waiting for inserted rows to be sent to remote storage")
+}
+
+// RemoteWriteRequests sums up the total number of remote write requests for the given remote write URL.
+func (app *Vlagent) RemoteWriteRequests(t *testing.T, url string) int {
+	re := regexp.MustCompile(fmt.Sprintf("vlagent_remotewrite_requests_total{.*url=%q.*}", url))
+	total := 0.0
+	for _, v := range app.GetMetricsByRegexp(t, re) {
+		total += v
+	}
+	return int(total)
 }
 
 func (app *Vlagent) remoteWriteBlocksSent(t *testing.T) int {

--- a/apptest/vlagent.go
+++ b/apptest/vlagent.go
@@ -94,32 +94,21 @@ func (app *Vlagent) WaitQueueEmptyAfter(t *testing.T, cb func()) {
 	t.Fatalf("timed out while waiting for inserted logs to be flushed to remote storage")
 }
 
-// WaitRemoteWriteRequests waits until each remote write URL reaches the corresponding requests count.
-func (app *Vlagent) WaitRemoteWriteRequests(t *testing.T, remoteWriteURLs []string, requests []int) {
+// WaitRemoteWriteRequests waits until the remote write URL reaches the given requests count.
+func (app *Vlagent) WaitRemoteWriteRequests(t *testing.T, remoteWriteURL string, requests int) {
 	t.Helper()
-
-	if len(remoteWriteURLs) != len(requests) {
-		t.Fatalf("unexpected arguments: got %d remote write URLs and %d request counts", len(remoteWriteURLs), len(requests))
-	}
 
 	const (
 		retries = 50
 		period  = 100 * time.Millisecond
 	)
 	for range retries {
-		ok := true
-		for i, remoteWriteURL := range remoteWriteURLs {
-			if app.RemoteWriteRequests(t, remoteWriteURL) != requests[i] {
-				ok = false
-				break
-			}
-		}
-		if ok {
+		if app.RemoteWriteRequests(t, remoteWriteURL) == requests {
 			return
 		}
 		time.Sleep(period)
 	}
-	t.Fatalf("timed out while waiting for remote write requests for %q to reach %v", remoteWriteURLs, requests)
+	t.Fatalf("timed out while waiting for remote write requests for %q to reach %d", remoteWriteURL, requests)
 }
 
 // sendBlocking executes send and waits until the data is added to every remote
@@ -162,12 +151,7 @@ func (app *Vlagent) sendBlocking(t *testing.T, numRecordsToSend int, send func()
 // RemoteWriteRequests returns the number of successful remote write requests for the given URL.
 func (app *Vlagent) RemoteWriteRequests(t *testing.T, url string) int {
 	metricName := fmt.Sprintf(`vlagent_remotewrite_requests_total{url=%q, status_code="2XX"}`, url)
-	re := regexp.MustCompile(`^` + regexp.QuoteMeta(metricName) + ` `)
-	total := 0.0
-	for _, v := range app.GetMetricsByRegexp(t, re) {
-		total += v
-	}
-	return int(total)
+	return int(app.GetMetric(t, metricName))
 }
 
 func (app *Vlagent) remoteWriteBlocksSent(t *testing.T) int {


### PR DESCRIPTION
The replication test could query storage before vlagent finished sending data to every replica. This waits for each available replica to receive the request before checking the stored logs.