### PR TITLE
Docs: add SEO meta descriptions to each page

### DIFF
--- a/docs/victorialogs/Articles.md
+++ b/docs/victorialogs/Articles.md
@@ -1,6 +1,7 @@
 ---
 weight: 70
 title: Articles
+description: "Articles and additional resources about VictoriaLogs and its use cases."
 menu:
   docs:
     parent: 'victorialogs'

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ---
 weight: 101
 title: CHANGELOG
+description: "Release history for VictoriaLogs"
 menu:
   docs:
     identifier: "victorialogs-changelog"

--- a/docs/victorialogs/FAQ.md
+++ b/docs/victorialogs/FAQ.md
@@ -1,6 +1,7 @@
 ---
 weight: 13
 title: FAQ
+description: "Frequently asked questions comparing VictoriaLogs with Elasticsearch, OpenSearch, and Loki."
 menu:
   docs:
     identifier: "victorialogs-faq"

--- a/docs/victorialogs/FAQ.md
+++ b/docs/victorialogs/FAQ.md
@@ -1,7 +1,7 @@
 ---
 weight: 13
 title: FAQ
-description: "Frequently asked questions comparing VictoriaLogs with Elasticsearch, OpenSearch, and Loki."
+description: "Frequently asked questions about VictoriaLogs, including comparisons with Elasticsearch, Loki, and ClickHouse, disk usage, field limits, and sizing."
 menu:
   docs:
     identifier: "victorialogs-faq"

--- a/docs/victorialogs/QuickStart.md
+++ b/docs/victorialogs/QuickStart.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: Quick Start
+description: "Get started with VictoriaLogs. Download, ingest logs, and query via the built-in Web UI."
 menu:
   docs:
     parent: victorialogs

--- a/docs/victorialogs/Release-Guide.md
+++ b/docs/victorialogs/Release-Guide.md
@@ -1,6 +1,7 @@
 ---
 weight: 100
 title: Release Process Guidance for VictoriaLogs
+description: "Guidance for preparing, testing, and publishing VictoriaLogs releases."
 menu:
   docs:
     parent: victorialogs

--- a/docs/victorialogs/Roadmap.md
+++ b/docs/victorialogs/Roadmap.md
@@ -1,6 +1,7 @@
 ---
 weight: 102
 title: Roadmap
+description: "Upcoming features for VictoriaLogs. Object storage support, log transformations, Kafka, backup tooling, multi-tenant querying."
 disableToc: true
 menu:
   docs:

--- a/docs/victorialogs/_index.md
+++ b/docs/victorialogs/_index.md
@@ -1,5 +1,6 @@
 ---
 title: VictoriaLogs
+description: "Documentation for VictoriaLogs, a database for storing and querying logs. Learn how to ingest, query, operate, and integrate it."
 weight: 0
 menu:
   docs:

--- a/docs/victorialogs/cluster.md
+++ b/docs/victorialogs/cluster.md
@@ -1,6 +1,7 @@
 ---
 weight: 3
 title: VictoriaLogs Cluster
+description: "Deploy VictoriaLogs in cluster mode with vlinsert, vlselect, and vlstorage components."
 menu:
   docs:
     parent: victorialogs

--- a/docs/victorialogs/data-ingestion/DataDogAgent.md
+++ b/docs/victorialogs/data-ingestion/DataDogAgent.md
@@ -1,6 +1,7 @@
 ---
 weight: 5
 title: DataDog Agent Setup
+description: "Configure DataDog agent to send logs to VictoriaLogs"
 disableToc: true
 menu:
   docs:

--- a/docs/victorialogs/data-ingestion/Filebeat.md
+++ b/docs/victorialogs/data-ingestion/Filebeat.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: Filebeat Setup
+description: "Configure Filebeat to send logs to VictoriaLogs"
 disableToc: true
 menu:
   docs:

--- a/docs/victorialogs/data-ingestion/Fluentbit.md
+++ b/docs/victorialogs/data-ingestion/Fluentbit.md
@@ -1,6 +1,7 @@
 ---
 weight: 2
 title: Fluentbit Setup
+description: "Configure Fluentbit to send logs to VictoriaLogs"
 disableToc: true
 menu:
   docs:

--- a/docs/victorialogs/data-ingestion/Fluentd.md
+++ b/docs/victorialogs/data-ingestion/Fluentd.md
@@ -1,6 +1,7 @@
 ---
 weight: 2
 title: Fluentd Setup
+description: "Configure Fluentd to send logs to VictoriaLogs"
 disableToc: true
 menu:
   docs:

