### PR TITLE
app/{vlselect,vlstorage}: require POST for all internal endpoints

### DIFF
--- a/app/vlselect/internalselect/internalselect.go
+++ b/app/vlselect/internalselect/internalselect.go
@@ -31,6 +31,11 @@ var maxConcurrentRequests = flag.Int("internalselect.maxConcurrentRequests", 8, 
 
 // RequestHandler processes requests to /internal/select/*
 func RequestHandler(ctx context.Context, w http.ResponseWriter, r *http.Request, path string) {
+	if r.Method != "POST" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
 	startTime := time.Now()
 
 	select {

--- a/app/vlstorage/main.go
+++ b/app/vlstorage/main.go
@@ -246,6 +246,12 @@ func Stop() {
 // RequestHandler is a storage request handler.
 func RequestHandler(w http.ResponseWriter, r *http.Request) bool {
 	path := strings.ReplaceAll(r.URL.Path, "//", "/")
+
+	if strings.HasPrefix(path, "/internal/") && r.Method != "POST" {
+		http.Error(w, fmt.Sprintf("Only POST method is allowed; got %s.", r.Method), http.StatusMethodNotAllowed)
+		return true
+	}
+
 	switch path {
 	case "/internal/log_new_streams":
 		return processLogNewStreams(w, r)

--- a/app/vlstorage/netinsert/netinsert.go
+++ b/app/vlstorage/netinsert/netinsert.go
@@ -263,10 +263,8 @@ func (sn *storageNode) sendInsertRequest(pendingData *bytesutil.ByteBuffer) erro
 }
 
 func (sn *storageNode) doRequest(path string, body io.Reader) error {
-	method := "GET"
-	if body != nil {
-		method = "POST"
-	}
+	// All the internal endpoints require the POST method.
+	method := "POST"
 
 	reqURL := sn.getRequestURL(path)
 	req, err := http.NewRequestWithContext(sn.s.sendCtx, method, reqURL, body)

--- a/apptest/tests/internal_api_test.go
+++ b/apptest/tests/internal_api_test.go
@@ -1,0 +1,53 @@
+package tests
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
+
+	"github.com/VictoriaMetrics/VictoriaLogs/apptest"
+)
+
+// TestVlsingleInternalEndpointsRequirePOST verifies that the internal endpoints require
+// the POST method in order to prevent GET-based SSRF attacks.
+//
+// See the related https://github.com/VictoriaMetrics/VictoriaLogs/issues/1635
+func TestVlsingleInternalEndpointsRequirePOST(t *testing.T) {
+	fs.MustRemoveDir(t.Name())
+
+	tc := apptest.NewTestCase(t)
+	defer tc.Stop()
+
+	sut := tc.MustStartVlsingle("vlsingle", []string{
+		"-internaldelete.enable=true",
+	})
+	cli := tc.Client()
+	baseURL := "http://" + sut.HTTPAddr()
+
+	f := func(method, path string, wantStatus int) {
+		t.Helper()
+		if body, statusCode := cli.Do(t, method, baseURL+path, "", nil); statusCode != wantStatus {
+			t.Fatalf("unexpected status code for %s %s: got %d; want %d; body\n%s", method, path, statusCode, wantStatus, body)
+		}
+	}
+
+	// Non-POST requests must be rejected with 405 both for the RPC endpoints (insert/select/delete)
+	// and for the human-facing storage endpoints.
+	paths := []string{
+		"/internal/insert",
+		"/internal/select/query",
+		"/internal/delete/run_task",
+		"/internal/force_merge",
+	}
+	for _, path := range paths {
+		for _, method := range []string{http.MethodGet, http.MethodHead, http.MethodPut, http.MethodDelete, http.MethodPatch} {
+			f(method, path, http.StatusMethodNotAllowed)
+		}
+	}
+
+	// A POST request must pass the method check.
+	if _, statusCode := cli.Do(t, http.MethodPost, baseURL+"/internal/select/query", "", nil); statusCode == http.StatusMethodNotAllowed {
+		t.Fatalf("unexpected 405 for POST /internal/select/query; POST must be allowed by the method check")
+	}
+}

--- a/apptest/vlcluster.go
+++ b/apptest/vlcluster.go
@@ -71,7 +71,7 @@ func (app *Vlcluster) ForceFlush(t *testing.T) {
 
 	url := fmt.Sprintf("http://%s/internal/force_flush", app.insertNode.httpListenAddr)
 
-	_, statusCode := app.insertNode.cli.Get(t, url)
+	_, statusCode := app.insertNode.cli.Post(t, url, "", nil)
 	if statusCode != http.StatusOK {
 		t.Fatalf("unexpected status code when querying %s: got %d; want %d", url, statusCode, http.StatusOK)
 	}

--- a/apptest/vlsingle.go
+++ b/apptest/vlsingle.go
@@ -85,7 +85,7 @@ func (app *Vlsingle) ForceFlush(t *testing.T) {
 	t.Helper()
 
 	url := fmt.Sprintf("http://%s/internal/force_flush", app.node.httpListenAddr)
-	_, statusCode := app.node.cli.Get(t, url)
+	_, statusCode := app.node.cli.Post(t, url, "", nil)
 	if statusCode != http.StatusOK {
 		t.Fatalf("unexpected status code when querying %s: got %d, want %d", url, statusCode, http.StatusOK)
 	}

--- a/docs/victorialogs/CHANGELOG.md
+++ b/docs/victorialogs/CHANGELOG.md
@@ -23,8 +23,11 @@ according to the following docs:
 
 ## tip
 
+**Update note:** the `/internal/force_merge`, `/internal/force_flush`, `/internal/log_new_streams` and `/internal/partition/*` HTTP endpoints now require the `POST` method. Update any scripts or automation calling these endpoints via `GET` to use `POST`.
+
 * SECURITY: upgrade Go builder from Go1.26.5 to Go1.26.6. See [the list of issues addressed in Go1.26.6](https://github.com/golang/go/issues?q=milestone%3AGo1.26.6%20label%3ACherryPickApproved).
 * SECURITY: [deletion API](https://docs.victoriametrics.com/victorialogs/#how-to-delete-logs): restrict the `/delete/run_task` endpoint to the `POST` method only in order to prevent some [SSRF](https://en.wikipedia.org/wiki/Server-side_request_forgery)-based log deletion attacks. See [#1635](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1635).
+* SECURITY: require the `POST` method for the `/internal/force_merge`, `/internal/force_flush`, `/internal/log_new_streams` and `/internal/partition/*` HTTP endpoints in order to prevent GET-based [SSRF](https://en.wikipedia.org/wiki/Server-side_request_forgery) attacks. See the related [#1635](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1635).
 
 * FEATURE: [cluster version](https://docs.victoriametrics.com/victorialogs/cluster/): optimize queries, which return the limited number of log entries with the biggest timestamps on the selected time range. [Web UI](https://docs.victoriametrics.com/victorialogs/querying/#web-ui) usually executes such queries. See [#1602](https://github.com/VictoriaMetrics/VictoriaLogs/issues/1602).
 * FEATURE: [dashboards/cluster](https://grafana.com/grafana/dashboards/23274), [dashboards/single](https://grafana.com/grafana/dashboards/22084), and [dashboards/vlagent](https://grafana.com/grafana/dashboards/24513): add `Fsync avg duration` panel to the Troubleshooting section of the single-node, cluster, and vlagent dashboards. This panel shows average `fsync` latency to help identify slow storage persistence. See [VictoriaMetrics#10432](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10432).

--- a/docs/victorialogs/README.md
+++ b/docs/victorialogs/README.md
@@ -253,7 +253,7 @@ at April 18, 2025 UTC. This allows flexible data management.
 
 For example, old per-day data is automatically and quickly deleted according to the provided [retention policy](https://docs.victoriametrics.com/victorialogs/#retention) by removing the corresponding per-day subdirectory (partition).
 
-VictoriaLogs supports the following HTTP API endpoints at `victoria-logs:9428` address for managing partitions:
+VictoriaLogs supports the following HTTP API endpoints at `victoria-logs:9428` address for managing partitions. All of them must be called with the `POST` method:
 
 - `/internal/partition/attach?name=YYYYMMDD` - attaches the partition directory with the given name `YYYYMMDD` to VictoriaLogs,
   so it becomes visible for querying and can be used for data ingestion.
@@ -324,11 +324,11 @@ It is recommended leaving the following amounts of spare resource for smooth wor
 VictoriaLogs can log new [log streams](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields) during [data ingestion](https://docs.victoriametrics.com/victorialogs/data-ingestion/).
 This is useful during the debugging of high cardinality or churn rate issues for the ingested log streams.
 This functionality can be enabled either on a permanent basis via `-logNewStreams` command-line flag or temporarily for the given number of seconds
-by sending HTTP request to `http://victoria-logs:9428/internal/log_new_streams?seconds=secs`. For example, the following command enables temporary logging
+by sending a `POST` HTTP request to `http://victoria-logs:9428/internal/log_new_streams?seconds=secs`. For example, the following command enables temporary logging
 of new log streams for 10 seconds:
 
 ```
-curl http://victoria-logs:9428/internal/log_new_streams?seconds=10
+curl -X POST http://victoria-logs:9428/internal/log_new_streams?seconds=10
 ```
 
 This endpoint can be protected with the `-logNewStreamsAuthKey` command-line flag.
@@ -342,7 +342,7 @@ VictoriaLogs performs data compactions in background in order to keep good perfo
 These compactions (merges) are performed independently on per-day partitions.
 This means that compactions are stopped for per-day partitions if no new data is ingested into these partitions.
 Sometimes it is necessary to trigger compactions for old partitions. In this case forced compaction may be initiated on the specified per-day partition
-by sending request to `/internal/force_merge?partition_prefix=YYYYMMDD`,
+by sending a `POST` request to `/internal/force_merge?partition_prefix=YYYYMMDD`,
 where `YYYYMMDD` is per-day partition name. For example, `http://victoria-logs:9428/internal/force_merge?partition_prefix=20240921` would initiate forced
 merge for September 21, 2024 partition. The call to `/internal/force_merge` returns immediately, while the corresponding forced merge continues running in background.
 
@@ -357,7 +357,7 @@ See [these docs](https://docs.victoriametrics.com/victorialogs/security-and-lb/#
 
 VictoriaLogs puts the recently [ingested logs](https://docs.victoriametrics.com/victorialogs/data-ingestion/) into in-memory buffers,
 which aren't available for [querying](https://docs.victoriametrics.com/victorialogs/querying/) for up to a second.
-If you need querying logs immediately after their ingestion, then the `/internal/force_flush` HTTP endpoint must be requested
+If you need querying logs immediately after their ingestion, then the `/internal/force_flush` HTTP endpoint must be requested with the `POST` method
 before querying. This endpoint converts in-memory buffers with the recently ingested logs into searchable [data blocks](https://victoriametrics.com/blog/victorialogs-internals-columnar-storage-on-disk/#41-logs-are-grouped-into-blocks-by-stream-and-by-time).
 
 It isn't recommended requesting the `/internal/force_flush` HTTP endpoint on a regular basis, since this increases CPU usage


### PR DESCRIPTION
Reject non-POST requests to all `/internal/*` endpoints to block GET-based SSRF.

Note: an unknown `/internal/*` path with a non-POST method now returns 405 instead of 404.

Related: #1635