### PR TITLE
app/vmui: show all rows in Table view when Rows per page is set to All

### DIFF
--- a/app/vmui/packages/vmui/src/components/Main/Pagination/Pagination.tsx
+++ b/app/vmui/packages/vmui/src/components/Main/Pagination/Pagination.tsx
@@ -18,7 +18,7 @@ const Pagination: FC<PaginationProps> = ({
   onPageChange,
   maxVisiblePages = 10
 }) => {
-  const totalPages = Math.ceil(totalItems / itemsPerPage);
+  const totalPages = itemsPerPage > 0 ? Math.ceil(totalItems / itemsPerPage) : 1;
   const handlePageChange = (page: number) => {
     if (page < 1 || page > totalPages) return;
     onPageChange(page);

--- a/app/vmui/packages/vmui/src/components/Views/TableView/TableLogsSettings.tsx
+++ b/app/vmui/packages/vmui/src/components/Views/TableView/TableLogsSettings.tsx
@@ -5,16 +5,14 @@ import TableSettings, { TableSettingsProps } from "../../Table/TableSettings/Tab
 
 interface Props extends TableSettingsProps {
   rowsPerPage: number,
-  setRowsPerPage: (limit: number) => void,
   targetRef: RefObject<HTMLElement>,
 }
 
-const TableLogsSettings: FC<Props> = ({ rowsPerPage, setRowsPerPage, targetRef, ...settingsProps }) => {
+const TableLogsSettings: FC<Props> = ({ rowsPerPage, targetRef, ...settingsProps }) => {
   const { setSearchParamsFromKeys } = useSearchParamsFromObject();
 
   const handleSetRowsPerPage = (limit: number) => {
-    setRowsPerPage(limit);
-    setSearchParamsFromKeys({ rows_per_page: limit });
+    setSearchParamsFromKeys({ rows_per_page: limit || "all" });
   };
 
   const controls = (

--- a/app/vmui/packages/vmui/src/components/Views/TableView/TableLogsSettings.tsx
+++ b/app/vmui/packages/vmui/src/components/Views/TableView/TableLogsSettings.tsx
@@ -21,6 +21,7 @@ const TableLogsSettings: FC<Props> = ({ rowsPerPage, setRowsPerPage, targetRef, 
     <div className="vm-table-view-settings">
       <div className="vm-table-view-settings__button">
         <SelectLimit
+          allowUnlimited
           limit={rowsPerPage}
           onChange={handleSetRowsPerPage}
         />

--- a/app/vmui/packages/vmui/src/components/Views/TableView/TableView.tsx
+++ b/app/vmui/packages/vmui/src/components/Views/TableView/TableView.tsx
@@ -1,17 +1,22 @@
 import { FC } from "preact/compat";
 import "./style.scss";
+import { useSearchParams } from "react-router-dom";
 import { ViewProps } from "../../../pages/QueryPage/QueryPageBody/types";
-import useStateSearchParams from "../../../hooks/useStateSearchParams";
 import EmptyLogs from "../../EmptyLogs/EmptyLogs";
 import { useTableColumnView } from "../../Table/hooks/useTableColumnView";
 import TableLogsSettings from "./TableLogsSettings";
 import TableLogs from "./TableLogs";
 import { useTableLogsKeys } from "./hooks/useTableLogsKeys";
+import { LOGS_URL_PARAMS } from "../../../constants/logs";
 
 const tableId = "table-query-logs";
 
 const TableView: FC<ViewProps> = ({ data, settingsRef }) => {
-  const [rowsPerPage, setRowsPerPage] = useStateSearchParams(100, "rows_per_page");
+  const [searchParams] = useSearchParams();
+
+  const rowsPerPageRaw = searchParams.get(LOGS_URL_PARAMS.ROWS_PER_PAGE);
+  const rowsPerPageNum = rowsPerPageRaw ? Number(rowsPerPageRaw) : 100;
+  const rowsPerPage = isNaN(rowsPerPageNum) ? 0 : rowsPerPageNum;
 
   const { columnKeys, streamKeys, statsByKey } = useTableLogsKeys(data);
   const { viewColumnKeys, dispatchViewColumns } = useTableColumnView(tableId, columnKeys, streamKeys);
@@ -25,15 +30,14 @@ const TableView: FC<ViewProps> = ({ data, settingsRef }) => {
         viewColumnKeys={viewColumnKeys}
         statsByKey={statsByKey}
         dispatchViewColumns={dispatchViewColumns}
-        rowsPerPage={Number(rowsPerPage)}
-        setRowsPerPage={setRowsPerPage}
+        rowsPerPage={rowsPerPage}
         targetRef={settingsRef}
       />
       <TableLogs
         tableId={tableId}
         logs={data}
         columns={viewColumnKeys}
-        rowsPerPage={Number(rowsPerPage)}
+        rowsPerPage={rowsPerPage}
         applyViewColumns={dispatchViewColumns}
       />
     </>

--- a/app/vmui/packages/vmui/src/components/Views/TableView/hooks/useTableLogsPaginate.ts
+++ b/app/vmui/packages/vmui/src/components/Views/TableView/hooks/useTableLogsPaginate.ts
@@ -8,8 +8,8 @@ type Options = {
 export const useTableLogsPaginate = ({ rowsPerPage, containerRef }: Options) => {
   const [page, setPage] = useState(1);
 
-  const startOffset = rowsPerPage ? (page - 1) * rowsPerPage : 0;
-  const endOffset = rowsPerPage ? page * rowsPerPage : Infinity;
+  const startOffset = rowsPerPage > 0 ? (page - 1) * rowsPerPage : 0;
+  const endOffset = rowsPerPage > 0 ? page * rowsPerPage : Infinity;
   const offset: [number, number] = [startOffset, endOffset];
 
   const onChangePage = (newPage: number) => {

--- a/app/vmui/packages/vmui/src/components/Views/TableView/hooks/useTableLogsPaginate.ts
+++ b/app/vmui/packages/vmui/src/components/Views/TableView/hooks/useTableLogsPaginate.ts
@@ -8,8 +8,8 @@ type Options = {
 export const useTableLogsPaginate = ({ rowsPerPage, containerRef }: Options) => {
   const [page, setPage] = useState(1);
 
-  const startOffset = (page - 1) * rowsPerPage;
-  const endOffset =  page * rowsPerPage;
+  const startOffset = rowsPerPage ? (page - 1) * rowsPerPage : 0;
+  const endOffset = rowsPerPage ? page * rowsPerPage : Infinity;
   const offset: [number, number] = [startOffset, endOffset];
 
   const onChangePage = (newPage: number) => {

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -23,6 +23,7 @@ according to the following docs:
 ## tip
 
 * BUGFIX: [cluster version](https://docs.victoriametrics.com/victorialogs/cluster/): evenly spread rerouted data across available `vlstorage` nodes. Previously, healthy nodes adjacent to unavailable nodes in the `-storageNode` list could receive much more data, resulting in uneven resource usage. See [#1548](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1548).
+* BUGFIX: [web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui): fix the `Table` view to show all logs when `All` is selected for `Rows per page`. Previously, the table showed no rows in this case. See [#1661](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1661).
 * BUGFIX: [data ingestion](https://docs.victoriametrics.com/victorialogs/data-ingestion/) and [querying](https://docs.victoriametrics.com/victorialogs/querying/): properly handle logs containing duplicate [stream field](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields) names. Previously, [v1.52.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.52.0) could panic when ingesting such logs in single-node VictoriaLogs, drop them during ingestion in VictoriaLogs cluster, or panic when querying such data written by earlier releases. See [#1603](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1603) and [#1604](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1604).
 
 ## [v1.52.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.52.0)


### PR DESCRIPTION
Table view shares rows_per_page with Group view but never treated 0 as All, so it sliced every row away
 - Handle 0 like Group view does
 - fix the pagination bar as well
 - and let Table view select All from its own selector too

fixes #1661 

https://github.com/user-attachments/assets/a32b497a-e18b-4cd9-a4ee-ccbbb50e90f3