--- a/docs/victorialogs/data-ingestion/Journald.md
+++ b/docs/victorialogs/data-ingestion/Journald.md
@@ -1,6 +1,7 @@
 ---
 weight: 10
 title: Journald Setup
+description: "Stream systemd journal logs to VictoriaLogs"
 disableToc: true
 menu:
   docs:

--- a/docs/victorialogs/data-ingestion/Logstash.md
+++ b/docs/victorialogs/data-ingestion/Logstash.md
@@ -1,6 +1,7 @@
 ---
 weight: 3
 title: Logstash Setup
+description: "Configure Logstash to send logs to VictoriaLogs via Elasticsearch or HTTP JSON output."
 disableToc: true
 menu:
   docs:

--- a/docs/victorialogs/data-ingestion/Promtail.md
+++ b/docs/victorialogs/data-ingestion/Promtail.md
@@ -1,7 +1,7 @@
 ---
 weight: 4
 title: Promtail Setup
-description: "Configure Loki collectors to send logs to VictoriaLogs."
+description: "Configure Promtail, Grafana Agent, and Grafana Alloy to send collected logs to VictoriaLogs."
 disableToc: true
 menu:
   docs:

--- a/docs/victorialogs/data-ingestion/Promtail.md
+++ b/docs/victorialogs/data-ingestion/Promtail.md
@@ -1,6 +1,7 @@
 ---
 weight: 4
 title: Promtail Setup
+description: "Configure Loki collectors to send logs to VictoriaLogs."
 disableToc: true
 menu:
   docs:

--- a/docs/victorialogs/data-ingestion/Splunk.md
+++ b/docs/victorialogs/data-ingestion/Splunk.md
@@ -1,6 +1,7 @@
 ---
 weight: 14
 title: Splunk Setup
+description: "Send logs to VictoriaLogs via Splunk HEC API"
 disableToc: true
 menu:
   docs:

--- a/docs/victorialogs/data-ingestion/Telegraf.md
+++ b/docs/victorialogs/data-ingestion/Telegraf.md
@@ -1,6 +1,7 @@
 ---
 weight: 5
 title: Telegraf Setup
+description: "Configure Telegraf to send logs to VictoriaLogs"
 disableToc: true
 menu:
   docs:

--- a/docs/victorialogs/data-ingestion/Vector.md
+++ b/docs/victorialogs/data-ingestion/Vector.md
@@ -1,6 +1,7 @@
 ---
 weight: 20
 title: Vector Setup
+description: "Configure Vector to send logs to VictoriaLogs via Elasticsearch or HTTP JSON."
 disableToc: true
 menu:
   docs:

--- a/docs/victorialogs/data-ingestion/_index.md
+++ b/docs/victorialogs/data-ingestion/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Data Ingestion
+description: "Supported methods for ingesting logs into VictoriaLogs. Syslog, Filebeat, Fluentbit, Fluentd, Logstash, Promtail, Vector, Telegraf, OpenTelemetry, Journald, Datadog, and Splunk."
 weight: 5
 menu:
   docs:

--- a/docs/victorialogs/data-ingestion/_index.md
+++ b/docs/victorialogs/data-ingestion/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Data Ingestion
-description: "Supported methods for ingesting logs into VictoriaLogs. Syslog, Filebeat, Fluentbit, Fluentd, Logstash, Promtail, Vector, Telegraf, OpenTelemetry, Journald, Datadog, and Splunk."
+description: "Supported VictoriaLogs log ingestion methods: Syslog, Rsyslog, Syslog-ng, Filebeat, Fluent Bit, Fluentd, Logstash, Vector, Promtail, Telegraf, OpenTelemetry, Journald, Datadog, and Splunk."
 weight: 5
 menu:
   docs:

--- a/docs/victorialogs/data-ingestion/_index.md
+++ b/docs/victorialogs/data-ingestion/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Data Ingestion
-description: "Supported VictoriaLogs log ingestion methods: Syslog, Rsyslog, Syslog-ng, Filebeat, Fluent Bit, Fluentd, Logstash, Vector, Promtail, Telegraf, OpenTelemetry, Journald, Datadog, and Splunk."
+description: "Ingest logs into VictoriaLogs from Syslog, Filebeat, Fluent Bit, Fluentd, Logstash, Vector, Promtail, Telegraf, OpenTelemetry, Journald, Datadog, and Splunk."
 weight: 5
 menu:
   docs:

