### PR TITLE
docs/victorialogs/README.md: fix rsync example for partition backups

### DIFF
--- a/docs/victorialogs/README.md
+++ b/docs/victorialogs/README.md
@@ -449,7 +449,7 @@ The following steps must be performed to make a backup of the given `YYYYMMDD` p
 1. To backup the created snapshot with [`rsync`](https://en.wikipedia.org/wiki/Rsync):
 
    ```sh
-   rsync -avh --progress --delete <path-to-snapshot> <username>@<host>:<path-to-backup>/YYYYMMDD
+   rsync -avh --progress --delete <path-to-snapshot>/ <username>@<host>:<path-to-backup>/YYYYMMDD
    ```
 
    The `--delete` option is required in the command above in order to ensures that the backup contains the full copy of the original data without superfluous files.


### PR DESCRIPTION
The following command is based on the current docs:

```sh
rsync -avh --progress --delete victoria-logs-data/partitions/20260824/snapshots/20260824165035-18CECBCB2923A4B9 user@host:/vl-backups/20260824
```

it creates /vl-backups/20260824/20260824165035-18CECBCB2923A4B9 folder at the destination, which makes the next command from the docs incorrect:

```
rsync -avh --progress --delete user@host:/vl-backups/20260824 victoria-logs-data/partitions/
```

The command above copies indexdb and datadb to victoria-logs-data/partitions/20260824/20260824165035-18CECBCB2923A4B9/{indexdb,datadb} instead victoria-logs-data/partitions/20260824/{indexdb, datadb}. VictoriaLogs will ignore this folder even after restart.

Explicetly specified `/` in the end of the source path fixes the issue.
