### PR TITLE
.github/workflows/vmui.yml: remove eslint annotation action

### DIFF
--- a/.github/workflows/vmui.yml
+++ b/.github/workflows/vmui.yml
@@ -24,9 +24,7 @@ jobs:
   vmui-checks:
     name: VMUI Checks (lint, test, typecheck)
     permissions:
-      checks: write
       contents: read
-      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: Code checkout
@@ -67,12 +65,6 @@ jobs:
         continue-on-error: true
         env:
           VMUI_SKIP_INSTALL: true
-
-      - name: Annotate Code Linting Results
-        uses: ataylorme/eslint-annotate-action@d57a1193d4c59cbfbf3f86c271f42612f9dbd9e9  # 3.0.0
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          report-json: app/vmui/packages/vmui/vmui-lint-report.json
 
       - name: Check overall status
         run: |

--- a/app/vmui/packages/vmui/.gitignore
+++ b/app/vmui/packages/vmui/.gitignore
@@ -23,4 +23,3 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 yarn.lock
-vmui-lint-report.json

--- a/app/vmui/packages/vmui/package.json
+++ b/app/vmui/packages/vmui/package.json
@@ -9,7 +9,7 @@
     "start": "vite",
     "start:playground": "cross-env PLAYGROUND=LOGS npm run start",
     "build": "vite build",
-    "lint": "eslint --output-file vmui-lint-report.json --format json 'src/**/*.{ts,tsx}'",
+    "lint": "eslint --format stylish 'src/**/*.{ts,tsx}'",
     "lint:local": "eslint --ext .ts,.tsx -f stylish src",
     "lint:fix": "eslint 'src/**/*.{ts,tsx}' --fix",
     "gen:logsql-pipes": "tsx --tsconfig scripts/tsconfig.json scripts/extractPipes.ts",


### PR DESCRIPTION
Remove the unmaintained third-party `ataylorme/eslint-annotate-action` from the vmui workflow in order to reduce supply-chain risk. 
Switch `npm run lint` back to human-readable ESLint output, since the JSON report was used only by the removed action.

The `make vmui-lint` command still fails CI on lint errors. Printing ESLint errors in the workflow logs should be enough for blocking pull requests with lint errors.

See the alternatives considered and why this was removed: https://github.com/VictoriaMetrics/VictoriaMetrics/pull/11259#issuecomment-4981601165

cc: @arkid15r 

Ref: [ataylorme/eslint-annotate-action](https://github.com/ataylorme/eslint-annotate-action)
