### PR TITLE
tests: migrate to (*testing.T).TempDir()

### DIFF
--- a/apptest/testcase.go
+++ b/apptest/testcase.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -34,11 +33,6 @@ func (tc *TestCase) T() *testing.T {
 	return tc.t
 }
 
-// Dir returns the directory name that should be used by as the -storageDataDir.
-func (tc *TestCase) Dir() string {
-	return tc.t.Name()
-}
-
 // Client returns an instance of the client that can be used for interacting with
 // the app(s) under test.
 func (tc *TestCase) Client() *Client {
@@ -54,9 +48,6 @@ func (tc *TestCase) Stop() {
 	tc.cli.CloseConnections()
 	for _, app := range tc.startedApps {
 		app.Stop()
-	}
-	if !tc.t.Failed() {
-		fs.MustRemoveDir(tc.Dir())
 	}
 }
 

--- a/apptest/tests/csv_response_test.go
+++ b/apptest/tests/csv_response_test.go
@@ -3,13 +3,10 @@ package tests
 import (
 	"testing"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
-
 	"github.com/VictoriaMetrics/VictoriaLogs/apptest"
 )
 
 func TestVlsingleQueryCSVResponse(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartDefaultVlsingle()
@@ -65,7 +62,6 @@ case 2,{},2025-06-06T14:30:19.088007Z,,,false,12345,"[""foo"",""bar""]"
 }
 
 func TestVlclusterQueryCSVResponse(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartDefaultVlcluster()

--- a/apptest/tests/delete_api_test.go
+++ b/apptest/tests/delete_api_test.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
-
 	"github.com/VictoriaMetrics/VictoriaLogs/apptest"
 )
 
@@ -13,8 +11,6 @@ import (
 //
 // See https://github.com/VictoriaMetrics/VictoriaLogs/issues/1635
 func TestVlsingleDeleteAPIRequiresPOST(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
-
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 

--- a/apptest/tests/hits_test.go
+++ b/apptest/tests/hits_test.go
@@ -3,13 +3,10 @@ package tests
 import (
 	"testing"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
-
 	"github.com/VictoriaMetrics/VictoriaLogs/apptest"
 )
 
 func TestHits(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 
@@ -40,7 +37,6 @@ func TestHits(t *testing.T) {
 }
 
 func TestVlclusterHits(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 

--- a/apptest/tests/ingest_protocols_test.go
+++ b/apptest/tests/ingest_protocols_test.go
@@ -3,14 +3,11 @@ package tests
 import (
 	"testing"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
-
 	"github.com/VictoriaMetrics/VictoriaLogs/apptest"
 	"github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage"
 )
 
 func TestVlsingleIngestionProtocols(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartDefaultVlsingle()

--- a/apptest/tests/ingest_timestamp_test.go
+++ b/apptest/tests/ingest_timestamp_test.go
@@ -6,13 +6,10 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
-
 	"github.com/VictoriaMetrics/VictoriaLogs/apptest"
 )
 
 func TestVlsingleElasticsearchBulkTimestampParsing(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 

--- a/apptest/tests/internal_api_test.go
+++ b/apptest/tests/internal_api_test.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
-
 	"github.com/VictoriaMetrics/VictoriaLogs/apptest"
 )
 
@@ -14,8 +12,6 @@ import (
 //
 // See the related https://github.com/VictoriaMetrics/VictoriaLogs/issues/1635
 func TestVlsingleInternalEndpointsRequirePOST(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
-
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 

--- a/apptest/tests/key_concepts_test.go
+++ b/apptest/tests/key_concepts_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/VictoriaMetrics/VictoriaLogs/apptest"
@@ -14,7 +13,6 @@ import (
 
 // TestVlsingleKeyConcepts verifies cases from https://docs.victoriametrics.com/victorialogs/keyconcepts/#data-model for vl-single.
 func TestVlsingleKeyConcepts(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartDefaultVlsingle()
@@ -140,7 +138,6 @@ func TestVlsingleKeyConcepts(t *testing.T) {
 
 // TestVlclusterKeyConcepts verifies cases from https://docs.victoriametrics.com/victorialogs/keyconcepts/#data-model for vl-cluster.
 func TestVlclusterKeyConcepts(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartDefaultVlcluster()

--- a/apptest/tests/lastnoptimization_test.go
+++ b/apptest/tests/lastnoptimization_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
-
 	"github.com/VictoriaMetrics/VictoriaLogs/apptest"
 )
 
@@ -13,7 +11,6 @@ import (
 //
 // See https://github.com/VictoriaMetrics/VictoriaLogs/issues/802#issuecomment-3584878274
 func TestVlsingleLastnOptimization(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartDefaultVlsingle()

--- a/apptest/tests/querying_endpoints_test.go
+++ b/apptest/tests/querying_endpoints_test.go
@@ -3,13 +3,10 @@ package tests
 import (
 	"testing"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
-
 	"github.com/VictoriaMetrics/VictoriaLogs/apptest"
 )
 
 func TestVlsingleFieldNamesResponse(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartDefaultVlsingle()
@@ -66,7 +63,6 @@ func TestVlsingleFieldNamesResponse(t *testing.T) {
 }
 
 func TestVlclusterFieldNamesResponse(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartDefaultVlcluster()
@@ -123,7 +119,6 @@ func TestVlclusterFieldNamesResponse(t *testing.T) {
 }
 
 func TestVlsingleFieldValuesResponse(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartDefaultVlsingle()
@@ -199,7 +194,6 @@ func TestVlsingleFieldValuesResponse(t *testing.T) {
 }
 
 func TestVlclusterFieldValuesResponse(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartDefaultVlcluster()
@@ -275,7 +269,6 @@ func TestVlclusterFieldValuesResponse(t *testing.T) {
 }
 
 func TestVlsingleStreamFieldNamesResponse(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartDefaultVlsingle()
@@ -334,7 +327,6 @@ func TestVlsingleStreamFieldNamesResponse(t *testing.T) {
 }
 
 func TestVlclusterStreamFieldNamesResponse(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartDefaultVlcluster()
@@ -393,7 +385,6 @@ func TestVlclusterStreamFieldNamesResponse(t *testing.T) {
 }
 
 func TestVlsingleStreamFieldValuesResponse(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartDefaultVlsingle()
@@ -457,7 +448,6 @@ func TestVlsingleStreamFieldValuesResponse(t *testing.T) {
 }
 
 func TestVlclusterStreamFieldValuesResponse(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartDefaultVlcluster()
@@ -521,7 +511,6 @@ func TestVlclusterStreamFieldValuesResponse(t *testing.T) {
 }
 
 func TestVlsingleStreamsResponse(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartDefaultVlsingle()
@@ -573,7 +562,6 @@ func TestVlsingleStreamsResponse(t *testing.T) {
 }
 
 func TestVlclusterStreamsResponse(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartDefaultVlcluster()

--- a/apptest/tests/stats_query_range_test.go
+++ b/apptest/tests/stats_query_range_test.go
@@ -5,11 +5,9 @@ import (
 	"testing"
 
 	"github.com/VictoriaMetrics/VictoriaLogs/apptest"
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestVlsingleStatsQueryRange_Success(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 
@@ -60,7 +58,6 @@ func TestVlsingleStatsQueryRange_Success(t *testing.T) {
 }
 
 func TestVlclusterStatsQueryRangeRate(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 
@@ -97,7 +94,6 @@ func TestVlclusterStatsQueryRangeRate(t *testing.T) {
 }
 
 func TestVlsingleStatsQueryRange_Failure(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 
@@ -146,7 +142,6 @@ func TestVlsingleStatsQueryRange_Failure(t *testing.T) {
 //
 // The test also verifies that `total_stats by (_time)` returns the same per-step total for every original series.
 func TestStatsQueryRangeTotalStatsBySubsetLabels(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 
@@ -182,7 +177,6 @@ func TestStatsQueryRangeTotalStatsBySubsetLabels(t *testing.T) {
 }
 
 func TestStatsQueryRangeHistogram(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 

--- a/apptest/tests/stats_query_test.go
+++ b/apptest/tests/stats_query_test.go
@@ -5,11 +5,9 @@ import (
 	"testing"
 
 	"github.com/VictoriaMetrics/VictoriaLogs/apptest"
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestVlsingleStatsQuery_Success(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 
@@ -68,7 +66,6 @@ func TestVlsingleStatsQuery_Success(t *testing.T) {
 }
 
 func TestVlclusterStatsQueryRateWithTimeBucket(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 
@@ -98,7 +95,6 @@ func TestVlclusterStatsQueryRateWithTimeBucket(t *testing.T) {
 }
 
 func TestVlsingleStatsQuery_Failure(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 
@@ -129,7 +125,6 @@ func TestVlsingleStatsQuery_Failure(t *testing.T) {
 }
 
 func TestStatsQueryHistogram(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 
@@ -177,7 +172,6 @@ func TestStatsQueryHistogram(t *testing.T) {
 }
 
 func TestStatsQueryRelativeTime(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 

--- a/apptest/tests/vlagent_remotewrite_test.go
+++ b/apptest/tests/vlagent_remotewrite_test.go
@@ -3,24 +3,20 @@ package tests
 import (
 	"fmt"
 	"os"
-	"path"
 	"testing"
 	"time"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 
 	"github.com/VictoriaMetrics/VictoriaLogs/apptest"
 )
 
 func TestVlagentRemoteWriteSingleTenant(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 
 	// test data ingestion into
 	const instance = "vlsingle"
 	sutFlags := []string{
-		"-storageDataPath=" + tc.Dir() + "/" + instance,
+		"-storageDataPath=" + t.TempDir(),
 	}
 
 	sut := tc.MustStartVlsingle(instance, sutFlags)
@@ -66,7 +62,6 @@ func TestVlagentRemoteWriteSingleTenant(t *testing.T) {
 }
 
 func TestVlagentRemoteWriteMultiTenant(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 
@@ -121,7 +116,6 @@ func TestVlagentRemoteWriteMultiTenant(t *testing.T) {
 }
 
 func TestVlagentRemoteWriteReplication(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 
@@ -131,10 +125,10 @@ func TestVlagentRemoteWriteReplication(t *testing.T) {
 		vlagentInstance  = "vlagent"
 	)
 	sutFlagsR0 := []string{
-		"-storageDataPath=" + path.Join(tc.Dir(), instanceReplica0),
+		"-storageDataPath=" + t.TempDir(),
 	}
 	sutFlagsR1 := []string{
-		"-storageDataPath=" + path.Join(tc.Dir(), instanceReplica1),
+		"-storageDataPath=" + t.TempDir(),
 	}
 
 	sutR0 := tc.MustStartVlsingle(instanceReplica0, sutFlagsR0)

--- a/apptest/tests/vlcluster_test.go
+++ b/apptest/tests/vlcluster_test.go
@@ -3,14 +3,11 @@ package tests
 import (
 	"testing"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
-
 	"github.com/VictoriaMetrics/VictoriaLogs/apptest"
 )
 
 // TestVlclusterUniqValuesMerge verifies that uniq_values correctly merges results when some storage nodes have no matching values.
 func TestVlclusterUniqValuesMerge(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartDefaultVlcluster()
@@ -38,7 +35,6 @@ func TestVlclusterUniqValuesMerge(t *testing.T) {
 
 // TestVlclusterIngestAndQuery verifies that logs are correctly ingested and queried from cluster.
 func TestVlclusterIngestAndQuery(t *testing.T) {
-	fs.MustRemoveDir(t.Name())
 	tc := apptest.NewTestCase(t)
 	defer tc.Stop()
 	sut := tc.MustStartDefaultVlcluster()

--- a/apptest/vlsingle.go
+++ b/apptest/vlsingle.go
@@ -26,9 +26,8 @@ type Vlsingle struct {
 func MustStartVlsingle(t *testing.T, instance string, flags []string, cli *Client) *Vlsingle {
 	t.Helper()
 
-	storageDataPath := fmt.Sprintf("%s/%s", t.Name(), instance)
 	flags = setDefaultFlags(flags, map[string]string{
-		"-storageDataPath": storageDataPath,
+		"-storageDataPath": t.TempDir(),
 		"-retentionPeriod": "100y",
 	})
 	node, extracts := mustStartVlnode(t, instance, flags, cli, []*regexp.Regexp{

--- a/lib/logstorage/filter_any_case_phrase_test.go
+++ b/lib/logstorage/filter_any_case_phrase_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestMatchAnyCasePhrase(t *testing.T) {
@@ -633,7 +631,4 @@ func TestFilterAnyCasePhrase(t *testing.T) {
 		pf = newFilterAnyCasePhrase("_msg", "2006-01-02T15:04:05.00500Z")
 		testFilterMatchForColumns(t, columns, pf, "_msg", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/filter_any_case_prefix_test.go
+++ b/lib/logstorage/filter_any_case_prefix_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestMatchAnyCasePrefix(t *testing.T) {
@@ -655,7 +653,4 @@ func TestFilterAnyCasePrefix(t *testing.T) {
 		fp = newFilterAnyCasePrefix("non-existing-column", "")
 		testFilterMatchForColumns(t, columns, fp, "_msg", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/filter_contains_all_test.go
+++ b/lib/logstorage/filter_contains_all_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestFilterContainsAll(t *testing.T) {
@@ -576,7 +574,4 @@ func TestFilterContainsAll(t *testing.T) {
 		fi = newFilterContainsAllValues("non-existing-column", []string{"2006"})
 		testFilterMatchForColumns(t, columns, fi, "_msg", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/filter_contains_any_test.go
+++ b/lib/logstorage/filter_contains_any_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestFilterContainsAny(t *testing.T) {
@@ -528,7 +526,4 @@ func TestFilterContainsAny(t *testing.T) {
 		fi = newFilterContainsAnyValues("_msg", []string{"2006-04-02T15:04:05.005Z"})
 		testFilterMatchForColumns(t, columns, fi, "_msg", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/filter_eq_field_test.go
+++ b/lib/logstorage/filter_eq_field_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestFilterEqField(t *testing.T) {
@@ -853,7 +851,4 @@ func TestFilterEqField(t *testing.T) {
 		fe = newFilterEqField("non-existing-column", "foo")
 		testFilterMatchForColumns(t, columns, fe, "foo", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/filter_exact_prefix_test.go
+++ b/lib/logstorage/filter_exact_prefix_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestFilterExactPrefix(t *testing.T) {
@@ -444,7 +442,4 @@ func TestFilterExactPrefix(t *testing.T) {
 		fep = newFilterExactPrefix("_msg", "0")
 		testFilterMatchForColumns(t, columns, fep, "_msg", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/filter_exact_test.go
+++ b/lib/logstorage/filter_exact_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestFilterExact(t *testing.T) {
@@ -450,7 +448,4 @@ func TestFilterExact(t *testing.T) {
 		fe = newFilterExact("_msg", "2006-03-02T15:04:05.005Z")
 		testFilterMatchForColumns(t, columns, fe, "_msg", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/filter_in_test.go
+++ b/lib/logstorage/filter_in_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestFilterIn(t *testing.T) {
@@ -507,7 +505,4 @@ func TestFilterIn(t *testing.T) {
 		fi = newFilterInValues("_msg", []string{"2006-04-02T15:04:05.005Z"})
 		testFilterMatchForColumns(t, columns, fi, "_msg", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/filter_ipv4_range_test.go
+++ b/lib/logstorage/filter_ipv4_range_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestMatchIPv4Range(t *testing.T) {
@@ -338,7 +336,4 @@ func TestFilterIPv4Range(t *testing.T) {
 		fr := newFilterIPv4Range("_msg", 0, 0xffffffff)
 		testFilterMatchForColumns(t, columns, fr, "_msg", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/filter_ipv6_range_test.go
+++ b/lib/logstorage/filter_ipv6_range_test.go
@@ -3,8 +3,6 @@ package logstorage
 import (
 	"fmt"
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestMatchIPv6Range(t *testing.T) {
@@ -179,9 +177,6 @@ func TestFilterIPv6Range(t *testing.T) {
 		fr = newFilterIPv6Range("foo", mustParseIPv6("2001:db8::"), mustParseIPv6("2001:db8::ffff"))
 		testFilterMatchForColumns(t, columns, fr, "foo", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }
 
 func mustParseIPv6(s string) [16]byte {

--- a/lib/logstorage/filter_json_array_contains_any_test.go
+++ b/lib/logstorage/filter_json_array_contains_any_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestMatchJSONArrayContainsAny(t *testing.T) {
@@ -157,7 +155,4 @@ func TestFilterJSONArrayContainsAny(t *testing.T) {
 		fa = newFilterJSONArrayContainsAny("foo", []string{"pear"})
 		testFilterMatchForColumns(t, columns, fa, "foo", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/filter_le_field_test.go
+++ b/lib/logstorage/filter_le_field_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestFilterLeField(t *testing.T) {
@@ -1036,7 +1034,4 @@ func TestFilterLeField(t *testing.T) {
 		fe = newFilterLeField("bar", "non-existing-column", true)
 		testFilterMatchForColumns(t, columns, fe, "foo", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/filter_len_range_test.go
+++ b/lib/logstorage/filter_len_range_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestMatchLenRange(t *testing.T) {
@@ -365,7 +363,4 @@ func TestFilterLenRange(t *testing.T) {
 		fr = newFilterLenRange("_msg", 10, 11, "")
 		testFilterMatchForColumns(t, columns, fr, "_msg", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/filter_pattern_match_test.go
+++ b/lib/logstorage/filter_pattern_match_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestFilterPatternMatch(t *testing.T) {
@@ -604,7 +602,4 @@ func TestFilterPatternMatch(t *testing.T) {
 		fp = newFilterPatternMatch("_msg", "", newPatternMatcher("2006-01-02T15:04:05.00500Z", patternMatcherOptionAny))
 		testFilterMatchForColumns(t, columns, fp, "_msg", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/filter_phrase_test.go
+++ b/lib/logstorage/filter_phrase_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestMatchPhrase(t *testing.T) {
@@ -638,7 +636,4 @@ func TestFilterPhrase(t *testing.T) {
 		pf = newFilterPhrase("_msg", "2006-01-02T15:04:05.00500Z")
 		testFilterMatchForColumns(t, columns, pf, "_msg", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/filter_prefix_test.go
+++ b/lib/logstorage/filter_prefix_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestMatchPrefix(t *testing.T) {
@@ -614,7 +612,4 @@ func TestFilterPrefix(t *testing.T) {
 		fp = newFilterPrefix("non-existing-column", "")
 		testFilterMatchForColumns(t, columns, fp, "_msg", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/filter_range_test.go
+++ b/lib/logstorage/filter_range_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestFilterRange(t *testing.T) {
@@ -430,7 +428,4 @@ func TestFilterRange(t *testing.T) {
 		fr := newFilterRange("_msg", -100, 100, "")
 		testFilterMatchForColumns(t, columns, fr, "_msg", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/filter_regexp_test.go
+++ b/lib/logstorage/filter_regexp_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/regexutil"
 )
 
@@ -301,9 +300,6 @@ func TestFilterRegexp(t *testing.T) {
 		fr = newFilterRegexp("_msg", mustCompileRegex("^01|04$"))
 		testFilterMatchForColumns(t, columns, fr, "_msg", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }
 
 func TestSkipFirstLastToken(t *testing.T) {

--- a/lib/logstorage/filter_sequence_test.go
+++ b/lib/logstorage/filter_sequence_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestMatchSequence(t *testing.T) {
@@ -592,7 +590,4 @@ func TestFilterSequence(t *testing.T) {
 		fs = newFilterSequence("_msg", []string{"06"})
 		testFilterMatchForColumns(t, columns, fs, "_msg", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/filter_stream_id_test.go
+++ b/lib/logstorage/filter_stream_id_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 	"time"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestFilterStreamID(t *testing.T) {
@@ -40,12 +38,10 @@ func TestFilterStreamID(t *testing.T) {
 func testFilterMatchForStreamID(t *testing.T, f filter, expectedRowIdxs []int) {
 	t.Helper()
 
-	storagePath := t.Name()
-
 	cfg := &StorageConfig{
 		Retention: 100 * 365 * time.Duration(nsecsPerDay),
 	}
-	s := MustOpenStorage(storagePath, cfg)
+	s := MustOpenStorage(t.TempDir(), cfg)
 
 	tenantID := TenantID{
 		AccountID: 123,
@@ -67,9 +63,7 @@ func testFilterMatchForStreamID(t *testing.T, f filter, expectedRowIdxs []int) {
 
 	testFilterMatchForStorage(t, s, tenantID, f, "_msg", expectedResults, expectedTimestamps)
 
-	// Close and delete the test storage
 	s.MustClose()
-	fs.MustRemoveDir(storagePath)
 }
 
 func generateTestLogStreams(s *Storage, tenantID TenantID, getMsgValue func(int) string, rowsCount, streamsCount int) {

--- a/lib/logstorage/filter_string_range_test.go
+++ b/lib/logstorage/filter_string_range_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestMatchStringRange(t *testing.T) {
@@ -411,7 +409,4 @@ func TestFilterStringRange(t *testing.T) {
 		fr = newFilterStringRange("_msg", "2006-01-03", "2006-01-02", "")
 		testFilterMatchForColumns(t, columns, fr, "_msg", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/filter_substring_test.go
+++ b/lib/logstorage/filter_substring_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestMatchSubstring(t *testing.T) {
@@ -630,7 +628,4 @@ func TestFilterSubstring(t *testing.T) {
 		fp = newFilterSubstring("_msg", "2006-01-02T15:04:05.00500Z")
 		testFilterMatchForColumns(t, columns, fp, "_msg", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/filter_test.go
+++ b/lib/logstorage/filter_test.go
@@ -7,8 +7,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestComplexFilters(t *testing.T) {
@@ -81,11 +79,10 @@ func testFilterMatchForColumns(t *testing.T, columns []column, f filter, neededC
 	t.Helper()
 
 	// Create the test storage
-	storagePath := t.Name()
 	cfg := &StorageConfig{
 		Retention: time.Duration(100 * 365 * nsecsPerDay),
 	}
-	s := MustOpenStorage(storagePath, cfg)
+	s := MustOpenStorage(t.TempDir(), cfg)
 
 	// Generate rows
 	tenantID := TenantID{
@@ -110,9 +107,8 @@ func testFilterMatchForColumns(t *testing.T, columns []column, f filter, neededC
 
 	testFilterMatchForStorage(t, s, tenantID, f, neededColumnName, expectedResults, expectedTimestamps)
 
-	// Close and delete the test storage
+	// Close the test storage
 	s.MustClose()
-	fs.MustRemoveDir(storagePath)
 }
 
 func testFilterMatchForStorage(t *testing.T, s *Storage, tenantID TenantID, f filter, neededColumnName string, expectedValues []string, expectedTimestamps []int64) {

--- a/lib/logstorage/filter_time_test.go
+++ b/lib/logstorage/filter_time_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 	"time"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestFilterTime(t *testing.T) {
@@ -59,11 +57,10 @@ func testFilterMatchForTimestamps(t *testing.T, timestamps []int64, f filter, ex
 	t.Helper()
 
 	// Create the test storage
-	storagePath := t.Name()
 	cfg := &StorageConfig{
 		Retention: 100 * 365 * time.Duration(nsecsPerDay),
 	}
-	s := MustOpenStorage(storagePath, cfg)
+	s := MustOpenStorage(t.TempDir(), cfg)
 
 	// Generate rows
 	getValue := func(rowIdx int) string {
@@ -84,9 +81,8 @@ func testFilterMatchForTimestamps(t *testing.T, timestamps []int64, f filter, ex
 
 	testFilterMatchForStorage(t, s, tenantID, f, "_msg", expectedResults, expectedTimestamps)
 
-	// Close and delete the test storage
+	// Close the test storage
 	s.MustClose()
-	fs.MustRemoveDir(storagePath)
 }
 
 func generateRowsFromTimestamps(s *Storage, tenantID TenantID, timestamps []int64, getValue func(rowIdx int) string) {

--- a/lib/logstorage/filter_value_type_test.go
+++ b/lib/logstorage/filter_value_type_test.go
@@ -2,8 +2,6 @@ package logstorage
 
 import (
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestFilterValueType(t *testing.T) {
@@ -379,7 +377,4 @@ func TestFilterValueType(t *testing.T) {
 		pv = newFilterValueType("_msg", "string")
 		testFilterMatchForColumns(t, columns, pv, "_msg", nil)
 	})
-
-	// Remove the remaining data files for the test
-	fs.MustRemoveDir(t.Name())
 }

--- a/lib/logstorage/indexdb_test.go
+++ b/lib/logstorage/indexdb_test.go
@@ -2,20 +2,24 @@ package logstorage
 
 import (
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"testing"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func TestStorageSearchStreamIDs(t *testing.T) {
 	t.Parallel()
 
-	path := t.Name()
 	const partitionName = "foobar"
+
 	s := newTestStorage()
+	defer closeTestStorage(s)
+
+	path := filepath.Join(t.TempDir(), "indexdb")
 	mustCreateIndexdb(path)
+
 	idb := mustOpenIndexdb(path, partitionName, s)
+	defer mustCloseIndexdb(idb)
 
 	tenantID := TenantID{
 		AccountID: 123,
@@ -246,24 +250,18 @@ func TestStorageSearchStreamIDs(t *testing.T) {
 		}
 	}
 	f(`{instance="instance-2",job!="job-1"}`, streamIDs)
-
-	mustCloseIndexdb(idb)
-	fs.MustRemoveDir(path)
-
-	closeTestStorage(s)
 }
 
 func TestGetTenantsIDs(t *testing.T) {
 	t.Parallel()
 
-	path := t.Name()
 	const partitionName = "foobar"
 
 	s := newTestStorage()
 	defer closeTestStorage(s)
 
+	path := filepath.Join(t.TempDir(), "indexdb")
 	mustCreateIndexdb(path)
-	defer fs.MustRemoveDir(path)
 
 	idb := mustOpenIndexdb(path, partitionName, s)
 	defer mustCloseIndexdb(idb)

--- a/lib/logstorage/partition_test.go
+++ b/lib/logstorage/partition_test.go
@@ -1,6 +1,7 @@
 package logstorage
 
 import (
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -11,7 +12,7 @@ import (
 func TestPartitionLifecycle(t *testing.T) {
 	t.Parallel()
 
-	path := t.Name()
+	path := filepath.Join(t.TempDir(), "partition")
 	var ddbStats DatadbStats
 
 	s := newTestStorage()
@@ -53,7 +54,7 @@ func TestPartitionLifecycle(t *testing.T) {
 func TestPartitionMustAddRowsSerial(t *testing.T) {
 	t.Parallel()
 
-	path := t.Name()
+	path := filepath.Join(t.TempDir(), "partition")
 	var ddbStats DatadbStats
 
 	s := newTestStorage()
@@ -135,15 +136,13 @@ func TestPartitionMustAddRowsSerial(t *testing.T) {
 	}
 
 	mustClosePartition(pt)
-	mustDeletePartition(path)
-
 	closeTestStorage(s)
 }
 
 func TestPartitionMustAddRowsConcurrent(t *testing.T) {
 	t.Parallel()
 
-	path := t.Name()
+	path := filepath.Join(t.TempDir(), "partition")
 	s := newTestStorage()
 
 	mustCreatePartition(path)
@@ -180,8 +179,6 @@ func TestPartitionMustAddRowsConcurrent(t *testing.T) {
 	}
 
 	mustClosePartition(pt)
-	mustDeletePartition(path)
-
 	closeTestStorage(s)
 }
 

--- a/lib/logstorage/storage_search_test.go
+++ b/lib/logstorage/storage_search_test.go
@@ -12,15 +12,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
-
 	"github.com/VictoriaMetrics/VictoriaLogs/lib/prefixfilter"
 )
 
 func TestStorageRunQuery(t *testing.T) {
 	t.Parallel()
-
-	path := t.Name()
 
 	const tenantsCount = 11
 	const streamsPerTenant = 3
@@ -30,7 +26,7 @@ func TestStorageRunQuery(t *testing.T) {
 	sc := &StorageConfig{
 		Retention: 24 * time.Hour,
 	}
-	s := MustOpenStorage(path, sc)
+	s := MustOpenStorage(t.TempDir(), sc)
 
 	// fill the storage with data
 	var allTenantIDs []TenantID
@@ -1139,9 +1135,8 @@ func TestStorageRunQuery(t *testing.T) {
 		})
 	})
 
-	// Close the storage and delete its data
+	// Close the storage
 	s.MustClose()
-	fs.MustRemoveDir(path)
 }
 
 func mustParseQuery(query string) *Query {
@@ -1155,8 +1150,6 @@ func mustParseQuery(query string) *Query {
 func TestStorageSearch(t *testing.T) {
 	t.Parallel()
 
-	path := t.Name()
-
 	const tenantsCount = 11
 	const streamsPerTenant = 3
 	const blocksPerStream = 5
@@ -1165,7 +1158,7 @@ func TestStorageSearch(t *testing.T) {
 	sc := &StorageConfig{
 		Retention: 24 * time.Hour,
 	}
-	s := MustOpenStorage(path, sc)
+	s := MustOpenStorage(t.TempDir(), sc)
 
 	// fill the storage with data.
 	var allTenantIDs []TenantID
@@ -1436,7 +1429,6 @@ func TestStorageSearch(t *testing.T) {
 	})
 
 	s.MustClose()
-	fs.MustRemoveDir(path)
 }
 
 func TestParseStreamFieldsSuccess(t *testing.T) {
@@ -1606,12 +1598,10 @@ func TestStorageSearchHiddenFieldsFilters(t *testing.T) {
 		},
 	}
 
-	path := t.Name()
-
 	cfg := &StorageConfig{
 		Retention: 30 * 24 * time.Hour,
 	}
-	s := MustOpenStorage(path, cfg)
+	s := MustOpenStorage(t.TempDir(), cfg)
 
 	now := time.Now().UnixNano()
 
@@ -1658,8 +1648,6 @@ func TestStorageSearchHiddenFieldsFilters(t *testing.T) {
 	check(q+" | count() rows", hiddenFieldsFilters, []string{`{"rows":"0"}`})
 
 	s.MustClose()
-
-	fs.MustRemoveDir(path)
 }
 
 func storeRowsForSearchHiddenFieldsFilters(s *Storage, tenantIDs []TenantID, now int64) {

--- a/lib/logstorage/storage_test.go
+++ b/lib/logstorage/storage_test.go
@@ -14,20 +14,19 @@ import (
 func TestStorageLifecycle(t *testing.T) {
 	t.Parallel()
 
-	path := t.Name()
+	path := t.TempDir()
 
 	for range 3 {
 		cfg := &StorageConfig{}
 		s := MustOpenStorage(path, cfg)
 		s.MustClose()
 	}
-	fs.MustRemoveDir(path)
 }
 
 func TestStorageMustAddRows(t *testing.T) {
 	t.Parallel()
 
-	path := t.Name()
+	path := t.TempDir()
 
 	cfg := &StorageConfig{}
 	s := MustOpenStorage(path, cfg)
@@ -107,14 +106,12 @@ func TestStorageMustAddRows(t *testing.T) {
 		t.Fatalf("unexpected number of entries in storage; got %d; want %d", n, totalRowsCount)
 	}
 	s.MustClose()
-
-	fs.MustRemoveDir(path)
 }
 
 func TestStoragePartitionDetachRecreateSameDaySameStream(t *testing.T) {
 	t.Parallel()
 
-	path := t.Name()
+	path := t.TempDir()
 
 	cfg := &StorageConfig{
 		Retention:       365 * 24 * time.Hour,
@@ -169,13 +166,12 @@ func TestStoragePartitionDetachRecreateSameDaySameStream(t *testing.T) {
 	check(`* | stats count(*) as rows`, 1)
 
 	s.MustClose()
-	fs.MustRemoveDir(path)
 }
 
 func TestStoragePartitionDetachRecreateSameDayStreamFilterQuery(t *testing.T) {
 	t.Parallel()
 
-	path := t.Name()
+	path := t.TempDir()
 
 	cfg := &StorageConfig{
 		Retention: 365 * 24 * time.Hour,
@@ -228,13 +224,12 @@ func TestStoragePartitionDetachRecreateSameDayStreamFilterQuery(t *testing.T) {
 	check(`{stream="new_stream"} | stats count(*) as rows`, 1)
 
 	s.MustClose()
-	fs.MustRemoveDir(path)
 }
 
 func TestStorageDeleteTaskOps(t *testing.T) {
 	t.Parallel()
 
-	path := t.Name()
+	path := t.TempDir()
 	cfg := &StorageConfig{}
 	s := MustOpenStorage(path, cfg)
 
@@ -283,14 +278,12 @@ func TestStorageDeleteTaskOps(t *testing.T) {
 	}
 
 	s.MustClose()
-
-	fs.MustRemoveDir(path)
 }
 
 func TestStorageProcessDeleteTask(t *testing.T) {
 	t.Parallel()
 
-	path := t.Name()
+	path := t.TempDir()
 	ctx := t.Context()
 
 	cfg := &StorageConfig{
@@ -400,21 +393,18 @@ func TestStorageProcessDeleteTask(t *testing.T) {
 	check(allTenantIDs, "* | count(host) rows", []string{`{"rows":"5284"}`})
 
 	s.MustClose()
-
-	fs.MustRemoveDir(path)
 }
 
 func TestStorageProcessDeleteTaskRelativeTimeUsesTaskStartTime(t *testing.T) {
 	t.Parallel()
 
-	path := t.Name()
 	ctx := t.Context()
 
 	cfg := &StorageConfig{
 		Retention:       30 * 24 * time.Hour,
 		FutureRetention: 30 * 24 * time.Hour,
 	}
-	s := MustOpenStorage(path, cfg)
+	s := MustOpenStorage(t.TempDir(), cfg)
 
 	tenantIDs := []TenantID{
 		{
@@ -456,17 +446,15 @@ func TestStorageProcessDeleteTaskRelativeTimeUsesTaskStartTime(t *testing.T) {
 	check(`row_id:=1 | stats count(*) as rows`, []string{`{"rows":"0"}`})
 
 	s.MustClose()
-	fs.MustRemoveDir(path)
 }
 
 func TestStorageHiddenFieldsWithFieldNamesPipe(t *testing.T) {
 	t.Parallel()
 
-	path := t.Name()
 	cfg := &StorageConfig{
 		Retention: 365 * 24 * time.Hour,
 	}
-	s := MustOpenStorage(path, cfg)
+	s := MustOpenStorage(t.TempDir(), cfg)
 
 	tenantIDs := []TenantID{{}}
 	ts := time.Now().UTC().UnixNano()
@@ -502,7 +490,6 @@ func TestStorageHiddenFieldsWithFieldNamesPipe(t *testing.T) {
 	check(`* | head 1000 | field_names | filter name:="_msg" | stats count(*) as c`, []string{"_msg"}, []string{`{"c":"0"}`})
 
 	s.MustClose()
-	fs.MustRemoveDir(path)
 }
 
 func checkQueryResults(t *testing.T, s *Storage, now int64, tenantIDs []TenantID, qStr string, hiddenFieldsFilters, resultsExpected []string) {
@@ -611,7 +598,7 @@ func storeRowsForProcessDeleteTaskTest(s *Storage, tenantIDs []TenantID, now int
 func TestStorageDropStalePartitions(t *testing.T) {
 	t.Parallel()
 
-	path := t.Name()
+	path := t.TempDir()
 
 	cfg := &StorageConfig{
 		Retention: 30 * 24 * time.Hour,
@@ -666,7 +653,4 @@ func TestStorageDropStalePartitions(t *testing.T) {
 	s.dropStalePartitions()
 	expectPartitionsNumber(0)
 	s.MustClose()
-
-	// Drop the created data on disk
-	fs.MustRemoveDir(path)
 }

--- a/lib/logstorage/storage_timing_test.go
+++ b/lib/logstorage/storage_timing_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 	"time"
-
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 )
 
 func BenchmarkStorageMustAddRows(b *testing.B) {
@@ -20,8 +18,8 @@ func benchmarkStorageMustAddRows(b *testing.B, rowsPerInsert int) {
 	cfg := &StorageConfig{
 		Retention: 24 * time.Hour,
 	}
-	testName := b.Name()
-	s := MustOpenStorage(testName, cfg)
+	s := MustOpenStorage(b.TempDir(), cfg)
+	defer s.MustClose()
 
 	b.ReportAllocs()
 	b.SetBytes(int64(rowsPerInsert))
@@ -39,7 +37,4 @@ func benchmarkStorageMustAddRows(b *testing.B, rowsPerInsert int) {
 			s.MustAddRows(lr)
 		}
 	})
-
-	s.MustClose()
-	fs.MustRemoveDir(testName)
 }


### PR DESCRIPTION
This commit migrates to `(*testing.T).TempDir()`, which automatically removes the temporary folder using `(*testing.T).Cleanup()` function after test is finished.

Previous approach stored temporary folder with test data to simplify reproducing a problem outside the test, but this is rarely needed and makes repeated test runs annoying instead. Canceled or failed tests left temporary folders, causing a second run to fail because the temp folder already existed, even if the test itself was fixed.
