### PR TITLE
lib/logstorage: clean test data in setup

### DIFF
--- a/lib/logstorage/filter_stream_id_test.go
+++ b/lib/logstorage/filter_stream_id_test.go
@@ -41,6 +41,7 @@ func testFilterMatchForStreamID(t *testing.T, f filter, expectedRowIdxs []int) {
 	t.Helper()
 
 	storagePath := t.Name()
+	clean(t, storagePath)
 
 	cfg := &StorageConfig{
 		Retention: 100 * 365 * time.Duration(nsecsPerDay),

--- a/lib/logstorage/filter_test.go
+++ b/lib/logstorage/filter_test.go
@@ -82,6 +82,7 @@ func testFilterMatchForColumns(t *testing.T, columns []column, f filter, neededC
 
 	// Create the test storage
 	storagePath := t.Name()
+	clean(t, storagePath)
 	cfg := &StorageConfig{
 		Retention: time.Duration(100 * 365 * nsecsPerDay),
 	}

--- a/lib/logstorage/filter_time_test.go
+++ b/lib/logstorage/filter_time_test.go
@@ -60,6 +60,7 @@ func testFilterMatchForTimestamps(t *testing.T, timestamps []int64, f filter, ex
 
 	// Create the test storage
 	storagePath := t.Name()
+	clean(t, storagePath)
 	cfg := &StorageConfig{
 		Retention: 100 * 365 * time.Duration(nsecsPerDay),
 	}

--- a/lib/logstorage/storage_test.go
+++ b/lib/logstorage/storage_test.go
@@ -2,6 +2,7 @@ package logstorage
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -11,10 +12,19 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
+func clean(t *testing.T, path string) {
+	t.Helper()
+
+	if err := os.RemoveAll(path); err != nil {
+		t.Fatalf("failed to delete test data %q: %v", path, err)
+	}
+}
+
 func TestStorageLifecycle(t *testing.T) {
 	t.Parallel()
 
 	path := t.Name()
+	clean(t, path)
 
 	for range 3 {
 		cfg := &StorageConfig{}
@@ -28,6 +38,7 @@ func TestStorageMustAddRows(t *testing.T) {
 	t.Parallel()
 
 	path := t.Name()
+	clean(t, path)
 
 	cfg := &StorageConfig{}
 	s := MustOpenStorage(path, cfg)
@@ -115,6 +126,7 @@ func TestStoragePartitionDetachRecreateSameDaySameStream(t *testing.T) {
 	t.Parallel()
 
 	path := t.Name()
+	clean(t, path)
 
 	cfg := &StorageConfig{
 		Retention:       365 * 24 * time.Hour,
@@ -176,6 +188,7 @@ func TestStoragePartitionDetachRecreateSameDayStreamFilterQuery(t *testing.T) {
 	t.Parallel()
 
 	path := t.Name()
+	clean(t, path)
 
 	cfg := &StorageConfig{
 		Retention: 365 * 24 * time.Hour,
@@ -235,6 +248,7 @@ func TestStorageDeleteTaskOps(t *testing.T) {
 	t.Parallel()
 
 	path := t.Name()
+	clean(t, path)
 	cfg := &StorageConfig{}
 	s := MustOpenStorage(path, cfg)
 
@@ -291,6 +305,7 @@ func TestStorageProcessDeleteTask(t *testing.T) {
 	t.Parallel()
 
 	path := t.Name()
+	clean(t, path)
 	ctx := t.Context()
 
 	cfg := &StorageConfig{
@@ -408,6 +423,7 @@ func TestStorageProcessDeleteTaskRelativeTimeUsesTaskStartTime(t *testing.T) {
 	t.Parallel()
 
 	path := t.Name()
+	clean(t, path)
 	ctx := t.Context()
 
 	cfg := &StorageConfig{
@@ -463,6 +479,7 @@ func TestStorageHiddenFieldsWithFieldNamesPipe(t *testing.T) {
 	t.Parallel()
 
 	path := t.Name()
+	clean(t, path)
 	cfg := &StorageConfig{
 		Retention: 365 * 24 * time.Hour,
 	}
@@ -612,6 +629,7 @@ func TestStorageDropStalePartitions(t *testing.T) {
 	t.Parallel()
 
 	path := t.Name()
+	clean(t, path)
 
 	cfg := &StorageConfig{
 		Retention: 30 * 24 * time.Hour,


### PR DESCRIPTION
This updates the logstorage tests to check for data from a previous run during
startup and clean the old data if it exists.

Tests in the logstorage package create files. When they fail, they leave those
files around for debugging purposes. If you don't clean those files up before
you re-run the tests, then the tests will happily use the existing files -
triggering another failure. This can cause confusion if you've fixed the issue
that caused them to fail.

This commit adds os.RemoveAll(path) to each test that calls MustOpenStorage(...)
to delete data from the previous run.

---

Some context:

I was just checking out Victoria and I ctrl+c'd out of the test run part of the way through `make test-race`. One of the directories from lib/logstorage was left around, causing that test to fail every time I ran it after that first run. I was confused for a little bit.

I was tempted to use `t.Cleanup()` to clean up those files after the test run, but it looks like they can be useful for debugging if one of the tests fails. Doing `os.RemoveAll` during test setup solves the issue while still allowing people to use the files for debugging.