### PR TITLE
vmui: dash placeholder instead of whole-entry dump when display fields are missing

### DIFF
--- a/app/vmui/packages/vmui/src/components/Views/GroupView/GroupLogsItem.tsx
+++ b/app/vmui/packages/vmui/src/components/Views/GroupView/GroupLogsItem.tsx
@@ -101,6 +101,8 @@ const GroupLogsItem: FC<Props> = ({
 
         value && values.push(value);
       });
+    } else if (displayFields.length) {
+      values.push("—");
     } else {
       Object.entries(log).forEach(([key, value]) => {
         values.push(`${key}: ${value}`);

--- a/app/vmui/packages/vmui/src/components/Views/GroupView/GroupLogsItem.tsx
+++ b/app/vmui/packages/vmui/src/components/Views/GroupView/GroupLogsItem.tsx
@@ -83,9 +83,7 @@ const GroupLogsItem: FC<Props> = ({
 
     if (!hasFields) {
       values.push("-");
-    }
-
-    if (displayFields.some(field => log[field])) {
+    } else if (displayFields.some(field => log[field])) {
       displayFields.filter(field => log[field]).forEach((field) => {
         let value: string | ReactNode[] = log[field];
 


### PR DESCRIPTION
Implements #1653.

When **Display fields** are selected but a row contains none of them, the Group view dumped every field of the entry as `key: value` — one wide structured log stretched to dozens of lines. This PR renders a compact `—` placeholder instead; the full entry is still one click away via row expansion.

The whole-entry fallback is preserved only when no display fields are configured at all.

Closes #1653