### PR TITLE
app/vlinsert/syslog: fix data race accessing globalTimezone

### DIFF
--- a/app/vlinsert/syslog/syslog_test.go
+++ b/app/vlinsert/syslog/syslog_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/VictoriaMetrics/VictoriaLogs/app/vlinsert/insertutil"
 )
@@ -78,10 +77,11 @@ func TestProcessStreamInternal_Success(t *testing.T) {
 	f := func(data string, currentYear int, timestampsExpected []int64, resultExpected string) {
 		t.Helper()
 
+		syslogTimezone = new("UTC")
+
 		MustInit()
 		defer MustStop()
 
-		globalTimezone = time.UTC
 		globalCurrentYear.Store(int64(currentYear))
 
 		tlp := &insertutil.TestLogMessageProcessor{}


### PR DESCRIPTION
Running `go test -race` in app/vlinsert/syslog reports a data race because `MustInit()` kicks off a goroutine that periodically accesses `globalTimezone` and `TestProcessStreamInternal_Success` changes `globalTimezone` after that goroutine has started.

This fix just sets syslogTimezone before MustInit() instead of setting the globalTimezone while the worker is running. This output appears to still satisfy the test, while not triggering the data race.

---

This is a cleaner and less impactful fix for the syslog data race than #1723. Long story short: I realized that the output doesn't expect the timezone to change while the worker is running, it only expects the year to change. Setting `syslogTimezone = "UTC"` before starting the worker does the same thing as setting `globalTimezone = time.UTC`, but in a way that lets `MustInit()` set up `globalTimezone` in a goroutine-safe way.