--- a/docs/victorialogs/data-ingestion/openshift.md
+++ b/docs/victorialogs/data-ingestion/openshift.md
@@ -1,6 +1,7 @@
 ---
 weight: 4
 title: OpenShift
+description: "Collect OpenShift cluster logs to VictoriaLogs"
 disableToc: true
 menu:
   docs:

--- a/docs/victorialogs/data-ingestion/opentelemetry.md
+++ b/docs/victorialogs/data-ingestion/opentelemetry.md
@@ -1,6 +1,7 @@
 ---
 weight: 4
 title: OpenTelemetry Setup
+description: "Configure OTel SDK or Collector to send logs to VictoriaLogs"
 disableToc: true
 menu:
   docs:

--- a/docs/victorialogs/data-ingestion/opentelemetry.md
+++ b/docs/victorialogs/data-ingestion/opentelemetry.md
@@ -1,7 +1,7 @@
 ---
 weight: 4
 title: OpenTelemetry Setup
-description: "Configure OTel SDK or Collector to send logs to VictoriaLogs"
+description: "Configure OpenTelemetry SDKs and Collectors to send logs to VictoriaLogs."
 disableToc: true
 menu:
   docs:

--- a/docs/victorialogs/data-ingestion/syslog.md
+++ b/docs/victorialogs/data-ingestion/syslog.md
@@ -1,6 +1,7 @@
 ---
 weight: 10
 title: Syslog Setup
+description: "Accept logs into VictoriaLogs via Syslog TCP, UDP, or Unix socket"
 disableToc: true
 menu:
   docs:

--- a/docs/victorialogs/integrations/_index.md
+++ b/docs/victorialogs/integrations/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Integrations
+description: "Integration guides for using VictoriaLogs with Grafana, Perses, and Bindplane."
 weight: 13
 menu:
   docs:

--- a/docs/victorialogs/integrations/bindplane.md
+++ b/docs/victorialogs/integrations/bindplane.md
@@ -1,5 +1,6 @@
 ---
 title: Bindplane
+description: "Configure Bindplane to collect and send logs to VictoriaLogs."
 weight: 3
 menu:
   docs:

--- a/docs/victorialogs/integrations/perses.md
+++ b/docs/victorialogs/integrations/perses.md
@@ -1,6 +1,7 @@
 ---
 weight: 2
 title: Perses
+description: "Use VictoriaLogs with Perses for log dashboards and visualization."
 menu:
   docs:
     identifier: integrations-vl-perses

--- a/docs/victorialogs/keyConcepts.md
+++ b/docs/victorialogs/keyConcepts.md
@@ -1,6 +1,7 @@
 ---
 weight: 2
 title: Key Concepts
+description: "VictoriaLogs data model. Structured and unstructured logs, fields, streams, and time."
 menu:
   docs:
     identifier: vl-key-concepts

--- a/docs/victorialogs/logql-to-logsql.md
+++ b/docs/victorialogs/logql-to-logsql.md
@@ -1,6 +1,7 @@
 ---
 weight: 51
 title: How To Convert Loki Queries to VictoriaLogs Queries
+description: "Convert Loki LogQL queries to VictoriaLogs LogsQL."
 menu:
   docs:
     parent: "victorialogs"

--- a/docs/victorialogs/logsql-examples.md
+++ b/docs/victorialogs/logsql-examples.md
@@ -1,6 +1,7 @@
 ---
 weight: 50
 title: LogsQL Examples
+description: "Practical LogsQL query cookbook for VictoriaLogs. Time filters, field searches, sorting, limiting, and common patterns."
 menu:
   docs:
     parent: "victorialogs"

--- a/docs/victorialogs/logsql.md
+++ b/docs/victorialogs/logsql.md
@@ -1,5 +1,6 @@
 ---
 title: LogsQL
+description: "Complete LogsQL query language reference for VictoriaLogs. Full-text search, phrase/prefix filters, logical filters, stats calculations, and step-by-step tutorial."
 weight: 7
 menu:
   docs:

--- a/docs/victorialogs/logsql.md
+++ b/docs/victorialogs/logsql.md
@@ -1,6 +1,6 @@
 ---
 title: LogsQL
-description: "Complete LogsQL query language reference for VictoriaLogs. Full-text search, phrase/prefix filters, logical filters, stats calculations, and step-by-step tutorial."
+description: "LogsQL query language reference for VictoriaLogs. Full-text search, phrase/prefix filters, logical filters, stats calculations, and step-by-step tutorial."
 weight: 7
 menu:
   docs:

