### PR TITLE
app/vlselect: support requests from v1.50 vlselect

### DIFF
--- a/app/vlselect/internalselect/internalselect.go
+++ b/app/vlselect/internalselect/internalselect.go
@@ -530,10 +530,11 @@ func getCommonParams(r *http.Request, expectedProtocolVersion string) (*commonPa
 
 func checkProtocolVersion(r *http.Request, expectedProtocolVersion string) error {
 	version := r.FormValue("version")
-	if version == expectedProtocolVersion {
-		return nil
+	if version != expectedProtocolVersion {
+		return fmt.Errorf("unexpected protocol version=%q; want %q; the most likely cause of this error is different versions of VictoriaLogs cluster components; "+
+			"make sure VictoriaLogs components have the same release version", version, expectedProtocolVersion)
 	}
-	return fmt.Errorf("unexpected protocol version=%q; want %q; the most likely cause of this error is incompatible versions of VictoriaLogs cluster components", version, expectedProtocolVersion)
+	return nil
 }
 
 func writeValuesWithHits(w http.ResponseWriter, qctx *logstorage.QueryContext, vhs []logstorage.ValueWithHits, disableCompression bool) error {

--- a/app/vlselect/internalselect/internalselect.go
+++ b/app/vlselect/internalselect/internalselect.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -340,7 +341,7 @@ func processStreamIDsRequest(ctx context.Context, w http.ResponseWriter, r *http
 }
 
 func processDeleteRunTask(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-	if err := checkProtocolVersion(r, netselect.DeleteRunTaskProtocolVersion); err != nil {
+	if err := checkProtocolVersion(r, netselect.DeleteRunTaskProtocolVersion, "v1"); err != nil {
 		return err
 	}
 
@@ -372,7 +373,7 @@ func processDeleteRunTask(ctx context.Context, w http.ResponseWriter, r *http.Re
 }
 
 func processDeleteStopTask(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-	if err := checkProtocolVersion(r, netselect.DeleteStopTaskProtocolVersion); err != nil {
+	if err := checkProtocolVersion(r, netselect.DeleteStopTaskProtocolVersion, "v1"); err != nil {
 		return err
 	}
 
@@ -385,7 +386,7 @@ func processDeleteStopTask(ctx context.Context, w http.ResponseWriter, r *http.R
 }
 
 func processDeleteActiveTasks(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-	if err := checkProtocolVersion(r, netselect.DeleteActiveTasksProtocolVersion); err != nil {
+	if err := checkProtocolVersion(r, netselect.DeleteActiveTasksProtocolVersion, "v1"); err != nil {
 		return err
 	}
 
@@ -460,7 +461,7 @@ func (cp *commonParams) UpdatePerQueryStatsMetrics() {
 }
 
 func getCommonParams(r *http.Request, expectedProtocolVersion string) (*commonParams, error) {
-	if err := checkProtocolVersion(r, expectedProtocolVersion); err != nil {
+	if err := checkProtocolVersion(r, expectedProtocolVersion, "v4"); err != nil {
 		return nil, err
 	}
 
@@ -508,13 +509,12 @@ func getCommonParams(r *http.Request, expectedProtocolVersion string) (*commonPa
 	return cp, nil
 }
 
-func checkProtocolVersion(r *http.Request, expectedProtocolVersion string) error {
+func checkProtocolVersion(r *http.Request, supportedProtocolVersions ...string) error {
 	version := r.FormValue("version")
-	if version != expectedProtocolVersion {
-		return fmt.Errorf("unexpected protocol version=%q; want %q; the most likely cause of this error is different versions of VictoriaLogs cluster components; "+
-			"make sure VictoriaLogs components have the same release version", version, expectedProtocolVersion)
+	if slices.Contains(supportedProtocolVersions, version) {
+		return nil
 	}
-	return nil
+	return fmt.Errorf("unexpected protocol version=%q; supported versions: %q; the most likely cause of this error is incompatible versions of VictoriaLogs cluster components", version, supportedProtocolVersions)
 }
 
 func writeValuesWithHits(w http.ResponseWriter, qctx *logstorage.QueryContext, vhs []logstorage.ValueWithHits, disableCompression bool) error {

--- a/app/vlselect/internalselect/internalselect.go
+++ b/app/vlselect/internalselect/internalselect.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -341,8 +340,13 @@ func processStreamIDsRequest(ctx context.Context, w http.ResponseWriter, r *http
 }
 
 func processDeleteRunTask(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-	if err := checkProtocolVersion(r, netselect.DeleteRunTaskProtocolVersion, "v1"); err != nil {
-		return err
+	if currentErr := checkProtocolVersion(r, netselect.DeleteRunTaskProtocolVersion); currentErr != nil {
+		// Only the protocol version needs a fallback, since parseRequest already supports
+		// both application/x-www-form-urlencoded and multipart/form-data.
+		// See https://github.com/VictoriaMetrics/VictoriaLogs/issues/1462
+		if fallbackErr := checkProtocolVersion(r, "v1"); fallbackErr != nil {
+			return currentErr
+		}
 	}
 
 	// Parse query args
@@ -373,8 +377,13 @@ func processDeleteRunTask(ctx context.Context, w http.ResponseWriter, r *http.Re
 }
 
 func processDeleteStopTask(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-	if err := checkProtocolVersion(r, netselect.DeleteStopTaskProtocolVersion, "v1"); err != nil {
-		return err
+	if currentErr := checkProtocolVersion(r, netselect.DeleteStopTaskProtocolVersion); currentErr != nil {
+		// Only the protocol version needs a fallback, since parseRequest already supports
+		// both application/x-www-form-urlencoded and multipart/form-data.
+		// See https://github.com/VictoriaMetrics/VictoriaLogs/issues/1462
+		if fallbackErr := checkProtocolVersion(r, "v1"); fallbackErr != nil {
+			return currentErr
+		}
 	}
 
 	taskID := r.FormValue("task_id")
@@ -386,8 +395,13 @@ func processDeleteStopTask(ctx context.Context, w http.ResponseWriter, r *http.R
 }
 
 func processDeleteActiveTasks(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-	if err := checkProtocolVersion(r, netselect.DeleteActiveTasksProtocolVersion, "v1"); err != nil {
-		return err
+	if currentErr := checkProtocolVersion(r, netselect.DeleteActiveTasksProtocolVersion); currentErr != nil {
+		// Only the protocol version needs a fallback, since parseRequest already supports
+		// both application/x-www-form-urlencoded and multipart/form-data.
+		// See https://github.com/VictoriaMetrics/VictoriaLogs/issues/1462
+		if fallbackErr := checkProtocolVersion(r, "v1"); fallbackErr != nil {
+			return currentErr
+		}
 	}
 
 	tasks, err := vlstorage.DeleteActiveTasks(ctx)
@@ -461,8 +475,13 @@ func (cp *commonParams) UpdatePerQueryStatsMetrics() {
 }
 
 func getCommonParams(r *http.Request, expectedProtocolVersion string) (*commonParams, error) {
-	if err := checkProtocolVersion(r, expectedProtocolVersion, "v4"); err != nil {
-		return nil, err
+	if currentErr := checkProtocolVersion(r, expectedProtocolVersion); currentErr != nil {
+		// Only the protocol version needs a fallback, since parseRequest already supports
+		// both application/x-www-form-urlencoded and multipart/form-data.
+		// See https://github.com/VictoriaMetrics/VictoriaLogs/issues/1462
+		if fallbackErr := checkProtocolVersion(r, "v4"); fallbackErr != nil {
+			return nil, currentErr
+		}
 	}
 
 	tenantIDsStr := r.FormValue("tenant_ids")
@@ -509,12 +528,12 @@ func getCommonParams(r *http.Request, expectedProtocolVersion string) (*commonPa
 	return cp, nil
 }
 
-func checkProtocolVersion(r *http.Request, supportedProtocolVersions ...string) error {
+func checkProtocolVersion(r *http.Request, expectedProtocolVersion string) error {
 	version := r.FormValue("version")
-	if slices.Contains(supportedProtocolVersions, version) {
+	if version == expectedProtocolVersion {
 		return nil
 	}
-	return fmt.Errorf("unexpected protocol version=%q; supported versions: %q; the most likely cause of this error is incompatible versions of VictoriaLogs cluster components", version, supportedProtocolVersions)
+	return fmt.Errorf("unexpected protocol version=%q; want %q; the most likely cause of this error is incompatible versions of VictoriaLogs cluster components", version, expectedProtocolVersion)
 }
 
 func writeValuesWithHits(w http.ResponseWriter, qctx *logstorage.QueryContext, vhs []logstorage.ValueWithHits, disableCompression bool) error {

--- a/app/vlstorage/netselect/netselect.go
+++ b/app/vlstorage/netselect/netselect.go
@@ -66,17 +66,17 @@ const (
 	// DeleteRunTaskProtocolVersion is the version of the protocol used for /internal/delete/run_task HTTP endpoint.
 	//
 	// It must be updated every time the protocol changes.
-	DeleteRunTaskProtocolVersion = "v1"
+	DeleteRunTaskProtocolVersion = "v2"
 
 	// DeleteStopTaskProtocolVersion is the version of the protocol used for /internal/delete/stop_task HTTP endpoint.
 	//
 	// It must be updated every time the protocol changes.
-	DeleteStopTaskProtocolVersion = "v1"
+	DeleteStopTaskProtocolVersion = "v2"
 
 	// DeleteActiveTasksProtocolVersion is the version of the protocol used for /internal/delete/active_tasks endpoint.
 	//
 	// It must be updated every time the protocol changes.
-	DeleteActiveTasksProtocolVersion = "v1"
+	DeleteActiveTasksProtocolVersion = "v2"
 )
 
 // Storage is a network storage for querying remote storage nodes in the cluster.

--- a/apptest/tests/internal_protocol_compatibility_test.go
+++ b/apptest/tests/internal_protocol_compatibility_test.go
@@ -1,0 +1,77 @@
+package tests
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
+
+	"github.com/VictoriaMetrics/VictoriaLogs/app/vlstorage/netselect"
+	"github.com/VictoriaMetrics/VictoriaLogs/apptest"
+	"github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage"
+)
+
+func TestVlsingleMultipleSelectProtocolVersions(t *testing.T) {
+	fs.MustRemoveDir(t.Name())
+	tc := apptest.NewTestCase(t)
+	defer tc.Stop()
+	sut := tc.MustStartDefaultVlsingle()
+
+	sut.JSONLineWrite(t, []string{
+		`{"_msg":"protocol compatibility","_time":"2025-06-05T14:30:19.088007Z"}`,
+	}, apptest.IngestOpts{})
+	sut.ForceFlush(t)
+
+	for _, protocolVersion := range []string{
+		"v4", // Used by vlselect v1.50.0.
+		netselect.QueryProtocolVersion,
+	} {
+		t.Run(protocolVersion, func(t *testing.T) {
+			values := url.Values{
+				"version":                {protocolVersion},
+				"tenant_ids":             {`[{"account_id":0,"project_id":0}]`},
+				"query":                  {`* | fields _msg`},
+				"timestamp":              {"0"},
+				"disable_compression":    {"true"},
+				"allow_partial_response": {"false"},
+				"hidden_fields_filters":  {"[]"},
+			}
+			u := "http://" + sut.HTTPAddr() + "/internal/select/query"
+			response, statusCode := tc.Client().PostForm(t, u, values)
+			if statusCode != http.StatusOK {
+				t.Fatalf("unexpected status code; got %d; want %d; response %q", statusCode, http.StatusOK, response)
+			}
+			if message := unmarshalFirstMessage(t, []byte(response)); message != "protocol compatibility" {
+				t.Fatalf("unexpected message; got %q; want %q", message, "protocol compatibility")
+			}
+		})
+	}
+}
+
+func unmarshalFirstMessage(t *testing.T, data []byte) string {
+	t.Helper()
+
+	if len(data) < 9 {
+		t.Fatalf("unexpectedly short query response: %d bytes", len(data))
+	}
+	blockLen := encoding.UnmarshalUint64(data)
+	if blockLen > uint64(len(data)-8) {
+		t.Fatalf("unexpected block size: %d bytes; response contains %d bytes", blockLen, len(data)-8)
+	}
+	blockData := data[8 : 8+blockLen]
+	if blockData[0] != 0 {
+		t.Fatalf("unexpected first block type: %d", blockData[0])
+	}
+
+	var db logstorage.DataBlock
+	if _, _, err := db.UnmarshalInplace(blockData[1:], nil); err != nil {
+		t.Fatalf("cannot unmarshal query result: %s", err)
+	}
+	c := db.GetColumnByName("_msg")
+	if c == nil || len(c.Values) != 1 {
+		t.Fatalf("unexpected _msg column: %#v", c)
+	}
+	return c.Values[0]
+}

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -22,6 +22,10 @@ according to the following docs:
 
 ## tip
 
+### v1.51.1 (UNRELEASED)
+
+* BUGFIX: [cluster version](https://docs.victoriametrics.com/victorialogs/cluster/): allow `vlstorage` v1.51.1 to accept requests from `vlselect` versions v1.38.0 through v1.51.0. This allows upgrading `vlstorage` nodes from older versions to v1.51.1 while `vlselect` nodes remain on the corresponding older version, and then upgrading the `vlselect` nodes to v1.51.1, without query downtime caused by an internal protocol mismatch. Starting from v1.52.0, `vlstorage` no longer accepts requests from `vlselect` v1.50.0 or earlier. See [#1665](https://github.com/VictoriaMetrics/VictoriaLogs/pull/1665).
+
 ## [v1.51.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.51.0)
 
 Released at 2026-06-17

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -22,7 +22,7 @@ according to the following docs:
 
 ## tip
 
-### v1.51.1 (UNRELEASED)
+### v1.51.1
 
 * BUGFIX: [cluster version](https://docs.victoriametrics.com/victorialogs/cluster/): allow `vlstorage` v1.51.1 to accept requests from `vlselect` versions v1.38.0 through v1.51.0. This allows upgrading `vlstorage` nodes from older versions to v1.51.1 while `vlselect` nodes remain on the corresponding older version, and then upgrading the `vlselect` nodes to v1.51.1, without query downtime caused by an internal protocol mismatch. Starting from v1.52.0, `vlstorage` no longer accepts requests from `vlselect` v1.50.0 or earlier. See [#1665](https://github.com/VictoriaMetrics/VictoriaLogs/pull/1665).
 


### PR DESCRIPTION
Allow vlstorage to accept the previous internal select and delete protocol versions, so vlstorage can be upgraded before vlselect without query downtime. 

Also bump deletion API to v2 to support rolling upgrade without downtime from v1.51.1 to v1.52.0 if users use deletion API.