### PR TITLE
docs: add KENT exporter for shipping Kubernetes events

### DIFF
--- a/docs/victorialogs/data-ingestion/README.md
+++ b/docs/victorialogs/data-ingestion/README.md
@@ -22,6 +22,7 @@ can accept logs from the following log collectors:
 - Journald - see [these docs](https://docs.victoriametrics.com/victorialogs/data-ingestion/journald/).
 - DataDog - see [these docs](https://docs.victoriametrics.com/victorialogs/data-ingestion/datadog-agent/).
 - Splunk - see [these docs](https://docs.victoriametrics.com/victorialogs/data-ingestion/splunk/).
+- KENT (Kubernetes events) - see [these docs](https://docs.victoriametrics.com/victorialogs/data-ingestion/kent/).
 
 The ingested logs can be queried according to [these docs](https://docs.victoriametrics.com/victorialogs/querying/).
 

--- a/docs/victorialogs/data-ingestion/kent.md
+++ b/docs/victorialogs/data-ingestion/kent.md
@@ -1,0 +1,49 @@
+---
+weight: 13
+title: KENT (Kubernetes events)
+disableToc: true
+menu:
+  docs:
+    parent: "victorialogs-data-ingestion"
+    weight: 13
+tags:
+  - logs
+  - kubernetes
+---
+[KENT](https://github.com/lev-stas/KENT) (Kubernetes Events Notifier) is a third-party exporter, which watches Kubernetes events
+(the same data as `kubectl get events` shows) and ships them to VictoriaLogs
+via the [JSON stream API](https://docs.victoriametrics.com/victorialogs/data-ingestion/#json-stream-api).
+
+Install KENT with its Helm chart:
+
+```sh
+git clone https://github.com/lev-stas/KENT.git
+cd KENT/deploy/chart
+helm upgrade --install -n monitoring -f values.yaml kent .
+```
+
+Point it at VictoriaLogs in `values.yaml`:
+
+```yaml
+config:
+  victorialogs:
+    enabled: true
+    endpoint: "http://victorialogs:9428"
+    clusterID: "prod"
+    streamFields: ["k8s.namespace"]
+```
+
+Every event becomes a structured log entry with `k8s.*` and `event.*` fields. The `clusterID` field together with the fields
+listed in `streamFields` is registered as [log stream fields](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields),
+so per-cluster and per-namespace queries stay fast. [Multitenancy](https://docs.victoriametrics.com/victorialogs/#multitenancy)
+is supported via `accountID` and `projectID` options.
+
+Events re-delivered by the Kubernetes watch are deduplicated and failed sends are retried with backoff,
+so VictoriaLogs restarts don't lead to duplicated or lost events.
+
+See [KENT documentation](https://github.com/lev-stas/KENT#readme) for authentication, TLS and other configuration options.
+
+See also:
+
+- [Data ingestion troubleshooting](https://docs.victoriametrics.com/victorialogs/data-ingestion/#troubleshooting).
+- [How to query VictoriaLogs](https://docs.victoriametrics.com/victorialogs/querying/).


### PR DESCRIPTION
### Describe Your Changes

Add [KENT](https://github.com/lev-stas/KENT) (Kubernetes Events Notifier) to the list of supported log collectors on the data ingestion page, with a short dedicated setup page following the format of the existing collector pages.

KENT is a third-party Apache 2.0 exporter that watches Kubernetes events and ships them to VictoriaLogs natively via the JSON stream API (stream fields, multitenancy, auth/TLS), or emits them to stdout for collection with `vlagent -kubernetesCollector`. It closes the gap discussed in #968 until native vlagent support for Kubernetes events lands.

Disclosure: I'm the author of KENT. We run it in production across five clusters.

### Checklist

- [x] The change is described in the PR description