### PR TITLE
app/vlinsert/syslog: fix data race accessing globalTimezone

### DIFF
--- a/app/vlinsert/syslog/syslog.go
+++ b/app/vlinsert/syslog/syslog.go
@@ -149,9 +149,9 @@ func MustInit() {
 		if err != nil {
 			logger.Fatalf("cannot parse -syslog.timezone=%q: %s", *syslogTimezone, err)
 		}
-		globalTimezone = tz
+		globalTimezone.Store(tz)
 	} else {
-		globalTimezone = time.Local
+		globalTimezone.Store(time.Local)
 	}
 
 	currentYear := nowInGlobalTZ().Year()
@@ -159,7 +159,7 @@ func MustInit() {
 	workersWG.Go(func() {
 		for {
 			now := nowInGlobalTZ()
-			nextYear := time.Date(now.Year()+1, 1, 1, 0, 0, 0, 0, globalTimezone)
+			nextYear := time.Date(now.Year()+1, 1, 1, 0, 0, 0, 0, globalTimezone.Load())
 			nextTick := min(time.Minute, nextYear.Sub(now))
 			select {
 			case <-workersStopCh:
@@ -174,11 +174,11 @@ func MustInit() {
 
 var (
 	globalCurrentYear atomic.Int64
-	globalTimezone    *time.Location
+	globalTimezone    atomic.Pointer[time.Location]
 )
 
 func nowInGlobalTZ() time.Time {
-	return time.Now().In(globalTimezone)
+	return time.Now().In(globalTimezone.Load())
 }
 
 var (
@@ -457,7 +457,7 @@ func processUncompressedStream(r io.Reader, useLocalTimestamp bool, remoteIP str
 		}
 
 		currentYear := int(globalCurrentYear.Load())
-		err := processLine(slr.line, currentYear, globalTimezone, useLocalTimestamp, remoteIP, lmp)
+		err := processLine(slr.line, currentYear, globalTimezone.Load(), useLocalTimestamp, remoteIP, lmp)
 		if err != nil {
 			errorsTotal.Inc()
 			return fmt.Errorf("cannot read line #%d: %w", n, err)

--- a/app/vlinsert/syslog/syslog_test.go
+++ b/app/vlinsert/syslog/syslog_test.go
@@ -81,7 +81,11 @@ func TestProcessStreamInternal_Success(t *testing.T) {
 		MustInit()
 		defer MustStop()
 
-		globalTimezone = time.UTC
+		prevTZ := globalTimezone.Load()
+		globalTimezone.Store(time.UTC)
+		t.Cleanup(func() {
+			globalTimezone.Store(prevTZ)
+		})
 		globalCurrentYear.Store(int64(currentYear))
 
 		tlp := &insertutil.TestLogMessageProcessor{}


### PR DESCRIPTION
Running `go test -race` in app/vlinsert/syslog reports a data race because `MustInit()` kicks off a goroutine that periodically accesses `globalTimezone`, and `TestProcessStreamInternal_Success` changes `globalTimezone` after that goroutine has started.

This makes the minor sacrifice of one extra `atomic.Pointer.Load()` per iteration in exchange for a passing `go test -race`.

---

Note: I first tried moving the `globalTimezone = time.UTC` step to before `MustInit()`, but the expected output in the tests require the time zone to change after the call to `MustInit()`. If that's a mistake, I would be happy to update the expectation and scrap the `atomic.Pointer`! I think that's a much less brittle test, anyway.

But if the test's expected output is that way for a reason, I think the cost of an `atomic.Load()` is a small price to get `go test -race` to pass.