--- a/docs/victorialogs/metrics.md
+++ b/docs/victorialogs/metrics.md
@@ -1,6 +1,7 @@
 ---
 weight: 20
 title: Metrics of VictoriaLogs
+description: "Prometheus metrics exposed by VictoriaLogs for operational monitoring."
 menu:
   docs:
     parent: victorialogs

--- a/docs/victorialogs/querying/_index.md
+++ b/docs/victorialogs/querying/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Querying
+description: "All ways to query VictoriaLogs. HTTP API, vlogscli, Web UI, and Grafana plugin."
 weight: 6
 menu:
   docs:

--- a/docs/victorialogs/querying/vlogscli.md
+++ b/docs/victorialogs/querying/vlogscli.md
@@ -1,7 +1,7 @@
 ---
 weight:
 title: vlogscli
-description: "Interactive command-line LogsQL query tool for VictoriaLogs with history, live tailing, and multiple output formats."
+description: "Use vlogscli, an interactive command-line tool, to query VictoriaLogs with LogsQL, history, live tailing, and multiple output formats."
 disableToc: true
 menu:
   docs:

--- a/docs/victorialogs/querying/vlogscli.md
+++ b/docs/victorialogs/querying/vlogscli.md
@@ -1,6 +1,7 @@
 ---
 weight:
 title: vlogscli
+description: "Interactive command-line LogsQL query tool for VictoriaLogs with history, live tailing, and multiple output formats."
 disableToc: true
 menu:
   docs:

--- a/docs/victorialogs/security-and-lb.md
+++ b/docs/victorialogs/security-and-lb.md
@@ -5,6 +5,7 @@ menu:
     parent: victorialogs
     weight: 12
 title: Security and Load Balancing
+description: "Secure VictoriaLogs with vmauth, TLS termination, and multi-tenant proxying."
 tags:
   - logs
 ---

--- a/docs/victorialogs/sql-to-logsql.md
+++ b/docs/victorialogs/sql-to-logsql.md
@@ -1,6 +1,7 @@
 ---
 weight: 52
 title: SQL to LogsQL Tutorial
+description: "Tutorial mapping SQL concepts to VictoriaLogs LogsQL syntax"
 menu:
   docs:
     parent: "victorialogs"

--- a/docs/victorialogs/vlagent-metrics.md
+++ b/docs/victorialogs/vlagent-metrics.md
@@ -1,7 +1,7 @@
 ---
 weight: 21
 title: Metrics of vlagent
-description: "Prometheus metrics exposed by vlagent for monitoring VictoriaLogs."
+description: "Prometheus metrics exposed by vlagent for monitoring log collection and remote write operations."
 menu:
   docs:
     parent: victorialogs

--- a/docs/victorialogs/vlagent-metrics.md
+++ b/docs/victorialogs/vlagent-metrics.md
@@ -1,6 +1,7 @@
 ---
 weight: 21
 title: Metrics of vlagent
+description: "Prometheus metrics exposed by vlagent for monitoring VictoriaLogs."
 menu:
   docs:
     parent: victorialogs

--- a/docs/victorialogs/vlagent.md
+++ b/docs/victorialogs/vlagent.md
@@ -1,5 +1,6 @@
 ---
 title: vlagent
+description: "Log collection agent for VictoriaLogs with Kubernetes pod log discovery, HTTP ingestion, replication, and on-disk buffering."
 weight: 4
 menu:
   docs:

--- a/docs/victorialogs/vmalert.md
+++ b/docs/victorialogs/vmalert.md
@@ -1,6 +1,7 @@
 ---
 weight: 9
 title: Alerting with Logs
+description: "Configure vmalert to alert on VictoriaLogs LogsQL stats queries."
 menu:
   docs:
     parent: "victorialogs"


### PR DESCRIPTION
This PR add meta descriptions to every page in the docs in this repository. Right now, we have one general meta description for every page. This PR adds page-specific descriptions.

Meta descriptions are not likely to improve rankings on search engines but can improve CTRs. They can also be used to keep LLMs.txt updated as new pages are added (by adding an automation later).

The descriptions were taken from LLMs.txt, so they were already reviewed in https://github.com/VictoriaMetrics/vmdocs/pull/251
I only tweaked those that needed trimming to fit into the 160 SEO character limit. We also revised them with our SEO specialist (Jonathan). So I think it's a good staring point.

I'm going to open a PR for every repository that contributes to the docs and add descriptions so eventually every page in the docs has a dedicated meta descriptions.
