### PR TITLE
docs/victorialogs/vlagent.md: rename quick start section

### DIFF
--- a/docs/victorialogs/vlagent.md
+++ b/docs/victorialogs/vlagent.md
@@ -352,7 +352,7 @@ See also: [How to exclude vlagent's own logs from collection](https://docs.victo
 `vlagent` can collect text-based logs directly from files on disk using the `-fileCollector.glob` flag.
 This is useful for collecting logs from applications that write to log files, such as nginx, Redis, ClickHouse.
 
-### Quick start
+### Quick start for file collector
 
 The following command starts `vlagent` to collect logs from the `/path/to/file` file
 and to send the collected logs to a VictoriaLogs instance at `victoria-logs:9428`:


### PR DESCRIPTION
This avoids duplicated quick starts for file and Kubernetes collectors

Closes #1306
